### PR TITLE
Various decompiler changes (CanReachUnderContext, FunctionReturnIsStackBalanceBlock, use of limitsize is optional)

### DIFF
--- a/gigahorse.py
+++ b/gigahorse.py
@@ -173,6 +173,15 @@ parser.add_argument("-cd",
                     metavar="NUM",
                     help="Override the maximum context depth for decompilation (default is 8).")
 
+parser.add_argument("--enable_limitsize",
+                    action="store_true",
+                    default=False,
+                    help= ("Adds a limitsize (see souffle documentation) that limits the outputs"
+                        "of certain key decompiler relations to improve scalability."
+                        "Can make decompilation output more incomplete and imprecise."
+                        )
+                    )
+
 parser.add_argument("--disable_inline",
                     action="store_true",
                     default=False,
@@ -239,6 +248,9 @@ def compile_datalog(spec, executable):
     pathlib.Path(args.cache_dir).mkdir(exist_ok=True)
 
     souffle_macros = f'GIGAHORSE_DIR={GIGAHORSE_DIR} BULK_ANALYSIS= {args.souffle_macros}'.strip()
+
+    if args.enable_limitsize:
+        souffle_macros+=' ENABLE_LIMITSIZE='
 
     cpp_macros = []
     for macro_def in souffle_macros.split(' '):

--- a/logic/decompiler_analytics.dl
+++ b/logic/decompiler_analytics.dl
@@ -22,6 +22,18 @@ Analytics_Jumps(block) :-
 Analytics_ReachableBlocks(blk):-
   ReachableContext(_, blk).
 
+.decl Analytics_Contexts(ctx: Context)
+.output Analytics_Contexts
+
+Analytics_Contexts(ctx):-
+  ReachableContext(ctx, _).
+
+.decl Analytics_ReachableUnderContext(ctx: Context, block: Block)
+.output Analytics_ReachableUnderContext
+
+Analytics_ReachableUnderContext(ctx, block):-
+  ReachableContext(ctx, block).
+
 .decl Analytics_ReachableBlocksInTAC(block: Block)
 .output Analytics_ReachableBlocksInTAC
 
@@ -32,10 +44,10 @@ Analytics_ReachableBlocksInTAC(blk):-
 
 // Incompleteness metric: this can happen due to our precision-favoring heuristics
 // or incompleteness due to the use of limitsize for scalability
-.decl Analytics_BlocksReachableInGlobalButNotInTAC(block: Block)
-.output Analytics_BlocksReachableInGlobalButNotInTAC
+.decl Analytics_BlockHasNoTACBlock(block: Block)
+.output Analytics_BlockHasNoTACBlock
 
-Analytics_BlocksReachableInGlobalButNotInTAC(blk):-
+Analytics_BlockHasNoTACBlock(blk):-
   Analytics_ReachableBlocks(blk),
   !Analytics_ReachableBlocksInTAC(blk).
 
@@ -157,8 +169,6 @@ Analytics_InexactFunctionCallArguments(call):-
   IsStackIndexLessThan(n_arg, n_args),
   !TAC_Use(call, _, n_arg).
 
-
-
 .decl Analytics_BlockInMultipleFunctions(block: IRBlock)
 .output Analytics_BlockInMultipleFunctions
 
@@ -167,13 +177,6 @@ Analytics_BlockInMultipleFunctions(block) :-
    IRInFunction(block, func2),
    func != func2.
 
-.decl Analytics_BlockHasNoIRBlock(block: Block)
-.output Analytics_BlockHasNoIRBlock
-
-Analytics_BlockHasNoIRBlock(block) :-
-   (BlockEdge(_, block, _, _);
-    BlockEdge(_, _, _, block)),
-   !Block_IRBlock(block, _, _).
 
 .decl Analytics_BlockInNoFunctions(block: IRBlock)
 .output Analytics_BlockInNoFunctions
@@ -312,3 +315,9 @@ Analytics_JumpToManyWithoutGlobalImprecision(reportBlock):-
 Analytics_InitiallyMissedCycleEntry(block) :-
    PotentialCycleEntry(block),
    !PossibleFunctionalBlockPopAndStackDelta(_, block, _, _, _).
+
+.decl Analytics_LocalBlockEdge(from: IRBlock, to: IRBlock)
+.output Analytics_LocalBlockEdge
+
+Analytics_LocalBlockEdge(from, to):-
+  LocalBlockEdge(from, to).

--- a/logic/functions.dl
+++ b/logic/functions.dl
@@ -15,15 +15,15 @@
          Generic basic block Reachable-from implementation
 ******/
 
-.decl CanReachUnderContext(fromCtx: Context, ctx: Context, block: Block)
+.decl CanReachUnderContext(fromCtx: Context, ctx: Context)
 .limitsize CanReachUnderContext(n=LIMITSIZE_CAN_REACH_UNDER_CONTEXT)
 
-CanReachUnderContext(ctx, ctx, block) :-
-  ReachableContext(ctx, block).
+CanReachUnderContext(ctx, ctx) :-
+  ReachableContext(ctx, _).
 
-CanReachUnderContext(ctxFrom, ctxTo, blockTo) :-
-  BlockEdge(ctxOther, blockOther, ctxTo, blockTo),
-  CanReachUnderContext(ctxFrom, ctxOther, blockOther).
+CanReachUnderContext(ctxFrom, ctxTo) :-
+  BlockEdge(ctxOther, _, ctxTo, _),
+  CanReachUnderContext(ctxFrom, ctxOther).
 
 
 
@@ -113,7 +113,7 @@ MaybeFunctionCallReturn(ctx, caller, func, retCtx, retBlock, retTarget) :-
   postTrans.Statement_Block(jump, caller),
   postTrans.Statement_Opcode(jump, "JUMP"), //Added to invalidate JUMPIs we will need to deal with them though
   BlockJumpValidTarget(ctx, caller, targetVar, func),
-  CanReachUnderContext(ctx, /*caller,*/ retCtx, retBlock),
+  CanReachUnderContext(ctx, /*caller,*/ retCtx/*, retBlock*/),
   BlockJumpValidTarget(retCtx, retBlock, _, retTarget).
 
 // Introduced to use in many rules that don't use the context of the context-sensitive version
@@ -127,7 +127,7 @@ MaybeFunctionCallReturn_Ins(caller, func, retBlock, retTarget):-
 .decl PossibleReturnAddressWithPositiveRank(callCtx:Context, targetSetter:Block, retCtx:Context, retBlock:Block, retTarget:Block, rank:number)
 PossibleReturnAddressWithPositiveRank(callCtx, caller, retCtx, retBlock, retTarget, n) :-
   PossibleReturnAddressWithRank(callCtx, caller, retCtx, retBlock, retTarget, n),
-  CanReachUnderContext(callCtx, /*caller,*/ retCtx, retBlock),
+  CanReachUnderContext(callCtx, /*caller,*/ retCtx/*, retBlock*/),
   BlockJumpValidTarget(retCtx, retBlock, _, retTarget),
   n > 0,
   n < RETURN_ADDRESS_RANK_THRESHOLD.

--- a/logic/functions.dl
+++ b/logic/functions.dl
@@ -408,7 +408,7 @@ IRFunction_Return_Edge(retir, callerretir) :-
   Block_IRBlock(caller, prevfunc, callerir),
   Block_IRBlock(callerret, prevfunc, callerretir),
   //CanReach(caller, callerret),
-  CanReachUnderContext(ctx, caller, _, callerret),
+  //CanReachUnderContext(ctx, caller, _, callerret),
   Function_IRFunction(func, irfunc).
   //!BlockToClone(func, prevfunc).
 
@@ -466,7 +466,7 @@ IRBlockEdge(irfrom, irto) :-
   MaybeInFunctionUnderContext(ctxFrom, from, func),
   MaybeInFunctionUnderContext(ctxTo, to, func),
   PubFun(func, pubFun),
-  CanReachUnderContext(_, func, ctxFrom, from),
+  //CanReachUnderContext(_, func, ctxFrom, from),
   Context_PublicFunction(ctxTo, pubFun),
   // The following negation makes our code incomplete in cases where the return block
   // can be shared by callee and caller, but keeps our produced IR precise.
@@ -483,7 +483,7 @@ IRBlockEdge(irfrom, irto) :-
   MaybeInFunctionUnderContext(ctxFrom, from, func),
   MaybeInFunctionUnderContext(ctxTo, to, func),
   !PubFun(func, _),
-  CanReachUnderContext(_, func, ctxFrom, from),
+  //CanReachUnderContext(_, func, ctxFrom, from),
   // The following negation makes our code incomplete in cases where the return block
   // can be shared by callee and caller, but keeps our produced IR precise.
   // Removing it results in inconsistent IR (return blocks with local edges from them)

--- a/logic/functions.dl
+++ b/logic/functions.dl
@@ -114,7 +114,7 @@ MaybeFunctionCallReturn(ctx, caller, func, retCtx, retBlock, retTarget) :-
   postTrans.Statement_Opcode(jump, "JUMP"), //Added to invalidate JUMPIs we will need to deal with them though
   BlockJumpValidTarget(ctx, caller, targetVar, func),
   CanReachUnderContext(ctx, caller, retCtx, retBlock),
-  CanReachUnderContext(retCtx, retBlock, _, retTarget).
+  BlockJumpValidTarget(retCtx, retBlock, _, retTarget).
 
 // Introduced to use in many rules that don't use the context of the context-sensitive version
 // Should be used when possible because the latter can get very heavy
@@ -128,7 +128,7 @@ MaybeFunctionCallReturn_Ins(caller, func, retBlock, retTarget):-
 PossibleReturnAddressWithPositiveRank(callCtx, caller, retCtx, retBlock, retTarget, n) :-
   PossibleReturnAddressWithRank(callCtx, caller, retCtx, retBlock, retTarget, n),
   CanReachUnderContext(callCtx, caller, retCtx, retBlock),
-  CanReachUnderContext(retCtx, retBlock, _, retTarget),
+  BlockJumpValidTarget(retCtx, retBlock, _, retTarget),
   n > 0,
   n < RETURN_ADDRESS_RANK_THRESHOLD.
 

--- a/logic/functions.dl
+++ b/logic/functions.dl
@@ -15,6 +15,10 @@
          Generic basic block Reachable-from implementation
 ******/
 
+.decl ContextEdge(ctxFrom:Context, ctxTo:Context)
+ContextEdge(ctxFrom, ctxTo):-
+  BlockEdge(ctxFrom, _, ctxTo, _).
+
 .decl CanReachUnderContext(fromCtx: Context, ctx: Context)
 .limitsize CanReachUnderContext(n=LIMITSIZE_CAN_REACH_UNDER_CONTEXT)
 
@@ -22,7 +26,8 @@ CanReachUnderContext(ctx, ctx) :-
   ReachableContext(ctx, _).
 
 CanReachUnderContext(ctxFrom, ctxTo) :-
-  BlockEdge(ctxOther, _, ctxTo, _),
+  //BlockEdge(ctxOther, _, ctxTo, _),
+  ContextEdge(ctxOther, ctxTo),
   CanReachUnderContext(ctxFrom, ctxOther).
 
 

--- a/logic/functions.dl
+++ b/logic/functions.dl
@@ -200,6 +200,12 @@ FunctionSharesReturnBlock(func) :-
   MaybeFunctionCallReturn_Ins(_, func2, retBlock, _),
   func != func2.
 
+.decl FunctionReturnIsStackBalanceBlock(func:Block)
+FunctionReturnIsStackBalanceBlock(func) :-
+  MaybeFunctionCallReturn_Ins(_, func, retBlock, _),
+  postTrans.StackBalanceBlock(retBlock).
+
+
 // Return block can only pertain to one function!
 .decl NotValidReturnBlock(func: Block, retBlock: Block) 
 NotValidReturnBlock(func, retBlock) :-
@@ -231,7 +237,7 @@ NotValidReturnEdge(retBlock, retTarget) :-
 IsFunctionCallReturn(ctx, caller, func, retCtx, retBlock, retTarget) :-
   MaybeFunctionCallReturn(ctx, caller, func, retCtx, retBlock, retTarget),
   //FunctionCalledMultipleTimes(func),
-  (FunctionCalledMultipleTimes(func) ; FunctionSharesReturnBlock(func) ; postTrans.StackBalanceBlock(retBlock)),
+  (FunctionCalledMultipleTimes(func) ; FunctionSharesReturnBlock(func) ; FunctionReturnIsStackBalanceBlock(func)),
   //!NotValidReturnBlock(func, retBlock),
   !NotValidReturnEdge(retBlock, retTarget).
 

--- a/logic/functions.dl
+++ b/logic/functions.dl
@@ -15,6 +15,8 @@
          Generic basic block Reachable-from implementation
 ******/
 
+// Created because its faster to iterate it than to iterate BlockEdge
+// when we only care about contexts
 .decl ContextEdge(ctxFrom:Context, ctxTo:Context)
 ContextEdge(ctxFrom, ctxTo):-
   BlockEdge(ctxFrom, _, ctxTo, _).
@@ -26,17 +28,10 @@ CanReachUnderContext(ctx, ctx) :-
   ReachableContext(ctx, _).
 
 CanReachUnderContext(ctxFrom, ctxTo) :-
-  //BlockEdge(ctxOther, _, ctxTo, _),
   ContextEdge(ctxOther, ctxTo),
   CanReachUnderContext(ctxFrom, ctxOther).
 
 
-
-// Derived from the context-sensitive version, maintains max precision when
-// contexts aren't needed.
-//.decl CanReach(from:Block, block:Block)
-//CanReach(from, to) :-
-//  CanReachUnderContext(_, from, _, to).
 
 /******
          Heuristics for detecting call-return patterns
@@ -118,7 +113,7 @@ MaybeFunctionCallReturn(ctx, caller, func, retCtx, retBlock, retTarget) :-
   postTrans.Statement_Block(jump, caller),
   postTrans.Statement_Opcode(jump, "JUMP"), //Added to invalidate JUMPIs we will need to deal with them though
   BlockJumpValidTarget(ctx, caller, targetVar, func),
-  CanReachUnderContext(ctx, /*caller,*/ retCtx/*, retBlock*/),
+  CanReachUnderContext(ctx, retCtx),
   BlockJumpValidTarget(retCtx, retBlock, _, retTarget).
 
 // Introduced to use in many rules that don't use the context of the context-sensitive version
@@ -132,7 +127,7 @@ MaybeFunctionCallReturn_Ins(caller, func, retBlock, retTarget):-
 .decl PossibleReturnAddressWithPositiveRank(callCtx:Context, targetSetter:Block, retCtx:Context, retBlock:Block, retTarget:Block, rank:number)
 PossibleReturnAddressWithPositiveRank(callCtx, caller, retCtx, retBlock, retTarget, n) :-
   PossibleReturnAddressWithRank(callCtx, caller, retCtx, retBlock, retTarget, n),
-  CanReachUnderContext(callCtx, /*caller,*/ retCtx/*, retBlock*/),
+  CanReachUnderContext(callCtx, retCtx),
   BlockJumpValidTarget(retCtx, retBlock, _, retTarget),
   n > 0,
   n < RETURN_ADDRESS_RANK_THRESHOLD.
@@ -418,8 +413,6 @@ IRFunction_Return_Edge(retir, callerretir) :-
   Block_IRBlock(ret, func, retir),
   Block_IRBlock(caller, prevfunc, callerir),
   Block_IRBlock(callerret, prevfunc, callerretir),
-  //CanReach(caller, callerret),
-  //CanReachUnderContext(ctx, caller, _, callerret),
   Function_IRFunction(func, irfunc).
   //!BlockToClone(func, prevfunc).
 
@@ -477,7 +470,6 @@ IRBlockEdge(irfrom, irto) :-
   MaybeInFunctionUnderContext(ctxFrom, from, func),
   MaybeInFunctionUnderContext(ctxTo, to, func),
   PubFun(func, pubFun),
-  //CanReachUnderContext(_, func, ctxFrom, from),
   Context_PublicFunction(ctxTo, pubFun),
   // The following negation makes our code incomplete in cases where the return block
   // can be shared by callee and caller, but keeps our produced IR precise.
@@ -494,7 +486,6 @@ IRBlockEdge(irfrom, irto) :-
   MaybeInFunctionUnderContext(ctxFrom, from, func),
   MaybeInFunctionUnderContext(ctxTo, to, func),
   !PubFun(func, _),
-  //CanReachUnderContext(_, func, ctxFrom, from),
   // The following negation makes our code incomplete in cases where the return block
   // can be shared by callee and caller, but keeps our produced IR precise.
   // Removing it results in inconsistent IR (return blocks with local edges from them)

--- a/logic/functions.dl
+++ b/logic/functions.dl
@@ -231,7 +231,7 @@ NotValidReturnEdge(retBlock, retTarget) :-
 IsFunctionCallReturn(ctx, caller, func, retCtx, retBlock, retTarget) :-
   MaybeFunctionCallReturn(ctx, caller, func, retCtx, retBlock, retTarget),
   //FunctionCalledMultipleTimes(func),
-  (FunctionCalledMultipleTimes(func) ; FunctionSharesReturnBlock(func)),
+  (FunctionCalledMultipleTimes(func) ; FunctionSharesReturnBlock(func) ; postTrans.StackBalanceBlock(retBlock)),
   //!NotValidReturnBlock(func, retBlock),
   !NotValidReturnEdge(retBlock, retTarget).
 

--- a/logic/functions.dl
+++ b/logic/functions.dl
@@ -22,7 +22,9 @@ ContextEdge(ctxFrom, ctxTo):-
   BlockEdge(ctxFrom, _, ctxTo, _).
 
 .decl ContextCanReach(fromCtx: Context, ctx: Context)
+#ifdef ENABLE_LIMITSIZE
 .limitsize ContextCanReach(n=LIMITSIZE_CAN_REACH_UNDER_CONTEXT)
+#endif
 
 ContextCanReach(ctx, ctx) :-
   ReachableContext(ctx, _).

--- a/logic/functions.dl
+++ b/logic/functions.dl
@@ -5,6 +5,12 @@
 #define RETURN_ADDRESS_RANK_THRESHOLD 25
 #define LIMITSIZE_CAN_REACH_UNDER_CONTEXT 25000000
 
+// Experiment with different limits than global stack
+#define MAX_FUNCTIONAL_STACK_HEIGHT 50
+#define CheckIsFunctionalStackIndex(v) ((v) >= 0, (v) < MAX_FUNCTIONAL_STACK_HEIGHT)
+#define CheckIsFunctionalPopDelta(v) ((v) >= 0, (v) < MAX_FUNCTIONAL_STACK_HEIGHT)
+#define CheckIsFunctionalStackDelta(n) ((n) < MAX_FUNCTIONAL_STACK_HEIGHT, (n) > -MAX_FUNCTIONAL_STACK_HEIGHT)
+
 
 /*****
  * Function discovery logic
@@ -720,7 +726,7 @@ FunctionalBlockPopDelta(from, newPopDelta) :-
   PossibleImpreciseNumberOfFunctionArguments(func, n_args),
   IRBlockStackDelta(from, stackDelta),
   newPopDelta = @max2(n_args - stackDelta, popDelta),
-  CheckIsPopDelta(newPopDelta).
+  CheckIsFunctionalPopDelta(newPopDelta).
 
 
 // What is the total difference in stack level during this block ?
@@ -738,7 +744,7 @@ FunctionalBlockStackDelta(from, newStackDelta) :-
   PossibleCombinedNumberOfFunctionReturnsAndArguments(func, ret, n_args, n_ret),
   IRBlockStackDelta(from, stackDelta),
   newStackDelta = stackDelta - n_args + n_ret,
-  CheckIsStackDelta(newStackDelta).
+  CheckIsFunctionalStackDelta(newStackDelta).
 
 // What about calls with no return? These don't get back to the
 // caller, so we never care about the level they leave the stack at,
@@ -783,15 +789,58 @@ NotCycleEntryLocalBlockEdge(from, to) :-
    LocalBlockEdge(from, to),
    !PotentialCycleEntry(to).
 
+.decl PossibleCyclicFunctionalBlockPopAndStackDeltaHelper(func: IRFunction, from: IRBlock, oldPath: Path, newPath: Path, popDelta: number, stackDelta: number)
+
+.decl PossibleCyclicFunctionalBlockEdgePopAndStackDeltaHelper(func: IRFunction, from: IRBlock, to: IRBlock, oldPath: Path, newPath: Path, prevPopDelta: number, prevStackDelta: number)
+
+.decl AddToPathRequest(prevPath:Path, blockToAdd:IRBlock)
+
+.decl AddToPathResponse(prevPath:Path, blockToAdd:IRBlock, newPath:Path)
+
+AddToPathRequest(prevPath, to):-
+  PossibleFunctionalBlockPopAndStackDelta(_, from, prevPath, _, _),
+  PotentialCycleEntryLocalBlockEdge(from, to).
+
+AddToPathResponse(prevPath, to, @add_set(prevPath, to)):-
+  AddToPathRequest(prevPath, to).
+
+// PossibleCyclicFunctionalBlockEdgePopAndStackDeltaHelper(func, from, to, prevPath, newPath, prevPopDelta, prevStackDelta):-
+//   PossibleFunctionalBlockPopAndStackDelta(func, from, prevPath, prevPopDelta, prevStackDelta),
+//   PotentialCycleEntryLocalBlockEdge(from, to),
+//   AddToPathResponse(prevPath, to, newPath).
+//   .plan 1:(3,2,1)
+
+PossibleCyclicFunctionalBlockPopAndStackDeltaHelper(func, to, prevPath, newPath, newPopDelta, newStackDelta):-
+  // PossibleCyclicFunctionalBlockEdgePopAndStackDeltaHelper(func, from, to, prevPath, newPath, prevPopDelta, prevStackDelta),
+  PossibleFunctionalBlockPopAndStackDelta(func, from, prevPath, prevPopDelta, prevStackDelta),
+  PotentialCycleEntryLocalBlockEdge(from, to),
+  AddToPathResponse(prevPath, to, newPath),
+  FunctionalBlockPopAndStackDelta(from, popDelta, stackDelta),
+  newStackDelta = stackDelta + prevStackDelta,
+  newPopDelta = @max2(popDelta - prevStackDelta, prevPopDelta).
+  .plan 1:(3,1,2,4), 2:(4,1,2,3)
 
 PossibleFunctionalBlockPopAndStackDelta(func, to, newPath, newPopDelta, newStackDelta) :-
+  //PossibleCyclicFunctionalBlockPopAndStackDeltaHelper(func, to, prevPath, newPath, newPopDelta, newStackDelta),
   PossibleFunctionalBlockPopAndStackDelta(func, from, prevPath, prevPopDelta, prevStackDelta),
-  ((PotentialCycleEntryLocalBlockEdge(from, to), newPath = @add_set(prevPath, to), newPath != prevPath) ;
-    (NotCycleEntryLocalBlockEdge(from, to), newPath = prevPath)),
+  PotentialCycleEntryLocalBlockEdge(from, to),
+  AddToPathResponse(prevPath, to, newPath),
   FunctionalBlockPopAndStackDelta(from, popDelta, stackDelta),
   newStackDelta = stackDelta + prevStackDelta,
   newPopDelta = @max2(popDelta - prevStackDelta, prevPopDelta),
-  CheckIsPopDelta(newPopDelta), CheckIsStackDelta(newStackDelta).
+  newPath != prevPath,
+  CheckIsFunctionalPopDelta(newPopDelta),
+  CheckIsFunctionalStackDelta(newStackDelta).
+  .plan 1:(3,1,2,4), 2:(4,1,2,3)
+  // TODO: Improve plan 1
+
+PossibleFunctionalBlockPopAndStackDelta(func, to, prevPath, newPopDelta, newStackDelta) :-
+  PossibleFunctionalBlockPopAndStackDelta(func, from, prevPath, prevPopDelta, prevStackDelta),
+  NotCycleEntryLocalBlockEdge(from, to),
+  FunctionalBlockPopAndStackDelta(from, popDelta, stackDelta),
+  newStackDelta = stackDelta + prevStackDelta,
+  newPopDelta = @max2(popDelta - prevStackDelta, prevPopDelta),
+  CheckIsFunctionalPopDelta(newPopDelta), CheckIsFunctionalStackDelta(newStackDelta).
   .plan 1:(3,2,1)
 
 // Basic blocks that need to be checked for cycles in path sensitive algorithms
@@ -819,9 +868,9 @@ PossibleCombinedNumberOfFunctionReturnsAndArguments(func, terminal, numArg, numR
   PossibleFunctionalBlockPopAndStackDelta(func, terminal, _, prevPopDelta, prevStackDelta),
   FunctionalBlockPopAndStackDelta(terminal, popDelta, stackDelta),
   numArg = @max2(popDelta - prevStackDelta, prevPopDelta),
-  CheckIsPopDelta(numArg),
+  CheckIsFunctionalPopDelta(numArg),
   numRet = prevStackDelta + stackDelta + numArg,
-  CheckIsStackIndex(numRet).
+  CheckIsFunctionalStackIndex(numRet).
     // When leaving the stack with d more items but it originally
     // contained a args, the total number of returned values is d+a.
  .plan 1:(2,1)
@@ -964,7 +1013,7 @@ FunctionalBlockOutputContents(caller, newIndex, variable) :-
    NumberOfFunctionArguments(func, n_in),
    index >= n_in,
    newIndex = index+n_out-n_in,
-   CheckIsStackIndex(newIndex).
+   CheckIsFunctionalStackIndex(newIndex).
 
 .decl BeforeFunctionCallFunctionalBlockOutputContents(caller: IRBlock, index: StackIndex, variable: Variable)
 
@@ -988,7 +1037,7 @@ BeforeFunctionCallFunctionalBlockOutputContents(block, index, realVariable) :-
   FunctionalBlockInputContents(block, stackIndex, realVariable),
   IRBasicBlock_Tail(block, stmt),
   IRLocalStackContents(stmt, index, stackIndex),
-  CheckIsStackIndex(stackIndex).
+  CheckIsFunctionalStackIndex(stackIndex).
 
 
 // TODO, check case for function call
@@ -1030,7 +1079,7 @@ FunctionalStatement_Defines(irstmt, newVar, 0) :-
 // Case: variable originates elsewhere
 FunctionalStatement_Uses(stmt, var, n) :-
    IRStatement_Uses_Local(stmt, stackIndex, n),
-   CheckIsStackIndex(stackIndex),
+   CheckIsFunctionalStackIndex(stackIndex),
    IRStatement_Block(stmt, block),
    FunctionalBlockInputContents(block, stackIndex, var).
 

--- a/logic/functions.dl
+++ b/logic/functions.dl
@@ -15,23 +15,23 @@
          Generic basic block Reachable-from implementation
 ******/
 
-.decl CanReachUnderContext(fromCtx: Context, from:Block, ctx: Context, block: Block)
+.decl CanReachUnderContext(fromCtx: Context, ctx: Context, block: Block)
 .limitsize CanReachUnderContext(n=LIMITSIZE_CAN_REACH_UNDER_CONTEXT)
 
-CanReachUnderContext(ctx, block, ctx, block) :-
+CanReachUnderContext(ctx, ctx, block) :-
   ReachableContext(ctx, block).
 
-CanReachUnderContext(ctxFrom, blockFrom, ctxTo, blockTo) :-
+CanReachUnderContext(ctxFrom, ctxTo, blockTo) :-
   BlockEdge(ctxOther, blockOther, ctxTo, blockTo),
-  CanReachUnderContext(ctxFrom, blockFrom, ctxOther, blockOther).
+  CanReachUnderContext(ctxFrom, ctxOther, blockOther).
 
 
 
 // Derived from the context-sensitive version, maintains max precision when
 // contexts aren't needed.
-.decl CanReach(from:Block, block:Block)
-CanReach(from, to) :-
-  CanReachUnderContext(_, from, _, to).
+//.decl CanReach(from:Block, block:Block)
+//CanReach(from, to) :-
+//  CanReachUnderContext(_, from, _, to).
 
 /******
          Heuristics for detecting call-return patterns
@@ -113,7 +113,7 @@ MaybeFunctionCallReturn(ctx, caller, func, retCtx, retBlock, retTarget) :-
   postTrans.Statement_Block(jump, caller),
   postTrans.Statement_Opcode(jump, "JUMP"), //Added to invalidate JUMPIs we will need to deal with them though
   BlockJumpValidTarget(ctx, caller, targetVar, func),
-  CanReachUnderContext(ctx, caller, retCtx, retBlock),
+  CanReachUnderContext(ctx, /*caller,*/ retCtx, retBlock),
   BlockJumpValidTarget(retCtx, retBlock, _, retTarget).
 
 // Introduced to use in many rules that don't use the context of the context-sensitive version
@@ -127,7 +127,7 @@ MaybeFunctionCallReturn_Ins(caller, func, retBlock, retTarget):-
 .decl PossibleReturnAddressWithPositiveRank(callCtx:Context, targetSetter:Block, retCtx:Context, retBlock:Block, retTarget:Block, rank:number)
 PossibleReturnAddressWithPositiveRank(callCtx, caller, retCtx, retBlock, retTarget, n) :-
   PossibleReturnAddressWithRank(callCtx, caller, retCtx, retBlock, retTarget, n),
-  CanReachUnderContext(callCtx, caller, retCtx, retBlock),
+  CanReachUnderContext(callCtx, /*caller,*/ retCtx, retBlock),
   BlockJumpValidTarget(retCtx, retBlock, _, retTarget),
   n > 0,
   n < RETURN_ADDRESS_RANK_THRESHOLD.

--- a/logic/functions.dl
+++ b/logic/functions.dl
@@ -21,15 +21,15 @@
 ContextEdge(ctxFrom, ctxTo):-
   BlockEdge(ctxFrom, _, ctxTo, _).
 
-.decl CanReachUnderContext(fromCtx: Context, ctx: Context)
-.limitsize CanReachUnderContext(n=LIMITSIZE_CAN_REACH_UNDER_CONTEXT)
+.decl ContextCanReach(fromCtx: Context, ctx: Context)
+.limitsize ContextCanReach(n=LIMITSIZE_CAN_REACH_UNDER_CONTEXT)
 
-CanReachUnderContext(ctx, ctx) :-
+ContextCanReach(ctx, ctx) :-
   ReachableContext(ctx, _).
 
-CanReachUnderContext(ctxFrom, ctxTo) :-
+ContextCanReach(ctxFrom, ctxTo) :-
   ContextEdge(ctxOther, ctxTo),
-  CanReachUnderContext(ctxFrom, ctxOther).
+  ContextCanReach(ctxFrom, ctxOther).
 
 
 
@@ -113,7 +113,7 @@ MaybeFunctionCallReturn(ctx, caller, func, retCtx, retBlock, retTarget) :-
   postTrans.Statement_Block(jump, caller),
   postTrans.Statement_Opcode(jump, "JUMP"), //Added to invalidate JUMPIs we will need to deal with them though
   BlockJumpValidTarget(ctx, caller, targetVar, func),
-  CanReachUnderContext(ctx, retCtx),
+  ContextCanReach(ctx, retCtx),
   BlockJumpValidTarget(retCtx, retBlock, _, retTarget).
 
 // Introduced to use in many rules that don't use the context of the context-sensitive version
@@ -127,7 +127,7 @@ MaybeFunctionCallReturn_Ins(caller, func, retBlock, retTarget):-
 .decl PossibleReturnAddressWithPositiveRank(callCtx:Context, targetSetter:Block, retCtx:Context, retBlock:Block, retTarget:Block, rank:number)
 PossibleReturnAddressWithPositiveRank(callCtx, caller, retCtx, retBlock, retTarget, n) :-
   PossibleReturnAddressWithRank(callCtx, caller, retCtx, retBlock, retTarget, n),
-  CanReachUnderContext(callCtx, retCtx),
+  ContextCanReach(callCtx, retCtx),
   BlockJumpValidTarget(retCtx, retBlock, _, retTarget),
   n > 0,
   n < RETURN_ADDRESS_RANK_THRESHOLD.

--- a/logic/functions.dl
+++ b/logic/functions.dl
@@ -5,12 +5,6 @@
 #define RETURN_ADDRESS_RANK_THRESHOLD 25
 #define LIMITSIZE_CAN_REACH_UNDER_CONTEXT 25000000
 
-// Experiment with different limits than global stack
-#define MAX_FUNCTIONAL_STACK_HEIGHT 50
-#define CheckIsFunctionalStackIndex(v) ((v) >= 0, (v) < MAX_FUNCTIONAL_STACK_HEIGHT)
-#define CheckIsFunctionalPopDelta(v) ((v) >= 0, (v) < MAX_FUNCTIONAL_STACK_HEIGHT)
-#define CheckIsFunctionalStackDelta(n) ((n) < MAX_FUNCTIONAL_STACK_HEIGHT, (n) > -MAX_FUNCTIONAL_STACK_HEIGHT)
-
 
 /*****
  * Function discovery logic
@@ -726,7 +720,7 @@ FunctionalBlockPopDelta(from, newPopDelta) :-
   PossibleImpreciseNumberOfFunctionArguments(func, n_args),
   IRBlockStackDelta(from, stackDelta),
   newPopDelta = @max2(n_args - stackDelta, popDelta),
-  CheckIsFunctionalPopDelta(newPopDelta).
+  CheckIsPopDelta(newPopDelta).
 
 
 // What is the total difference in stack level during this block ?
@@ -744,7 +738,7 @@ FunctionalBlockStackDelta(from, newStackDelta) :-
   PossibleCombinedNumberOfFunctionReturnsAndArguments(func, ret, n_args, n_ret),
   IRBlockStackDelta(from, stackDelta),
   newStackDelta = stackDelta - n_args + n_ret,
-  CheckIsFunctionalStackDelta(newStackDelta).
+  CheckIsStackDelta(newStackDelta).
 
 // What about calls with no return? These don't get back to the
 // caller, so we never care about the level they leave the stack at,
@@ -789,58 +783,15 @@ NotCycleEntryLocalBlockEdge(from, to) :-
    LocalBlockEdge(from, to),
    !PotentialCycleEntry(to).
 
-.decl PossibleCyclicFunctionalBlockPopAndStackDeltaHelper(func: IRFunction, from: IRBlock, oldPath: Path, newPath: Path, popDelta: number, stackDelta: number)
-
-.decl PossibleCyclicFunctionalBlockEdgePopAndStackDeltaHelper(func: IRFunction, from: IRBlock, to: IRBlock, oldPath: Path, newPath: Path, prevPopDelta: number, prevStackDelta: number)
-
-.decl AddToPathRequest(prevPath:Path, blockToAdd:IRBlock)
-
-.decl AddToPathResponse(prevPath:Path, blockToAdd:IRBlock, newPath:Path)
-
-AddToPathRequest(prevPath, to):-
-  PossibleFunctionalBlockPopAndStackDelta(_, from, prevPath, _, _),
-  PotentialCycleEntryLocalBlockEdge(from, to).
-
-AddToPathResponse(prevPath, to, @add_set(prevPath, to)):-
-  AddToPathRequest(prevPath, to).
-
-// PossibleCyclicFunctionalBlockEdgePopAndStackDeltaHelper(func, from, to, prevPath, newPath, prevPopDelta, prevStackDelta):-
-//   PossibleFunctionalBlockPopAndStackDelta(func, from, prevPath, prevPopDelta, prevStackDelta),
-//   PotentialCycleEntryLocalBlockEdge(from, to),
-//   AddToPathResponse(prevPath, to, newPath).
-//   .plan 1:(3,2,1)
-
-PossibleCyclicFunctionalBlockPopAndStackDeltaHelper(func, to, prevPath, newPath, newPopDelta, newStackDelta):-
-  // PossibleCyclicFunctionalBlockEdgePopAndStackDeltaHelper(func, from, to, prevPath, newPath, prevPopDelta, prevStackDelta),
-  PossibleFunctionalBlockPopAndStackDelta(func, from, prevPath, prevPopDelta, prevStackDelta),
-  PotentialCycleEntryLocalBlockEdge(from, to),
-  AddToPathResponse(prevPath, to, newPath),
-  FunctionalBlockPopAndStackDelta(from, popDelta, stackDelta),
-  newStackDelta = stackDelta + prevStackDelta,
-  newPopDelta = @max2(popDelta - prevStackDelta, prevPopDelta).
-  .plan 1:(3,1,2,4), 2:(4,1,2,3)
 
 PossibleFunctionalBlockPopAndStackDelta(func, to, newPath, newPopDelta, newStackDelta) :-
-  //PossibleCyclicFunctionalBlockPopAndStackDeltaHelper(func, to, prevPath, newPath, newPopDelta, newStackDelta),
   PossibleFunctionalBlockPopAndStackDelta(func, from, prevPath, prevPopDelta, prevStackDelta),
-  PotentialCycleEntryLocalBlockEdge(from, to),
-  AddToPathResponse(prevPath, to, newPath),
+  ((PotentialCycleEntryLocalBlockEdge(from, to), newPath = @add_set(prevPath, to), newPath != prevPath) ;
+    (NotCycleEntryLocalBlockEdge(from, to), newPath = prevPath)),
   FunctionalBlockPopAndStackDelta(from, popDelta, stackDelta),
   newStackDelta = stackDelta + prevStackDelta,
   newPopDelta = @max2(popDelta - prevStackDelta, prevPopDelta),
-  newPath != prevPath,
-  CheckIsFunctionalPopDelta(newPopDelta),
-  CheckIsFunctionalStackDelta(newStackDelta).
-  .plan 1:(3,1,2,4), 2:(4,1,2,3)
-  // TODO: Improve plan 1
-
-PossibleFunctionalBlockPopAndStackDelta(func, to, prevPath, newPopDelta, newStackDelta) :-
-  PossibleFunctionalBlockPopAndStackDelta(func, from, prevPath, prevPopDelta, prevStackDelta),
-  NotCycleEntryLocalBlockEdge(from, to),
-  FunctionalBlockPopAndStackDelta(from, popDelta, stackDelta),
-  newStackDelta = stackDelta + prevStackDelta,
-  newPopDelta = @max2(popDelta - prevStackDelta, prevPopDelta),
-  CheckIsFunctionalPopDelta(newPopDelta), CheckIsFunctionalStackDelta(newStackDelta).
+  CheckIsPopDelta(newPopDelta), CheckIsStackDelta(newStackDelta).
   .plan 1:(3,2,1)
 
 // Basic blocks that need to be checked for cycles in path sensitive algorithms
@@ -868,9 +819,9 @@ PossibleCombinedNumberOfFunctionReturnsAndArguments(func, terminal, numArg, numR
   PossibleFunctionalBlockPopAndStackDelta(func, terminal, _, prevPopDelta, prevStackDelta),
   FunctionalBlockPopAndStackDelta(terminal, popDelta, stackDelta),
   numArg = @max2(popDelta - prevStackDelta, prevPopDelta),
-  CheckIsFunctionalPopDelta(numArg),
+  CheckIsPopDelta(numArg),
   numRet = prevStackDelta + stackDelta + numArg,
-  CheckIsFunctionalStackIndex(numRet).
+  CheckIsStackIndex(numRet).
     // When leaving the stack with d more items but it originally
     // contained a args, the total number of returned values is d+a.
  .plan 1:(2,1)
@@ -1013,7 +964,7 @@ FunctionalBlockOutputContents(caller, newIndex, variable) :-
    NumberOfFunctionArguments(func, n_in),
    index >= n_in,
    newIndex = index+n_out-n_in,
-   CheckIsFunctionalStackIndex(newIndex).
+   CheckIsStackIndex(newIndex).
 
 .decl BeforeFunctionCallFunctionalBlockOutputContents(caller: IRBlock, index: StackIndex, variable: Variable)
 
@@ -1037,7 +988,7 @@ BeforeFunctionCallFunctionalBlockOutputContents(block, index, realVariable) :-
   FunctionalBlockInputContents(block, stackIndex, realVariable),
   IRBasicBlock_Tail(block, stmt),
   IRLocalStackContents(stmt, index, stackIndex),
-  CheckIsFunctionalStackIndex(stackIndex).
+  CheckIsStackIndex(stackIndex).
 
 
 // TODO, check case for function call
@@ -1079,7 +1030,7 @@ FunctionalStatement_Defines(irstmt, newVar, 0) :-
 // Case: variable originates elsewhere
 FunctionalStatement_Uses(stmt, var, n) :-
    IRStatement_Uses_Local(stmt, stackIndex, n),
-   CheckIsFunctionalStackIndex(stackIndex),
+   CheckIsStackIndex(stackIndex),
    IRStatement_Block(stmt, block),
    FunctionalBlockInputContents(block, stackIndex, var).
 

--- a/logic/global.dl
+++ b/logic/global.dl
@@ -36,7 +36,9 @@
 
 // Stack contents at input and output of a block, given its calling context.
 .decl BlockOutputContents(context:Context, block:Block, index:StackIndex, var:Variable)
+#ifdef ENABLE_LIMITSIZE
 .limitsize BlockOutputContents(n=LIMITSIZE_BLOCK_OUTPUT_CONTENTS)
+#endif
 
 .decl BlockInputContents(context:Context, block:Block, index:StackIndex, var:Variable)
 


### PR DESCRIPTION
# Various decompiler changes (`CanReachUnderContext`, `FunctionReturnIsStackBalanceBlock`, use of limitsize is optional)

This pull request mainly includes changes to `CanReachUnderContext` (now `ContextCanReach`) that improve  the scalability of the decompiler.
It also contains a change in function inference, making gigahorse infer functions more eagerly, to improve the precision of its output.

These changes were evaluated on a set of 4035 recently scraped smart contracts.

An optional `--enable_limitsize` flag was also added, to enable the use of limitsize for two key decompiler relations (`CanReachUnderContext`, `BlockOutputContents`).

## Main changes

### Replaced relation `CanReachUnderContext(fromCtx: Context, from:Block, ctx: Context, block: Block)` with `ContextCanReach(fromCtx: Context, ctx: Context)`
This was made possible by first removing uses of `CanReachUnderContext` that could be replaced with another predicate or removed without suffering a loss of precision.
For the two remaining uses where it was not possible to remove it without losing precision the use of `ContextCanReach` gives roughly the same results while providing much better scalability.

After these changes (comparing commits `f89ccb4fa6cf3063317363c1726dccce734ead27` and `259f6c175c9884911d10751433ea789a213a1a9b`) our timeouts dropped from 201 to 143 contracts, total decompilation time for the contracts 201 contracts decompilable in both configurations dropped from around 9500s to around 4200s. In terms of differences in precision `JumpToMany` had different results for 3 contracts but the difference was minor overall.

### Function inference change
Made the logic more eager to infer functions by infering possible functions when their infered return blocks are "stack balancing" blocks (see `local.dl`).
This was done because these are the blocks that are normally causing us to be imprecise (producing instances of `JumpToMany`).

The impact of this change was minor in terms of timeouts (dropped by 1) or decompilation time. However the number of `JumpToMany` results dropped from 2921 to 2651, with the number of contracts reporting any `JumpToMany` results dropping by 98 (from 840 to 742).

## Unmerged experimental optimizations

I also experimented with some other optimizations which ended up not being significant enough to give us a performance benefit in real-world contracts.

The reason their impact was not significant was the fact that when these were made a bottleneck, programs had multiple other unavoidable bottlenecks. This was usually due to an explosion of reachable contexts, making relations like `IsFunctionCallReturn` or `MaybeFunctionCallReturn` produce hundreds of millions of tuples.

I believe our best course of action to decompile such pathological cases would be to use different maximum context depths.

### Use of the `add_set` functor (`PossibleFunctionalBlockPopAndStackDelta`)

I found that in some pathological cases (ex `2B31763D9845583C53CF62170682C1F2`) the evaluation of `PossibleFunctionalBlockPopAndStackDelta` was taking a very long time.
This was due to multiple redundant calls being made to the `add_set` functor. 
I improved it by using the request/response patern:

```
.decl AddToPathRequest(prevPath:Path, blockToAdd:IRBlock)

.decl AddToPathResponse(prevPath:Path, blockToAdd:IRBlock, newPath:Path)

AddToPathRequest(prevPath, to):-
  PossibleFunctionalBlockPopAndStackDelta(_, from, prevPath, _, _),
  PotentialCycleEntryLocalBlockEdge(from, to).

AddToPathResponse(prevPath, to, @add_set(prevPath, to)):-
  AddToPathRequest(prevPath, to).

PossibleFunctionalBlockPopAndStackDelta(func, to, newPath, newPopDelta, newStackDelta) :-
  PossibleFunctionalBlockPopAndStackDelta(func, from, prevPath, prevPopDelta, prevStackDelta),
  PotentialCycleEntryLocalBlockEdge(from, to),
  AddToPathResponse(prevPath, to, newPath),
  FunctionalBlockPopAndStackDelta(from, popDelta, stackDelta),
  newStackDelta = stackDelta + prevStackDelta,
  newPopDelta = @max2(popDelta - prevStackDelta, prevPopDelta),
  newPath != prevPath,
  CheckIsFunctionalPopDelta(newPopDelta),
  CheckIsFunctionalStackDelta(newStackDelta).
  .plan 1:(3,1,2,4), 2:(4,1,2,3)
  // TODO: Improve plan 1

PossibleFunctionalBlockPopAndStackDelta(func, to, prevPath, newPopDelta, newStackDelta) :-
  PossibleFunctionalBlockPopAndStackDelta(func, from, prevPath, prevPopDelta, prevStackDelta),
  NotCycleEntryLocalBlockEdge(from, to),
  FunctionalBlockPopAndStackDelta(from, popDelta, stackDelta),
  newStackDelta = stackDelta + prevStackDelta,
  newPopDelta = @max2(popDelta - prevStackDelta, prevPopDelta),
  CheckIsFunctionalPopDelta(newPopDelta), CheckIsFunctionalStackDelta(newStackDelta).
  .plan 1:(3,2,1)
```

While it provided a significant performance benefit (execution of the relevant rules went from 2m to 10s for my config) decompilation of the examined would still not terminate after a reasonable amount of time.
Running it for the evaluation set of this PR didn't give us any benefit for a timeout of up to 5 minutes.

### Optimization for `PossibleReturnAddressWithRank`

Looking at a pathological contract (`E4EE50C295CAFD6DC954DD584DB4F898`), analyzed with a depth of 8.
Made the following refactoring of the code.

```
.decl MaybeFunctionCallReturnNewContext(ctx:Context, caller:Block, retTargetCtx:Context, retTarget:Block)
MaybeFunctionCallReturnNewContext(ctx, caller, retTargetCtx, retTarget) :-
  MaybeFunctionCallReturn(ctx, caller, _, retCtx, ret, retTarget),
  BlockEdge(retCtx, ret, retTargetCtx, retTarget),
  postTrans.ImmediateBlockJumpTarget(retTarget, _). // only keep target blocks that are direct jumps

.decl MaybeFunctionCallReturnNewContextWithMaxRank(ctx:Context, caller:Block, retTargetCtx:Context, retTarget:Block, maxrank:number)
MaybeFunctionCallReturnNewContextWithMaxRank(ctx, caller, retTargetCtx, retTarget, maxrank):-
  MaybeFunctionCallReturnNewContext(ctx, caller, retTargetCtx, retTarget),
  MaxRankForPossibleReturnAddressSetter(retTarget, maxrank).

// If we have found a likely call-return pattern, we propagate to the return
// block the extra pushed return values of the former caller. Stacking return
// values is a usual pattern in produced code.

// Case where the caller pushes new return targets as well.
PossibleReturnAddressWithRank(newCallCtx, caller, retCtx, retBlock, retTarget, n + maxrank) :-
  PossibleReturnAddressWithPositiveRank(prevCallCtx, targetSetter, retCtx, retBlock, retTarget, n),
  MaybeFunctionCallReturnNewContextWithMaxRank(prevCallCtx, targetSetter, newCallCtx, caller, maxrank),
  n + maxrank < RETURN_ADDRESS_RANK_THRESHOLD.
 .plan 1:(2,1)

.decl MaybeFunctionCallReturnNewContextWithNoPossibleReturnAddress(ctx:Context, caller:Block, retTargetCtx:Context, retTarget:Block)
MaybeFunctionCallReturnNewContextWithNoPossibleReturnAddress(ctx, caller, retTargetCtx, retTarget):-
  MaybeFunctionCallReturnNewContext(ctx, caller, retTargetCtx, retTarget),
  !PossibleReturnAddressWithPos(retTarget, _, _, _, _).

// Case where the caller doesn't push new return targets to the stack
PossibleReturnAddressWithRank(newCallCtx, caller, retCtx, retBlock, retTarget, n-1) :-
  PossibleReturnAddressWithPositiveRank(prevCallCtx, targetSetter, retCtx, retBlock, retTarget, n),
  MaybeFunctionCallReturnNewContextWithNoPossibleReturnAddress(prevCallCtx, targetSetter, newCallCtx, caller).
 .plan 1:(2,1)
```

While it was  2x faster it did not end up making a huge difference.
