### PR TITLE
Fix the transformation for conditional throw jumps (old THROWI statements)

### DIFF
--- a/clientlib/util.dl
+++ b/clientlib/util.dl
@@ -27,6 +27,8 @@ Fail(a) :- Fail(a). // suppress warning
 #define LIST_OF_3(a,...)    [a, LIST_OF_2(__VA_ARGS__)]
 #define LIST_OF_4(a,...)    [a, LIST_OF_3(__VA_ARGS__)]
 #define LIST_OF_5(a,...)    [a, LIST_OF_4(__VA_ARGS__)]
+#define LIST_OF_6(a,...)    [a, LIST_OF_5(__VA_ARGS__)]
+#define LIST_OF_7(a,...)    [a, LIST_OF_6(__VA_ARGS__)]
 
 // NUM_ARGS(...) evaluates to the literal number of the passed-in arguments.
 #define _NUM_ARGS2(X,X64,X63,X62,X61,X60,X59,X58,X57,X56,X55,X54,X53,X52,X51,X50,X49,X48,X47,X46,X45,X44,X43,X42,X41,X40,X39,X38,X37,X36,X35,X34,X33,X32,X31,X30,X29,X28,X27,X26,X25,X24,X23,X22,X21,X20,X19,X18,X17,X16,X15,X14,X13,X12,X11,X10,X9,X8,X7,X6,X5,X4,X3,X2,X1,N,...) N

--- a/logic/debug.dl
+++ b/logic/debug.dl
@@ -2,7 +2,6 @@
 .output BlockEdge, FallthroughEdge, BlockJumpValidTarget, BlockJumpTarget, MaybeInFunctionUnderContext
 .output NotValidReturnBlock, NotValidReturnEdge
 .output MaybeFunctionCallReturn // DEBUG
-.output CanReachUnderContext //DEBUG
 .output PotentialCall // DEBUG
 .output PossibleReturnAddressWithPos // DEBUG
 .output IsFunctionCallReturn // DEBUG

--- a/logic/local.dl
+++ b/logic/local.dl
@@ -286,7 +286,7 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
      Variable_Value(variable, targetValue),
      !JUMPDEST(@cast_to_symbol(targetValue)),
      BasicBlock_Tail(block, jmp).
-  
+
   /*
    ***********
    * Define semantics of instructions
@@ -667,18 +667,29 @@ insertor.insertOps(jmp,
   preTrans.JUMP(jmp).
 
 // This one removes conditional "throw jumps"
-insertor.removeOp(jmp),
-insertor.insertOps(jmp,
+// The old "target" was the invalid and the fallthrough
+// was the valid "next" block. So we create 2 labels
+// and add the "invalid" block after the old jumpi
+// and the JUMPDEST for the old valid "next" block right after it
+// We need to add this last JUMPDEST is because it was originally
+// a fallthrough block so it didn't need to start with a JUMPDEST
+// All this also requires adding ISZERO to reverse the condition.
+// Even if it did we don't break anything by adding an extra one.
+insertor.removeOp(jumpi),
+insertor.insertOps(jumpi,
   LIST(
     STMT(POP, ""),
-    STMT(PUSH4, MAKE_LABEL_REFERENCE(jmp)),
+    STMT(ISZERO, ""),
+    STMT(PUSH4, MAKE_LABEL_REFERENCE(fallthrough)),
     STMT(JUMPI, ""),
-    STMT(JUMPDEST, MAKE_LABEL_REFERENCE(jmp)),
-    STMT(INVALID, "")
+    STMT(JUMPDEST, MAKE_LABEL_REFERENCE(jumpi)),
+    STMT(INVALID, ""),
+    STMT(JUMPDEST, MAKE_LABEL_REFERENCE(fallthrough))
   )
 ) :-
-  preTrans.ThrowJump(jmp),
-  preTrans.JUMPI(jmp).
+  preTrans.ThrowJump(jumpi),
+  preTrans.JUMPI(jumpi),
+  preTrans.FallthroughStmt(jumpi, fallthrough).
 
 // This one removes conditional jumps that "always" jump
 insertor.removeOp(jmpi),


### PR DESCRIPTION
## Overview
The old transformation for conditional throw jumps (conditional jumps with the target pointing to an invalid statement) was broken and this resulted in dead code. This PR introduces a fix me and @iliastsa wrote for it.

## Issue/fix explanation
The issue of the old code was that because the target of the `JUMPI` statement was an invalid statement causing the halting of the program's execution, the valid continuation of the control flow was the fallthrough of the `JUMPI` statement. However the new statements were inserted after the same `JUMPI` statement, effectively overriding the old fallthrough, resulting in unreachable code.

The fix is more complex than the code it replaces because it needs to insert two generated blocks relative to that `JUMPI` statement.

## Effect
We checked the effect of this fix in 3 datasets:
* 4k recent/fresh contracts: 12 new blocks reachable out of 1133407 total reachable
* 2k contracts from the memory modeling dataset: 6029 new blocks reachable out of 448522 total reachable (1.3%)
* 800 old contracts with value (ethscrape dataset): 15260 new blocks reachable out of 287139 total reachable (5.3%)

It seems that this is a pattern no longer produced by the solidity compiler but it can cause a pretty significant increase in coverage for old contracts.