### PR TITLE
Add control-flow related components. Recognize OZ-style reentrancy guards.

### DIFF
--- a/clientlib/dominators.dl
+++ b/clientlib/dominators.dl
@@ -104,23 +104,25 @@ LocalStatementPathInBlock(stmt1, stmt3):-
 /**
   Component used to get a cheap statement-level global may happen before relation if we can describe the sets of statements
   relevant to our query at compile time.
-  This can be used to answer questions like: "Can we have an SSTORE statement to the same address, one followed by the other?"
+  This can be used to answer questions like: "Can we have two SSTORE statements to the same address, one followed by the other?"
 
   This is useful because computing such relations (all-pairs) at the statement-level is prohibitively expensive
   but computing them top-down (on demand) like this makes it very cheap even inter-procedurally.
 
-  The Before(before:Statement, arg:symbol) and After(after:Statement, arg:symbol) input relations are populated at every instantiation of the component
-  to describe the relevant sets of statements for our query.
+  The Before(before:Statement, arg:symbol) and After(after:Statement, arg:symbol) input relations
+  are populated at every instantiation of the component to describe the relevant sets of statements for our query.
 
   Output relation MayHappenBefore(before:Statement, after:Statement, arg:symbol) will contain a subset of statements `before`,`after` such that
   statement `before` can be executed before statement `after` for some program path. Both statements are associated with the same `arg`.
 
+  Only external (outside of the component) library relations used are LocalStatementPathInBlock and LocalBlockPath.
+
   The example described above would be:
-    .init storesSameAddress = MayHappenBeforeWithArg
+    .init storesSameAddress = MayHappenBeforeGlobalWithArg
     storesSameAddress.Before(before, val):- SSTORE(before, var, _), Variable_Value(var, val).
     storesSameAddress.After(after, val):- SSTORE(after, var, _), Variable_Value(var, val).
 */
-.comp MayHappenBeforeWithArg {
+.comp MayHappenBeforeGlobalWithArg {
   // Input relations
   .decl Before(before:Statement, arg:symbol)
   .decl After(after:Statement, arg:symbol)
@@ -182,8 +184,10 @@ LocalStatementPathInBlock(stmt1, stmt3):-
   This is useful because computing such relations (all-pairs) at the statement-level is prohibitively expensive
   but computing them top-down (on demand) like this makes it very cheap even inter-procedurally.
 
-  The Before(before:Statement) and After(after:Statement) input relations are populated at every instantiation of the component
-  to describe the relevant sets of statements for our query.
+  Internally it uses MayHappenBeforeGlobalWithArg.
+
+  The Before(before:Statement) and After(after:Statement) input relations are populated
+  at every instantiation of the component to describe the relevant sets of statements for our query.
 
   Output relation MayHappenBefore(before:Statement, after:Statement) will contain a subset of statements `before`,`after` such that
   statement `before` can be executed before statement `after` for some program path.
@@ -202,7 +206,7 @@ LocalStatementPathInBlock(stmt1, stmt3):-
   // Output relation 'before' can happen before 'after'
   .decl MayHappenBefore(before:Statement, after:Statement)
 
-  .init mayHappenBeforeInternal = MayHappenBeforeWithArg
+  .init mayHappenBeforeInternal = MayHappenBeforeGlobalWithArg
 
   mayHappenBeforeInternal.Before(before, "NULL"):- Before(before).
   mayHappenBeforeInternal.After(after, "NULL"):- After(after).
@@ -210,11 +214,29 @@ LocalStatementPathInBlock(stmt1, stmt3):-
   MayHappenBefore(before, after):- mayHappenBeforeInternal.MayHappenBefore(before, after, "NULL").
 }
 
+/**
+  Component used to get a cheap statement-level global may happen before relation if we can describe the sets of statements
+  relevant to our query at compile time.
+
+  This is useful because computing such relations (all-pairs) at the statement-level is prohibitively expensive
+  but computing them top-down (on demand) like this makes it very cheap even inter-procedurally.
+
+  Internally it uses two instantiations of MayHappenBeforeGlobal.
+
+  The Before(before:Statement), Between(between:Statement), and After(after:Statement) input relations
+  are populated at every instantiation of the component to describe the relevant sets of statements for our query.
+
+  Output relation MayHappenInBetween(before:Statement, between:Statement, after:Statement) will contain a subset of statements `before`, `between`, `after`
+  such that statement `between` can be executed after statement `before` and before statement `after`, for some program path.
+*/
+
 .comp MayHappenInBetweenGlobal {
+  // Input relations
   .decl Before(before:Statement)
   .decl Between(between:Statement)
   .decl After(after:Statement)
 
+  // Output relation
   .decl MayHappenInBetween(before:Statement, between:Statement, after:Statement)
 
   .init beforeToBetween = MayHappenBeforeGlobal

--- a/clientlib/dominators.dl
+++ b/clientlib/dominators.dl
@@ -78,3 +78,154 @@ HappensAfter(nextnext, stmt) :-
   HappensAfter(next, stmt),
   HappensAfterBase(nextnext, next).
 
+
+/**
+  Helper control-flow-related predicates
+**/
+
+.decl LocalBlockPath(from:Block, to:Block)
+
+LocalBlockPath(src, target):-
+  LocalBlockEdge(src, target).
+
+LocalBlockPath(src, target):-
+  LocalBlockPath(src, mid),
+  LocalBlockEdge(mid, target).
+
+.decl LocalStatementPathInBlock(stmt1:Statement, stmt2:Statement)
+
+LocalStatementPathInBlock(stmt1, stmt2):-
+  Helper_NextStatementInSameBlock(stmt1, stmt2).
+
+LocalStatementPathInBlock(stmt1, stmt3):-
+  LocalStatementPathInBlock(stmt1, stmt2),
+  Helper_NextStatementInSameBlock(stmt2, stmt3).
+
+/**
+  Component used to get a cheap statement-level global may happen before relation if we can describe the sets of statements
+  relevant to our query at compile time.
+  This can be used to answer questions like: "Can we have an SSTORE statement to the same address, one followed by the other?"
+
+  This is useful because computing such relations (all-pairs) at the statement-level is prohibitively expensive
+  but computing them top-down (on demand) like this makes it very cheap even inter-procedurally.
+
+  The Before(before:Statement, arg:symbol) and After(after:Statement, arg:symbol) input relations are populated at every instantiation of the component
+  to describe the relevant sets of statements for our query.
+
+  Output relation MayHappenBefore(before:Statement, after:Statement, arg:symbol) will contain a subset of statements `before`,`after` such that
+  statement `before` can be executed before statement `after` for some program path. Both statements are associated with the same `arg`.
+
+  The example described above would be:
+    .init storesSameAddress = MayHappenBeforeWithArg
+    storesSameAddress.Before(before, val):- SSTORE(before, var, _), Variable_Value(var, val).
+    storesSameAddress.After(after, val):- SSTORE(after, var, _), Variable_Value(var, val).
+*/
+.comp MayHappenBeforeWithArg {
+  // Input relations
+  .decl Before(before:Statement, arg:symbol)
+  .decl After(after:Statement, arg:symbol)
+
+  // Output relation 'before' can happen before 'after'
+  .decl MayHappenBefore(before:Statement, after:Statement, arg:symbol)
+
+  // Intermediate relations. These start before the original `before` and `after` statements populating the input relations
+  // and transitively go back through function calls to work inter-procedurally
+  // originalBefore/After are kept because to report the original statements, before/after is what changes when going through private calls
+  // before/afterBlock, before/afterFunction are relative to before/after and not the original ones and are in the relation to enable more efficient joins.
+  .decl BeforeInfo(originalBefore:Statement, before:Statement, beforeBlock:Block, beforeFunction:Function, arg:symbol)
+  .decl AfterInfo(originalAfter:Statement, after:Statement, afterBlock:Block, afterFunction:Function, arg:symbol)
+
+  // base case, starting from Before
+  BeforeInfo(before, before, beforeBlock, beforeFunction, arg):-
+    Before(before, arg),
+    Statement_Block(before, beforeBlock),
+    InFunction(beforeBlock, beforeFunction).
+
+  // base case, starting before After
+  AfterInfo(after, after, afterBlock, afterFunction, arg):-
+    After(after, arg),
+    Statement_Block(after, afterBlock),
+    InFunction(afterBlock, afterFunction).
+
+  // transitive case: moving backwards through function calls
+  BeforeInfo(originalBefore, callStmt, calleeBlock, calleeFunction, arg):-
+    BeforeInfo(originalBefore, _, _, beforeFunction, arg),
+    CallGraphEdge(calleeBlock, beforeFunction),
+    InFunction(calleeBlock, calleeFunction),
+    Statement_Block(callStmt, calleeBlock),
+    Statement_Opcode(callStmt, "CALLPRIVATE").
+
+  // transitive case: moving backwards through function calls
+  AfterInfo(originalAfter, callStmt, calleeBlock, calleeFunction, arg):-
+    AfterInfo(originalAfter, _, _, afterFunction, arg),
+    CallGraphEdge(calleeBlock, afterFunction),
+    InFunction(calleeBlock, calleeFunction),
+    Statement_Block(callStmt, calleeBlock),
+    Statement_Opcode(callStmt, "CALLPRIVATE").
+
+  MayHappenBefore(originalBefore, originalAfter, arg):-
+    BeforeInfo(originalBefore, before, block, fun, arg),
+    AfterInfo(originalAfter, after, block, fun, arg),
+    LocalStatementPathInBlock(before, after).
+
+  MayHappenBefore(originalBefore, originalAfter, arg):-
+    BeforeInfo(originalBefore, _, beforeBlock, fun, arg),
+    AfterInfo(originalAfter, _, afterBlock, fun, arg), // REVIEW: maybe inverted order is faster.
+    LocalBlockPath(beforeBlock, afterBlock).
+}
+
+/**
+  Component used to get a cheap statement-level global may happen before relation if we can describe the sets of statements
+  relevant to our query at compile time.
+  This can be used to answer questions like: "Can we have an SSTORE statement after external call?"
+
+  This is useful because computing such relations (all-pairs) at the statement-level is prohibitively expensive
+  but computing them top-down (on demand) like this makes it very cheap even inter-procedurally.
+
+  The Before(before:Statement) and After(after:Statement) input relations are populated at every instantiation of the component
+  to describe the relevant sets of statements for our query.
+
+  Output relation MayHappenBefore(before:Statement, after:Statement) will contain a subset of statements `before`,`after` such that
+  statement `before` can be executed before statement `after` for some program path.
+
+  The example described above would be:
+    .init storeAfterCall = MayHappenBeforeGlobal
+    storeAfterCall.Before(before):- CallStmt(before).
+    storeAfterCall.After(after):- SSTORE(after, _, _).
+*/
+
+.comp MayHappenBeforeGlobal {
+  // Input relations
+  .decl Before(before:Statement)
+  .decl After(after:Statement)
+
+  // Output relation 'before' can happen before 'after'
+  .decl MayHappenBefore(before:Statement, after:Statement)
+
+  .init mayHappenBeforeInternal = MayHappenBeforeWithArg
+
+  mayHappenBeforeInternal.Before(before, "NULL"):- Before(before).
+  mayHappenBeforeInternal.After(after, "NULL"):- After(after).
+
+  MayHappenBefore(before, after):- mayHappenBeforeInternal.MayHappenBefore(before, after, "NULL").
+}
+
+.comp MayHappenInBetweenGlobal {
+  .decl Before(before:Statement)
+  .decl Between(between:Statement)
+  .decl After(after:Statement)
+
+  .decl MayHappenInBetween(before:Statement, between:Statement, after:Statement)
+
+  .init beforeToBetween = MayHappenBeforeGlobal
+  beforeToBetween.Before(before):- Before(before).
+  beforeToBetween.After(after):- Between(after).
+
+  .init betweenToAfter = MayHappenBeforeGlobal
+  betweenToAfter.Before(before):- Between(before).
+  betweenToAfter.After(after):- After(after).
+
+  MayHappenInBetween(before, between, after):-
+    beforeToBetween.MayHappenBefore(before, between),
+    betweenToAfter.MayHappenBefore(between, after).
+}

--- a/clientlib/guards.dl
+++ b/clientlib/guards.dl
@@ -114,6 +114,11 @@ StoreValueToGlobalVariable(stmt, globalVar, storedVal):-
   StoreGlobalVariable(stmt, globalVar, var),
   Variable_Value(var, storedVal).
 
+// HACK to cover cases where the "0" value stored is not stored in a val
+// Need to make it cleaner at some later point
+StoreValueToGlobalVariable(stmt, globalVar, "0x0"):-
+  StoreGlobalVariable(stmt, globalVar, "0xNoVar").
+
 /*
   Instantiation of MayHappenBeforeGlobalWithArg to detect consecutive stores of constant values to global variables.
 */
@@ -131,8 +136,12 @@ ReentrancyGuard(globalVar):-
   !NotReentrancyGuard(globalVar).
 
 NotReentrancyGuard(globalVar):-
-  StoreGlobalVariable(_, globalVar, var),
-  !Variable_Value(var, _).
+  GlobalVariable(globalVar),
+  !StoreGlobalVariable(_, globalVar, _).
+
+NotReentrancyGuard(globalVar):-
+  StoreGlobalVariable(stmt, globalVar, _),
+  !StoreValueToGlobalVariable(stmt, globalVar, _).
 
 NotReentrancyGuard(globalVar):-
   StoreValueToGlobalVariable(stmt, globalVar, _),

--- a/clientlib/guards.dl
+++ b/clientlib/guards.dl
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "memory_modeling/memory_modeling.dl"
 #include "data_structures.dl"
 #include "flows.dl"
 

--- a/clientlib/guards.dl
+++ b/clientlib/guards.dl
@@ -95,3 +95,60 @@ UnguardedGlobalBlockEdge(block, next) :-
    !StaticallyGuardedBlock(block, _),
    !StaticallyGuardedBlock(next, _).
 
+/**
+  Reentrancy Guard Logic
+  This is made to model the OZ-style ReentrancyGuard.
+
+  A top-level storage variable is inferred to be a ReentrancyGuard if:
+    * Constant values are always stored to it
+    * Each store is followed by another one
+    * Every use of it (two stores), always stores the same two values in the same order
+
+  Right now in practise its good enough.
+  TODO: Also have the first store be controlled by the appropriate require() guard.
+**/
+
+.decl StoreValueToGlobalVariable(stmt: Statement, globalVar: Value, storedVal: Value)
+
+StoreValueToGlobalVariable(stmt, globalVar, storedVal):-
+  StoreGlobalVariable(stmt, globalVar, var),
+  Variable_Value(var, storedVal).
+
+/*
+  Instantiation of MayHappenBeforeGlobalWithArg to detect consecutive stores of constant values to global variables.
+*/
+.init storeAfterStore = MayHappenBeforeGlobalWithArg
+storeAfterStore.Before(before, globalVar):- StoreValueToGlobalVariable(before, globalVar, _).
+storeAfterStore.After(after, globalVar):- StoreValueToGlobalVariable(after, globalVar, _).
+
+.decl ReentrancyGuard(globalVar:Value)
+
+.decl NotReentrancyGuard(globalVar: Value)
+
+
+ReentrancyGuard(globalVar):-
+  GlobalVariable(globalVar),
+  !NotReentrancyGuard(globalVar).
+
+NotReentrancyGuard(globalVar):-
+  StoreGlobalVariable(_, globalVar, var),
+  !Variable_Value(var, _).
+
+NotReentrancyGuard(globalVar):-
+  StoreValueToGlobalVariable(stmt, globalVar, _),
+  !storeAfterStore.MayHappenBefore(stmt, _, globalVar),
+  !storeAfterStore.MayHappenBefore(_, stmt, globalVar).
+
+NotReentrancyGuard(globalVar):-
+  storeAfterStore.MayHappenBefore(stmt, _, globalVar),
+  storeAfterStore.MayHappenBefore(stmt2, _, globalVar),
+  StoreValueToGlobalVariable(stmt, globalVar, storedVal),
+  StoreValueToGlobalVariable(stmt2, globalVar, storedVal2),
+  storedVal != storedVal2.
+
+NotReentrancyGuard(globalVar):-
+  storeAfterStore.MayHappenBefore(_, stmt, globalVar),
+  storeAfterStore.MayHappenBefore(_, stmt2, globalVar),
+  StoreValueToGlobalVariable(stmt, globalVar, storedVal),
+  StoreValueToGlobalVariable(stmt2, globalVar, storedVal2),
+  storedVal != storedVal2.

--- a/clientlib/memory_modeling/helpers.dl
+++ b/clientlib/memory_modeling/helpers.dl
@@ -21,27 +21,6 @@ DEBUG_OUTPUT(Variable_NumericValue)
 Variable_NumericValue(var, @hex_to_number(val)):-
   Variable_Value(var, val).
 
-/**
-  
-**/
-
-.decl LocalBlockPath(from:Block, to:Block)
-
-LocalBlockPath(src, target):-
-  LocalBlockEdge(src, target).
-
-LocalBlockPath(src, target):-
-  LocalBlockPath(src, mid),
-  LocalBlockEdge(mid, target).
-
-.decl LocalStatementPathInBlock(stmt1:Statement, stmt2:Statement)
-
-LocalStatementPathInBlock(stmt1, stmt2):-
-  Helper_NextStatementInSameBlock(stmt1, stmt2).
-
-LocalStatementPathInBlock(stmt1, stmt3):-
-  LocalStatementPathInBlock(stmt1, stmt2),
-  Helper_NextStatementInSameBlock(stmt2, stmt3).
 
 .decl MSTORE8(stmt:Statement, index:Variable, from:Variable)
 MSTORE8(stmt, index, from):-


### PR DESCRIPTION
## Overview

This PR includes various additions to the client libraries:

1. Add support for [OZ style](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/security/ReentrancyGuard.sol) reentrancy guards. Results are populating relation `ReentrancyGuard(storageVar:Value)`.
2. Make `guards.dl` use the memory modeling by default.
3. Introduced various top-down control-flow related components. These work inter-procedurally and efficiently by computing the results only for the subset of the CFG that is relevant to our query, defined at every instantiation of the component.
   * `MayHappenBeforeGlobal`: This can be used to produce results for queries such as *"Find all external calls that can be followed by an sstore for any program path"*
   * `MayHappenBeforeGlobalWithArg`: This can be used to produce results for queries such as *"Find all sstores that write to the same storage address, with one following the other"*
   * `MayHappenInBetweenGlobal`: Internally uses two instantiations of `MayHappenBeforeGlobal` to support more complex queries.