### PR TITLE
Fix type problems in Gigahorse

### DIFF
--- a/clientlib/constants.dl
+++ b/clientlib/constants.dl
@@ -21,12 +21,12 @@
   // Not the most efficient because the string matching of the operator
   // will happen last, but rule should fire rarely?
   #define BINOP_SEMANTICS(_OP, _functor) \
-  ConstantFoldResult2(#_OP, arg1, arg2, result) :- \
+  ConstantFoldResult2(#_OP, arg1, arg2, as(result,Value)) :- \
     ValidConstantFoldOperation(#_OP, arg1, arg2), \
     result = _functor(arg1, arg2)
 
   #define UNOP_SEMANTICS(_OP, _functor) \
-  ConstantFoldResult1(#_OP, arg, result) :- \
+  ConstantFoldResult1(#_OP, arg, as(result, Value)) :- \
     RequestConstantFold1(#_OP, arg), \
     result = _functor(arg)
 
@@ -53,7 +53,7 @@
   UNOP_SEMANTICS(NOT, @not_256).
 
   // constant-fold ISZERO as a special case of EQ
-  ConstantFoldResult1("ISZERO", arg, result) :-
+  ConstantFoldResult1("ISZERO", arg, as(result, Value)) :-
     RequestConstantFold1("ISZERO", arg),
     result = @eq_256(arg, "0x0").
 }

--- a/clientlib/constants.dl
+++ b/clientlib/constants.dl
@@ -21,7 +21,7 @@
   // Not the most efficient because the string matching of the operator
   // will happen last, but rule should fire rarely?
   #define BINOP_SEMANTICS(_OP, _functor) \
-  ConstantFoldResult2(#_OP, arg1, arg2, as(result,Value)) :- \
+  ConstantFoldResult2(#_OP, arg1, arg2, as(result, Value)) :- \
     ValidConstantFoldOperation(#_OP, arg1, arg2), \
     result = _functor(arg1, arg2)
 

--- a/clientlib/data_structures.dl
+++ b/clientlib/data_structures.dl
@@ -463,7 +463,7 @@ AnyLoadStoreStorVarBytes(stmt, storVar, 0, 31):-
 FailedMergedStorageModeling(storVar):-
   AnyLoadStoreStorVarBytes(_, storVar, low, high),
   AnyLoadStoreStorVarBytes(_, storVar, otherLow, otherHigh),  otherLow = otherLow, otherHigh = otherHigh, // NOWARN
-  !ArrayIdToStorageIndex(@cast_to_symbol(storVar), _),
+  !ArrayIdToStorageIndex(as(storVar,symbol), _),
   (low != otherLow ; high != otherHigh),
   ( (low < otherLow , otherLow < high) ; (low < otherHigh, otherHigh < high) ).
 
@@ -479,13 +479,13 @@ FailedMergedStorageModeling(storVar):-
   !AnyLoadStoreStorVarBytes(stmt, storVar, _, _),
   !VarWrittenToBytesOfStorVar(_, _, stmt, storVar, _, _),
   !ConstWrittenToBytesOfStorVar(_, _, _, stmt, storVar, _, _),
-  !ArrayIdToStorageIndex(@cast_to_symbol(storVar), _).
+  !ArrayIdToStorageIndex(as(storVar,symbol), _).
 
 
 SuccessfulMergedStorageModeling(storVar):-
   AnyLoadStoreStorVarBytes(_, storVar, _, _),
   !FailedMergedStorageModeling(storVar),
-  !ArrayIdToStorageIndex(@cast_to_symbol(storVar), _).
+  !ArrayIdToStorageIndex(as(storVar,symbol), _).
 
 .decl VarWrittenToBytesOfStorVar(var:Variable, store:Statement, load:Statement, storVar:symbol, byteLow:number, byteHigh:number)
 .output VarWrittenToBytesOfStorVar
@@ -593,7 +593,7 @@ LoadGlobalVariable(stmt, storVar, var):-
   SLOADOfConst(stmt, storVar, var),
   FailedMergedStorageModeling(storVar).
 
-LoadGlobalVariable(stmt, @cast_to_symbol(storVar), var):-
+LoadGlobalVariable(stmt, as(storVar,symbol), var):-
   SuccessfulMergedStorageModeling(storVar),
   VarHoldsBytesOfStorVarFinal(var, _, storVar, 0, 31),
   Statement_Defines(stmt, var, 0).

--- a/clientlib/data_structures.dl
+++ b/clientlib/data_structures.dl
@@ -463,7 +463,7 @@ AnyLoadStoreStorVarBytes(stmt, storVar, 0, 31):-
 FailedMergedStorageModeling(storVar):-
   AnyLoadStoreStorVarBytes(_, storVar, low, high),
   AnyLoadStoreStorVarBytes(_, storVar, otherLow, otherHigh),  otherLow = otherLow, otherHigh = otherHigh, // NOWARN
-  !ArrayIdToStorageIndex(as(storVar,symbol), _),
+  !ArrayIdToStorageIndex(as(storVar, Value), _),
   (low != otherLow ; high != otherHigh),
   ( (low < otherLow , otherLow < high) ; (low < otherHigh, otherHigh < high) ).
 
@@ -479,13 +479,13 @@ FailedMergedStorageModeling(storVar):-
   !AnyLoadStoreStorVarBytes(stmt, storVar, _, _),
   !VarWrittenToBytesOfStorVar(_, _, stmt, storVar, _, _),
   !ConstWrittenToBytesOfStorVar(_, _, _, stmt, storVar, _, _),
-  !ArrayIdToStorageIndex(as(storVar,symbol), _).
+  !ArrayIdToStorageIndex(as(storVar, Value), _).
 
 
 SuccessfulMergedStorageModeling(storVar):-
   AnyLoadStoreStorVarBytes(_, storVar, _, _),
   !FailedMergedStorageModeling(storVar),
-  !ArrayIdToStorageIndex(as(storVar,symbol), _).
+  !ArrayIdToStorageIndex(as(storVar, Value), _).
 
 .decl VarWrittenToBytesOfStorVar(var:Variable, store:Statement, load:Statement, storVar:symbol, byteLow:number, byteHigh:number)
 .output VarWrittenToBytesOfStorVar
@@ -593,7 +593,7 @@ LoadGlobalVariable(stmt, storVar, var):-
   SLOADOfConst(stmt, storVar, var),
   FailedMergedStorageModeling(storVar).
 
-LoadGlobalVariable(stmt, as(storVar,symbol), var):-
+LoadGlobalVariable(stmt, as(storVar, Value), var):-
   SuccessfulMergedStorageModeling(storVar),
   VarHoldsBytesOfStorVarFinal(var, _, storVar, 0, 31),
   Statement_Defines(stmt, var, 0).

--- a/clientlib/memory_modeling/arrays.dl
+++ b/clientlib/memory_modeling/arrays.dl
@@ -770,13 +770,13 @@ ABIEncodedArrayVarsInSameClass(arrVar1, arrVar2):-
   MLOADSFreePtrUnchangedNoMemReuse(mload1, mload2),
   Variable_SymbolicValue(arrVar2, val2).
 
-ABIEncodedArrayVar_ClassRep(arrVar, as(arrVarRep,ArrayVariable)):-
+ABIEncodedArrayVar_ClassRep(arrVar, as(arrVarRep, ArrayVariable)):-
   IsABIEncodedArrayVar(arrVar),
   maxordy = max ord(arrVar2) : ABIEncodedArrayVarsInSameClass(arrVar, arrVar2),
   ABIEncodedArrayVarsInSameClass(arrVar, arrVarRep),
   maxordy = ord(arrVarRep).
 
-RegularArrayVar_ClassRep(arrVar, as(arrVarRep,ArrayVariable)):-
+RegularArrayVar_ClassRep(arrVar, as(arrVarRep, ArrayVariable)):-
   arrayClassRep.Var_ClassRep(arrVar, arrVarRep).
 
 
@@ -793,7 +793,7 @@ arrayClassRep.InSameClass(arrVar1, arrVar2):- RegularArrayVarsInSameClass(arrVar
 .init rawDataArrayClassRep = DominatorInClass
 rawDataArrayClassRep.InSameClass(arrVar1, arrVar2):- RawDataArrayVarsInSameClass(arrVar1, arrVar2).
 
-RawDataArrayVar_ClassRep(arrVar, as(classRep,ArrayVariable)):-
+RawDataArrayVar_ClassRep(arrVar, as(classRep, ArrayVariable)):-
   rawDataArrayClassRep.Var_ClassRep(arrVar, classRep).
 
 

--- a/clientlib/memory_modeling/arrays.dl
+++ b/clientlib/memory_modeling/arrays.dl
@@ -770,13 +770,13 @@ ABIEncodedArrayVarsInSameClass(arrVar1, arrVar2):-
   MLOADSFreePtrUnchangedNoMemReuse(mload1, mload2),
   Variable_SymbolicValue(arrVar2, val2).
 
-ABIEncodedArrayVar_ClassRep(arrVar, @cast_to_symbol(arrVarRep)):-
+ABIEncodedArrayVar_ClassRep(arrVar, as(arrVarRep,ArrayVariable)):-
   IsABIEncodedArrayVar(arrVar),
   maxordy = max ord(arrVar2) : ABIEncodedArrayVarsInSameClass(arrVar, arrVar2),
   ABIEncodedArrayVarsInSameClass(arrVar, arrVarRep),
   maxordy = ord(arrVarRep).
 
-RegularArrayVar_ClassRep(arrVar, @cast_to_symbol(arrVarRep)):-
+RegularArrayVar_ClassRep(arrVar, as(arrVarRep,ArrayVariable)):-
   arrayClassRep.Var_ClassRep(arrVar, arrVarRep).
 
 
@@ -793,7 +793,7 @@ arrayClassRep.InSameClass(arrVar1, arrVar2):- RegularArrayVarsInSameClass(arrVar
 .init rawDataArrayClassRep = DominatorInClass
 rawDataArrayClassRep.InSameClass(arrVar1, arrVar2):- RawDataArrayVarsInSameClass(arrVar1, arrVar2).
 
-RawDataArrayVar_ClassRep(arrVar, @cast_to_symbol(classRep)):-
+RawDataArrayVar_ClassRep(arrVar, as(classRep,ArrayVariable)):-
   rawDataArrayClassRep.Var_ClassRep(arrVar, classRep).
 
 

--- a/clientlib/memory_modeling/memory_addresses.dl
+++ b/clientlib/memory_modeling/memory_addresses.dl
@@ -254,7 +254,7 @@ FreePointerBasedValue(val, mload, newDepth, res):-
  to get a constant
  **/
 //TODO: use diff relation, after all other fixes
-Variable_Value(to, @number_to_hex(res)):-
+Variable_Value(to, as(@number_to_hex(res), Value)):-
   SUB(_, var1, var2, to),
   Variable_SymbolicValue(var1, freePtrBasedVal1),
   FreePointerBasedValue(freePtrBasedVal1, _, _, numVal1),

--- a/logic/context-sensitivity/transactional-context.dl
+++ b/logic/context-sensitivity/transactional-context.dl
@@ -87,7 +87,7 @@ PrivateFunctionCallOrReturn(caller) :-
   postTrans.Statement_Block(stmt, caller),
   postTrans.Statement_Defines(stmt, var),
   postTrans.Variable_Value(var, val),
-  postTrans.JUMPDEST(@cast_to_symbol(val)),
+  postTrans.JUMPDEST(as(val,symbol)),
   !Block_Uses_Local(caller, var).
 
 PrivateFunctionCallOrReturn(caller) :-
@@ -106,7 +106,7 @@ Context_PublicFunction(ctx, pubFun):-
 StaticBlockJumpTarget(caller, target) :-
   postTrans.ImmediateBlockJumpTarget(caller, targetVar),
   postTrans.Variable_Value(targetVar, target),
-  postTrans.JUMPDEST(@cast_to_symbol(target)).
+  postTrans.JUMPDEST(as(target,symbol)).
 
 .decl MergeContext(ctx: Context, caller: Block, newContext: Context)
 

--- a/logic/context-sensitivity/transactional-context.dl
+++ b/logic/context-sensitivity/transactional-context.dl
@@ -87,7 +87,7 @@ PrivateFunctionCallOrReturn(caller) :-
   postTrans.Statement_Block(stmt, caller),
   postTrans.Statement_Defines(stmt, var),
   postTrans.Variable_Value(var, val),
-  postTrans.JUMPDEST(as(val,symbol)),
+  postTrans.JUMPDEST(as(val, symbol)),
   !Block_Uses_Local(caller, var).
 
 PrivateFunctionCallOrReturn(caller) :-
@@ -106,7 +106,7 @@ Context_PublicFunction(ctx, pubFun):-
 StaticBlockJumpTarget(caller, target) :-
   postTrans.ImmediateBlockJumpTarget(caller, targetVar),
   postTrans.Variable_Value(targetVar, target),
-  postTrans.JUMPDEST(as(target,symbol)).
+  postTrans.JUMPDEST(as(target, symbol)).
 
 .decl MergeContext(ctx: Context, caller: Block, newContext: Context)
 

--- a/logic/decompiler_output.dl
+++ b/logic/decompiler_output.dl
@@ -15,7 +15,7 @@
 
 .decl FunctionalBlock_Uses_Local(block: IRBlock, stackIndex: StackIndex)
 
-FunctionalBlock_Uses_Local(block, @cast_to_number(stackIndex)) :-
+FunctionalBlock_Uses_Local(block, as(stackIndex,StackIndex)) :-
   IRStatement_Block(stmt, block),
   FunctionalStatement_Uses_Local(stmt, stackIndex, _),
   CheckIsStackIndex(stackIndex).
@@ -75,11 +75,11 @@ SHA3Decompositions(a, b, c, d) :- SHA3Decompositions(a, b, c, d).
 /// Heuristically change the values of all constants that match cloned
 /// basic block labels! Don't up
 
-TAC_Variable_BlockValue(@cast_to_symbol(tacvar), irvalue) :-
+TAC_Variable_BlockValue(as(tacvar,TACVariable), irvalue) :-
   FunctionalStatement_Defines(stmt, var, _),
   Variable_Stmt_String(var, stmt, tacvar),
   postTrans.Variable_Value(var, value),
-  StatementAndBlockInSameFunction(stmt, @cast_to_symbol(value), irvalue),
+  StatementAndBlockInSameFunction(stmt, as(value,symbol), irvalue),
    // value matches address of block
    STARTSWITH(value, "0x").
 
@@ -90,7 +90,7 @@ StatementAndBlockInSameFunction(stmt, block, irblock) :-
 
 
 // Normal variable
-TAC_Variable_Value(@cast_to_symbol(tacvar), value) :-
+TAC_Variable_Value(as(tacvar,TACVariable), value) :-
    FunctionalStatement_Defines(stmt, var, _),
    Variable_Stmt_String(var, stmt, tacvar),
    postTrans.Variable_Value(var, value),
@@ -131,17 +131,17 @@ TAC_Def(stmt, var, 0),
 TAC_Stmt(stmt),
 TAC_Op(stmt, "PHI") :-
    PHILocation(_, _, stmt),
-   var = @cast_to_symbol(stmt).
+   var = as(stmt,TACVariable).
 
 // Non-phi, non-call variable id same as stmt it is defined in
 TAC_Var(tac_var),
 TAC_Def(stmt, tac_var, n) :-
    FunctionalStatement_Defines(stmt, var, n),
    Variable_Stmt_String(var, stmt, var_rep),
-   tac_var = @cast_to_symbol(var_rep).
+   tac_var = as(var_rep,TACVariable).
 
 // Case 1: Uses locally defined variable
-TAC_Use(stmt, @cast_to_symbol(var_rep), n) :-
+TAC_Use(stmt, as(var_rep,TACVariable), n) :-
   FunctionalStatement_Uses_Local(stmt, var, n),
   CheckIsVariable(var),
   Variable_Stmt_String(var, stmt, var_rep).
@@ -150,7 +150,7 @@ TAC_Use(stmt, @cast_to_symbol(var_rep), n) :-
 // Using the block in which the var is defined,
 // Fixes cases where a stmt in a cloned block is using
 // a variable defined in a non cloned block
-TAC_Use(stmt, @cast_to_symbol(var_rep), n) :-
+TAC_Use(stmt, as(var_rep,TACVariable), n) :-
   FunctionalStatement_Uses_Local(stmt, stackIndex, n),
   CheckIsStackIndex(stackIndex),
   IRStatement_Block(stmt, block),
@@ -163,7 +163,7 @@ TAC_Use(stmt, @cast_to_symbol(var_rep), n) :-
   Variable_Block_String(var, defBlock, var_rep).
 
 //Case 2.1: Uses arg(like the above case, but not defined)
-TAC_Use(stmt, @cast_to_symbol(var_rep), n) :-
+TAC_Use(stmt, as(var_rep,TACVariable), n) :-
   FunctionalStatement_Uses_Local(stmt, stackIndex, n),
   CheckIsStackIndex(stackIndex),
   IRStatement_Block(stmt, block),
@@ -174,7 +174,7 @@ TAC_Use(stmt, @cast_to_symbol(var_rep), n) :-
 
 
 // Case 3: Is a PHI statement
-TAC_Use(phiStmt, @cast_to_symbol(var_rep), -1) :-
+TAC_Use(phiStmt, as(var_rep,TACVariable), -1) :-
   PHILocation(block, stackIndex, phiStmt),
   FunctionalBlockInputContents(block, stackIndex, var),
   IRInFunction(block, fun),
@@ -184,7 +184,7 @@ TAC_Use(phiStmt, @cast_to_symbol(var_rep), -1) :-
   Variable_Block_String(var, defBlock, var_rep).
 
 // Case 3.1: Phis using args
-TAC_Use(phiStmt, @cast_to_symbol(var_rep), -1) :-
+TAC_Use(phiStmt, as(var_rep,TACVariable), -1) :-
   PHILocation(block, stackIndex, phiStmt),
   FunctionalBlockInputContents(block, stackIndex, var),
   FunctionArgument(_, _, var),
@@ -192,7 +192,7 @@ TAC_Use(phiStmt, @cast_to_symbol(var_rep), -1) :-
 
 
 // Case 4: Uses polymorphic variable
-TAC_Use(stmt, @cast_to_symbol(phiStmt), n) :-
+TAC_Use(stmt, as(phiStmt,TACVariable), n) :-
   FunctionalStatement_Uses_Local(stmt, stackIndex, n),
   CheckIsStackIndex(stackIndex),
   IRStatement_Block(stmt, block),
@@ -225,7 +225,7 @@ TAC_Block(phiStmt, block) :-
 .decl FormalArgs(func:IRFunction, var:TACVariable, n:number)
 .output FormalArgs
 
-FormalArgs(func, @cast_to_symbol(var_rep), n) :-
+FormalArgs(func, as(var_rep, TACVariable), n) :-
    FunctionArgument(func, n, var),
    Variable_String(var, var_rep).
 

--- a/logic/decompiler_output.dl
+++ b/logic/decompiler_output.dl
@@ -15,7 +15,7 @@
 
 .decl FunctionalBlock_Uses_Local(block: IRBlock, stackIndex: StackIndex)
 
-FunctionalBlock_Uses_Local(block, as(stackIndex,StackIndex)) :-
+FunctionalBlock_Uses_Local(block, as(stackIndex, StackIndex)) :-
   IRStatement_Block(stmt, block),
   FunctionalStatement_Uses_Local(stmt, stackIndex, _),
   CheckIsStackIndex(stackIndex).
@@ -79,7 +79,7 @@ TAC_Variable_BlockValue(as(tacvar,TACVariable), irvalue) :-
   FunctionalStatement_Defines(stmt, var, _),
   Variable_Stmt_String(var, stmt, tacvar),
   postTrans.Variable_Value(var, value),
-  StatementAndBlockInSameFunction(stmt, as(value,symbol), irvalue),
+  StatementAndBlockInSameFunction(stmt, as(value, symbol), irvalue),
    // value matches address of block
    STARTSWITH(value, "0x").
 
@@ -90,7 +90,7 @@ StatementAndBlockInSameFunction(stmt, block, irblock) :-
 
 
 // Normal variable
-TAC_Variable_Value(as(tacvar,TACVariable), value) :-
+TAC_Variable_Value(as(tacvar, TACVariable), value) :-
    FunctionalStatement_Defines(stmt, var, _),
    Variable_Stmt_String(var, stmt, tacvar),
    postTrans.Variable_Value(var, value),
@@ -131,17 +131,17 @@ TAC_Def(stmt, var, 0),
 TAC_Stmt(stmt),
 TAC_Op(stmt, "PHI") :-
    PHILocation(_, _, stmt),
-   var = as(stmt,TACVariable).
+   var = as(stmt, TACVariable).
 
 // Non-phi, non-call variable id same as stmt it is defined in
 TAC_Var(tac_var),
 TAC_Def(stmt, tac_var, n) :-
    FunctionalStatement_Defines(stmt, var, n),
    Variable_Stmt_String(var, stmt, var_rep),
-   tac_var = as(var_rep,TACVariable).
+   tac_var = as(var_rep, TACVariable).
 
 // Case 1: Uses locally defined variable
-TAC_Use(stmt, as(var_rep,TACVariable), n) :-
+TAC_Use(stmt, as(var_rep, TACVariable), n) :-
   FunctionalStatement_Uses_Local(stmt, var, n),
   CheckIsVariable(var),
   Variable_Stmt_String(var, stmt, var_rep).
@@ -150,7 +150,7 @@ TAC_Use(stmt, as(var_rep,TACVariable), n) :-
 // Using the block in which the var is defined,
 // Fixes cases where a stmt in a cloned block is using
 // a variable defined in a non cloned block
-TAC_Use(stmt, as(var_rep,TACVariable), n) :-
+TAC_Use(stmt, as(var_rep, TACVariable), n) :-
   FunctionalStatement_Uses_Local(stmt, stackIndex, n),
   CheckIsStackIndex(stackIndex),
   IRStatement_Block(stmt, block),
@@ -163,7 +163,7 @@ TAC_Use(stmt, as(var_rep,TACVariable), n) :-
   Variable_Block_String(var, defBlock, var_rep).
 
 //Case 2.1: Uses arg(like the above case, but not defined)
-TAC_Use(stmt, as(var_rep,TACVariable), n) :-
+TAC_Use(stmt, as(var_rep, TACVariable), n) :-
   FunctionalStatement_Uses_Local(stmt, stackIndex, n),
   CheckIsStackIndex(stackIndex),
   IRStatement_Block(stmt, block),
@@ -174,7 +174,7 @@ TAC_Use(stmt, as(var_rep,TACVariable), n) :-
 
 
 // Case 3: Is a PHI statement
-TAC_Use(phiStmt, as(var_rep,TACVariable), -1) :-
+TAC_Use(phiStmt, as(var_rep, TACVariable), -1) :-
   PHILocation(block, stackIndex, phiStmt),
   FunctionalBlockInputContents(block, stackIndex, var),
   IRInFunction(block, fun),
@@ -184,7 +184,7 @@ TAC_Use(phiStmt, as(var_rep,TACVariable), -1) :-
   Variable_Block_String(var, defBlock, var_rep).
 
 // Case 3.1: Phis using args
-TAC_Use(phiStmt, as(var_rep,TACVariable), -1) :-
+TAC_Use(phiStmt, as(var_rep, TACVariable), -1) :-
   PHILocation(block, stackIndex, phiStmt),
   FunctionalBlockInputContents(block, stackIndex, var),
   FunctionArgument(_, _, var),
@@ -192,7 +192,7 @@ TAC_Use(phiStmt, as(var_rep,TACVariable), -1) :-
 
 
 // Case 4: Uses polymorphic variable
-TAC_Use(stmt, as(phiStmt,TACVariable), n) :-
+TAC_Use(stmt, as(phiStmt, TACVariable), n) :-
   FunctionalStatement_Uses_Local(stmt, stackIndex, n),
   CheckIsStackIndex(stackIndex),
   IRStatement_Block(stmt, block),

--- a/logic/functions.dl
+++ b/logic/functions.dl
@@ -360,9 +360,9 @@ StackBalancingBlockJumpImprecision(block, func):-
  ***********/
 #define FRESH_IRBLOCK(b, f) cat((b), (f))
 #define FRESH_IRSTATEMENT(s, f) cat((s), (f))
-#define BLOCK_TO_IRBLOCK(b) as(b,IRBlock)
-#define STATEMENT_TO_IRSTATEMENT(s) as(s,IRStatement)
-#define FUNCTION_TO_IRFUNCTION(f) as(f,IRBlock)
+#define BLOCK_TO_IRBLOCK(b) as(b, IRBlock)
+#define STATEMENT_TO_IRSTATEMENT(s) as(s, IRStatement)
+#define FUNCTION_TO_IRFUNCTION(f) as(f, IRBlock)
  
 .type IRBlock <: symbol
 // exploit type checking in new IR
@@ -773,7 +773,7 @@ NotCycleEntryLocalBlockEdge(from, to) :-
 
 PossibleFunctionalBlockPopAndStackDelta(func, to, newPath, newPopDelta, newStackDelta) :-
   PossibleFunctionalBlockPopAndStackDelta(func, from, prevPath, prevPopDelta, prevStackDelta),
-  ((PotentialCycleEntryLocalBlockEdge(from, to), newPath = as(@add_set(prevPath, to),Path), newPath != prevPath) ;
+  ((PotentialCycleEntryLocalBlockEdge(from, to), newPath = as(@add_set(prevPath, to), Path), newPath != prevPath) ;
     (NotCycleEntryLocalBlockEdge(from, to), newPath = prevPath)),
   FunctionalBlockPopAndStackDelta(from, popDelta, stackDelta),
   newStackDelta = stackDelta + prevStackDelta,
@@ -963,7 +963,7 @@ BeforeFunctionCallFunctionalBlockOutputContents(callee, index+delta, variable) :
   IRBlockStackDelta(callee, delta).
 
 // Handle the proper variables pushed by this basic block
-BeforeFunctionCallFunctionalBlockOutputContents(block, index, as(var,Variable)) :-
+BeforeFunctionCallFunctionalBlockOutputContents(block, index, as(var, Variable)) :-
   IRInFunction(block, _),
   IRBasicBlock_Tail(block, stmt),
   IRLocalStackContents(stmt, index, var),

--- a/logic/functions.dl
+++ b/logic/functions.dl
@@ -360,9 +360,9 @@ StackBalancingBlockJumpImprecision(block, func):-
  ***********/
 #define FRESH_IRBLOCK(b, f) cat((b), (f))
 #define FRESH_IRSTATEMENT(s, f) cat((s), (f))
-#define BLOCK_TO_IRBLOCK @cast_to_symbol
-#define STATEMENT_TO_IRSTATEMENT @cast_to_symbol
-#define FUNCTION_TO_IRFUNCTION @cast_to_symbol
+#define BLOCK_TO_IRBLOCK(b) as(b,IRBlock)
+#define STATEMENT_TO_IRSTATEMENT(s) as(s,IRStatement)
+#define FUNCTION_TO_IRFUNCTION(f) as(f,IRBlock)
  
 .type IRBlock <: symbol
 // exploit type checking in new IR
@@ -706,7 +706,7 @@ FunctionalBlockPopDelta(from, newPopDelta) :-
   IRFunctionCall(from, func),
   PossibleImpreciseNumberOfFunctionArguments(func, n_args),
   IRBlockStackDelta(from, stackDelta),
-  newPopDelta = @max2(n_args - stackDelta, popDelta),
+  newPopDelta = max(n_args - stackDelta, popDelta),
   CheckIsPopDelta(newPopDelta).
 
 
@@ -746,7 +746,7 @@ FunctionalBlockPopAndStackDelta(from, popDelta, stackDelta) :-
 
 PossibleFunctionalBlockPopAndStackDelta(from, from, initPath, 0, 0) :-
    IRFunctionEntry(from),
-   initPath = @cast_to_symbol(from).
+   initPath = as(from, Path).
 
 .decl PotentialCycleEntry(block: IRBlock)
 
@@ -773,11 +773,11 @@ NotCycleEntryLocalBlockEdge(from, to) :-
 
 PossibleFunctionalBlockPopAndStackDelta(func, to, newPath, newPopDelta, newStackDelta) :-
   PossibleFunctionalBlockPopAndStackDelta(func, from, prevPath, prevPopDelta, prevStackDelta),
-  ((PotentialCycleEntryLocalBlockEdge(from, to), newPath = @add_set(prevPath, to), newPath != prevPath) ;
+  ((PotentialCycleEntryLocalBlockEdge(from, to), newPath = as(@add_set(prevPath, to),Path), newPath != prevPath) ;
     (NotCycleEntryLocalBlockEdge(from, to), newPath = prevPath)),
   FunctionalBlockPopAndStackDelta(from, popDelta, stackDelta),
   newStackDelta = stackDelta + prevStackDelta,
-  newPopDelta = @max2(popDelta - prevStackDelta, prevPopDelta),
+  newPopDelta = max(popDelta - prevStackDelta, prevPopDelta),
   CheckIsPopDelta(newPopDelta), CheckIsStackDelta(newStackDelta).
   .plan 1:(3,2,1)
 
@@ -802,10 +802,10 @@ CycleEntry(func, block) :-
 // then add the delta again. Tedious.
 .decl PossibleCombinedNumberOfFunctionReturnsAndArguments(func: IRFunction, terminal: IRBlock, numArg: StackIndex, numRet: StackIndex)
 
-PossibleCombinedNumberOfFunctionReturnsAndArguments(func, terminal, numArg, numRet) :-
+PossibleCombinedNumberOfFunctionReturnsAndArguments(func, terminal, as(numArg, StackIndex), numRet) :-
   PossibleFunctionalBlockPopAndStackDelta(func, terminal, _, prevPopDelta, prevStackDelta),
   FunctionalBlockPopAndStackDelta(terminal, popDelta, stackDelta),
-  numArg = @max2(popDelta - prevStackDelta, prevPopDelta),
+  numArg = max(popDelta - prevStackDelta, prevPopDelta),
   CheckIsPopDelta(numArg),
   numRet = prevStackDelta + stackDelta + numArg,
   CheckIsStackIndex(numRet).
@@ -881,7 +881,6 @@ Variable_Block_String(var, block, res) :-
 .decl FunctionalStatement_Uses(stmt:IRStatement, var:Variable, n:StackIndex)
 .decl FunctionalStatement_Defines(callStmt:IRStatement, newVar:Variable, n: number)
 
-
 Variable_String(var, var_rep) :-
    postTrans.Statement_Defines(var_rep, var).
 
@@ -890,7 +889,7 @@ FunctionArgument(func, n, var) :-
 //// REVIEW
 //  PossibleNumberOfFunctionArguments(func, n_args),
   FunctionArgumentIndices(func, n),
-  FRESH_VARIABLE(var, BLOCK_TO_IRBLOCK(func), n). // TODO: use entry?
+  FRESH_VARIABLE(var, as(func, IRStatement), n). // TODO: use entry?
 
 .decl FunctionArgumentIndices(func: IRFunction, n: StackIndex)
 
@@ -964,7 +963,7 @@ BeforeFunctionCallFunctionalBlockOutputContents(callee, index+delta, variable) :
   IRBlockStackDelta(callee, delta).
 
 // Handle the proper variables pushed by this basic block
-BeforeFunctionCallFunctionalBlockOutputContents(block, index, @cast_to_number(var)) :-
+BeforeFunctionCallFunctionalBlockOutputContents(block, index, as(var,Variable)) :-
   IRInFunction(block, _),
   IRBasicBlock_Tail(block, stmt),
   IRLocalStackContents(stmt, index, var),
@@ -1005,7 +1004,7 @@ FunctionalStatement_Uses_Local(irstmt, varOrStackIndex, n) :-
    postTrans.Statement_Uses_Local(stmt, varOrStackIndex, n),
    Statement_IRStatement(stmt, _, irstmt).
 
-FunctionalStatement_Uses(irstmt, @cast_to_number(var), n) :-
+FunctionalStatement_Uses(irstmt, as(var, Variable), n) :-
    postTrans.Statement_Uses_Local(stmt, var, n),
    CheckIsVariable(var),
    Statement_IRStatement(stmt, _, irstmt).

--- a/logic/global.dl
+++ b/logic/global.dl
@@ -58,7 +58,7 @@
 .decl VariableContainsJumpTarget(var: Variable)
 VariableContainsJumpTarget(var) :-
   postTrans.Variable_Value(var, value),
-  postTrans.JUMPDEST(@cast_to_symbol(value)).
+  postTrans.JUMPDEST(as(value,symbol)).
 
 .decl AuxBlockOutputContentsJumpTarget(context:Context, block:Block, index:StackIndex, var:Variable)
 AuxBlockOutputContentsJumpTarget(context, block, index, var) :-
@@ -79,14 +79,14 @@ BlockOutputContents(calleeCtx, callee, index+delta, variable) :-
   index+delta <= MAX_STACK_HEIGHT.
 
 // Handle the proper variables pushed by this basic block
-BlockOutputContents(ctx, block, index, @cast_to_number(var)) :-
+BlockOutputContents(ctx, block, index, as(var,Variable)) :-
   ReachableContext(ctx, block),
   postTrans.BasicBlock_Tail(block, stmt),
   postTrans.LocalStackContents(stmt, index, var),
   CheckIsVariable(var).
 
 // Handle the stackIndexes pushed by this basic block
-BlockOutputContents(ctx, block, index, @cast_to_number(realVariable)) :-
+BlockOutputContents(ctx, block, index, as(realVariable,Variable)) :-
   BlockInputContents(ctx, block, stackIndex, realVariable),
   CheckIsStackIndex(stackIndex),
   postTrans.BasicBlock_Tail(block, stmt),
@@ -110,10 +110,10 @@ BlockJumpTarget(ctx, block, realVariable) :-
 // is equal to the label of "target" block.
 .decl BlockJumpValidTarget(ctx:Context, block:Block, variable: Variable, target:Block)
 
-BlockJumpValidTarget(ctx, block, targetVar, @cast_to_symbol(targetValue)) :-
+BlockJumpValidTarget(ctx, block, targetVar, as(targetValue,Block)) :-
   BlockJumpTarget(ctx, block, targetVar),
   postTrans.Variable_Value(targetVar, targetValue),
-  postTrans.JUMPDEST(@cast_to_symbol(targetValue)).
+  postTrans.JUMPDEST(as(targetValue,symbol)).
 
 
 /*
@@ -130,8 +130,8 @@ ReachableContext(initCtx, FUNCTION_SELECTOR) :-
 
 .decl FallthroughEdge(caller: Block, fallthroughBlock: Block)
 
-FallthroughEdge(caller, @cast_to_symbol(fallthrough)),
-BlockEdge(callerCtx, caller, calleeCtx, @cast_to_symbol(fallthrough)) :-
+FallthroughEdge(caller, as(fallthrough, Block)),
+BlockEdge(callerCtx, caller, calleeCtx, as(fallthrough,Block)) :-
   MergeContext(callerCtx, caller, calleeCtx),  // implies reachable
   postTrans.Statement_Block(stmt, caller),
   postTrans.FallthroughStmt(stmt, fallthrough),
@@ -146,7 +146,7 @@ BlockEdge(callerCtx, caller, calleeCtx, callee) :-
 .decl Statement_Uses(stmt:Statement, var:Variable, n:StackIndex)
 
 // Case: variable originates locally
-Statement_Uses(stmt, @cast_to_number(var), n) :-
+Statement_Uses(stmt, as(var, Variable), n) :-
    postTrans.Statement_Uses_Local(stmt, var, n),
    CheckIsVariable(var).
 

--- a/logic/global.dl
+++ b/logic/global.dl
@@ -58,7 +58,7 @@
 .decl VariableContainsJumpTarget(var: Variable)
 VariableContainsJumpTarget(var) :-
   postTrans.Variable_Value(var, value),
-  postTrans.JUMPDEST(as(value,symbol)).
+  postTrans.JUMPDEST(as(value, symbol)).
 
 .decl AuxBlockOutputContentsJumpTarget(context:Context, block:Block, index:StackIndex, var:Variable)
 AuxBlockOutputContentsJumpTarget(context, block, index, var) :-
@@ -79,14 +79,14 @@ BlockOutputContents(calleeCtx, callee, index+delta, variable) :-
   index+delta <= MAX_STACK_HEIGHT.
 
 // Handle the proper variables pushed by this basic block
-BlockOutputContents(ctx, block, index, as(var,Variable)) :-
+BlockOutputContents(ctx, block, index, as(var, Variable)) :-
   ReachableContext(ctx, block),
   postTrans.BasicBlock_Tail(block, stmt),
   postTrans.LocalStackContents(stmt, index, var),
   CheckIsVariable(var).
 
 // Handle the stackIndexes pushed by this basic block
-BlockOutputContents(ctx, block, index, as(realVariable,Variable)) :-
+BlockOutputContents(ctx, block, index, as(realVariable, Variable)) :-
   BlockInputContents(ctx, block, stackIndex, realVariable),
   CheckIsStackIndex(stackIndex),
   postTrans.BasicBlock_Tail(block, stmt),
@@ -110,10 +110,10 @@ BlockJumpTarget(ctx, block, realVariable) :-
 // is equal to the label of "target" block.
 .decl BlockJumpValidTarget(ctx:Context, block:Block, variable: Variable, target:Block)
 
-BlockJumpValidTarget(ctx, block, targetVar, as(targetValue,Block)) :-
+BlockJumpValidTarget(ctx, block, targetVar, as(targetValue, Block)) :-
   BlockJumpTarget(ctx, block, targetVar),
   postTrans.Variable_Value(targetVar, targetValue),
-  postTrans.JUMPDEST(as(targetValue,symbol)).
+  postTrans.JUMPDEST(as(targetValue, symbol)).
 
 
 /*
@@ -131,7 +131,7 @@ ReachableContext(initCtx, FUNCTION_SELECTOR) :-
 .decl FallthroughEdge(caller: Block, fallthroughBlock: Block)
 
 FallthroughEdge(caller, as(fallthrough, Block)),
-BlockEdge(callerCtx, caller, calleeCtx, as(fallthrough,Block)) :-
+BlockEdge(callerCtx, caller, calleeCtx, as(fallthrough, Block)) :-
   MergeContext(callerCtx, caller, calleeCtx),  // implies reachable
   postTrans.Statement_Block(stmt, caller),
   postTrans.FallthroughStmt(stmt, fallthrough),

--- a/logic/global_pre_analysis.dl
+++ b/logic/global_pre_analysis.dl
@@ -13,7 +13,7 @@ InitialContext("0x0").
 
 .decl MergeContext(ctx: Context, caller: Block, newContext: Context)
 
-MergeContext(ctx, caller, as(sigHash,symbol)) :-
+MergeContext(ctx, caller, as(sigHash, symbol)) :-
   ReachableContext(ctx, caller),
   postTrans.PublicFunction(caller, sigHash).
 

--- a/logic/global_pre_analysis.dl
+++ b/logic/global_pre_analysis.dl
@@ -13,7 +13,7 @@ InitialContext("0x0").
 
 .decl MergeContext(ctx: Context, caller: Block, newContext: Context)
 
-MergeContext(ctx, caller, @cast_to_symbol(sigHash)) :-
+MergeContext(ctx, caller, as(sigHash,symbol)) :-
   ReachableContext(ctx, caller),
   postTrans.PublicFunction(caller, sigHash).
 

--- a/logic/local.dl
+++ b/logic/local.dl
@@ -96,7 +96,7 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
   .plan 1:(3,2,1)
 
   .decl UnopStatementOpAndArgs(stmt: Statement, op: Opcode, a: Variable)
-  UnopStatementOpAndArgs(stmt, op, as(a,Variable)) :-
+  UnopStatementOpAndArgs(stmt, op, as(a, Variable)) :-
     Statement_Opcode(stmt, op),
     Statement_Uses_Local(stmt, a, 0),
     !Statement_Uses_Local(stmt, _, 1),
@@ -147,7 +147,7 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
     Statement_Opcode(stmt, opcode),
     OpcodePushWords(opcode, m), m > 0,
     !TACNOP(stmt),
-    var = as(n,Variable).
+    var = as(n, Variable).
   
    
   .decl IsValue(v:Value)
@@ -200,7 +200,7 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
   .decl Statement_BlockHead(statement:Statement, head:Statement)
   
   Statement_BlockHead(stmt, stmt),
-  Statement_Block(stmt, as(stmt,Block)) :-
+  Statement_Block(stmt, as(stmt, Block)) :-
     IsBasicBlockHead(stmt).
   
   Statement_BlockHead(stmt, as(block, Statement)),
@@ -254,7 +254,7 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
   .decl StatementPopDelta(statement: Statement, delta: number)
   .decl StatementStackDelta(statement: Statement, delta: number)
   
-  ImmediateBlockJumpTarget(block, as(var,Variable)) :-
+  ImmediateBlockJumpTarget(block, as(var, Variable)) :-
     BasicBlock_Tail(block, stmt),
     IsJump(stmt),
     BeforeLocalStackContents(stmt, 0, var),
@@ -284,7 +284,7 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
   ThrowJump(jmp) :-
      ImmediateBlockJumpTarget(block, variable),
      Variable_Value(variable, targetValue),
-     !JUMPDEST(as(targetValue,Statement)),
+     !JUMPDEST(as(targetValue, Statement)),
      BasicBlock_Tail(block, jmp).
 
   /*
@@ -312,7 +312,7 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
     Statement_Defines(stmt, var).
   
   // Get current program counter
-  Variable_Value(var, as(stmt,Value)) :-
+  Variable_Value(var, as(stmt, Value)) :-
     PC(stmt),
     Statement_Defines(stmt, var).
 
@@ -436,7 +436,7 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
   IsValue(v) :-
      PushValue(_, v).
   
-  IsValue(as(v,Value)) :-
+  IsValue(as(v, Value)) :-
     PC(v).
   
   .decl DynamicStatement(stmt:Statement)
@@ -562,7 +562,7 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
     ImmediateBlockJumpTarget(block, var),
     Statement_Defines(push, var),
     PushValue(push, targetValue),
-    JUMPDEST(as(targetValue,symbol)).
+    JUMPDEST(as(targetValue, symbol)).
 
   .decl BlockComparesCallDataSizeToFour(block: Block, jumpi: Statement, target: Block)
   .decl BlockJumpsOnCallDataSize(block: Block, jumpi: Statement, target: Block)
@@ -648,7 +648,7 @@ insertor.insertOps(pushStmt,
 insertor.insertOps(jumpDestStmt,
   LIST(
     STMT(JUMPDEST, MAKE_LABEL_REFERENCE(jumpDestStmt)),
-    STMT(PUSH4, as(jumpDestStmt,symbol)),
+    STMT(PUSH4, as(jumpDestStmt, symbol)),
     STMT(JUMP, cat("PublicFunctionJump:", hash))
   )
 ) :-
@@ -656,7 +656,7 @@ insertor.insertOps(jumpDestStmt,
    preTrans.PublicFunction(start, hash),
    preTrans.Statement_Block(jumpDestStmt, start),
    preTrans.JUMPDEST(jumpDestStmt),
-   preTrans.PushValue(pushStmt, as(jumpDestStmt,symbol)),
+   preTrans.PushValue(pushStmt, as(jumpDestStmt, symbol)),
    preTrans.Statement_Block(pushStmt, block),
    preTrans.Statement_Defines(pushStmt, pushedVar),
    preTrans.Statement_Uses_Local(jumpStmt, pushedVar, 0),

--- a/logic/local.dl
+++ b/logic/local.dl
@@ -81,7 +81,7 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
 
   // Auxiliary relations for constant folding
   .decl BinopStatementOpAndArgs(stmt: Statement, op: Opcode, a: Variable, b: Variable)
-  BinopStatementOpAndArgs(stmt, op, @cast_to_number(a), @cast_to_number(b)) :-
+  BinopStatementOpAndArgs(stmt, op, as(a, Variable), as(b, Variable)) :-
     Statement_Opcode(stmt, op),
     Statement_Uses_Local(stmt, a, 0),
     Statement_Uses_Local(stmt, b, 1),
@@ -96,7 +96,7 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
   .plan 1:(3,2,1)
 
   .decl UnopStatementOpAndArgs(stmt: Statement, op: Opcode, a: Variable)
-  UnopStatementOpAndArgs(stmt, op, @cast_to_number(a)) :-
+  UnopStatementOpAndArgs(stmt, op, as(a,Variable)) :-
     Statement_Opcode(stmt, op),
     Statement_Uses_Local(stmt, a, 0),
     !Statement_Uses_Local(stmt, _, 1),
@@ -147,7 +147,7 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
     Statement_Opcode(stmt, opcode),
     OpcodePushWords(opcode, m), m > 0,
     !TACNOP(stmt),
-    var = @cast_to_number(n).
+    var = as(n,Variable).
   
    
   .decl IsValue(v:Value)
@@ -200,10 +200,10 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
   .decl Statement_BlockHead(statement:Statement, head:Statement)
   
   Statement_BlockHead(stmt, stmt),
-  Statement_Block(stmt, @cast_to_symbol(stmt)) :-
+  Statement_Block(stmt, as(stmt,Block)) :-
     IsBasicBlockHead(stmt).
   
-  Statement_BlockHead(stmt, @cast_to_symbol(block)),
+  Statement_BlockHead(stmt, as(block, Statement)),
   Statement_Block(stmt, block) :-
     Statement_Block(prevstmt, block),
     Statement_Next(prevstmt, stmt),
@@ -254,7 +254,7 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
   .decl StatementPopDelta(statement: Statement, delta: number)
   .decl StatementStackDelta(statement: Statement, delta: number)
   
-  ImmediateBlockJumpTarget(block, @cast_to_number(var)) :-
+  ImmediateBlockJumpTarget(block, as(var,Variable)) :-
     BasicBlock_Tail(block, stmt),
     IsJump(stmt),
     BeforeLocalStackContents(stmt, 0, var),
@@ -284,7 +284,7 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
   ThrowJump(jmp) :-
      ImmediateBlockJumpTarget(block, variable),
      Variable_Value(variable, targetValue),
-     !JUMPDEST(@cast_to_symbol(targetValue)),
+     !JUMPDEST(as(targetValue,Statement)),
      BasicBlock_Tail(block, jmp).
 
   /*
@@ -312,7 +312,7 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
     Statement_Defines(stmt, var).
   
   // Get current program counter
-  Variable_Value(var, @cast_to_symbol(stmt)) :-
+  Variable_Value(var, as(stmt,Value)) :-
     PC(stmt),
     Statement_Defines(stmt, var).
 
@@ -400,7 +400,7 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
     OpcodePopWords(opcode, delta).
   
   
-  StatementPopDelta(stmt, @max2(prevPopDelta, popDelta - prevStackDelta)) :-
+  StatementPopDelta(stmt, max(prevPopDelta, popDelta - prevStackDelta)) :-
     StatementPopDelta(prevstmt, prevPopDelta),
     !BasicBlock_Tail(_, prevstmt),
     StatementStackDelta(prevstmt, prevStackDelta),
@@ -436,7 +436,7 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
   IsValue(v) :-
      PushValue(_, v).
   
-  IsValue(@cast_to_symbol(v)) :-
+  IsValue(as(v,Value)) :-
     PC(v).
   
   .decl DynamicStatement(stmt:Statement)
@@ -557,18 +557,18 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
 
   PublicFunctionJump(block, sigHash) :-   BlockComparesSig(block, sigHash).
 
-  PublicFunction(@cast_to_symbol(targetValue), sigHash) :-
+  PublicFunction(as(targetValue, Block), sigHash) :-
     BlockComparesSig(block, sigHash),
     ImmediateBlockJumpTarget(block, var),
     Statement_Defines(push, var),
     PushValue(push, targetValue),
-    JUMPDEST(@cast_to_symbol(targetValue)).
+    JUMPDEST(as(targetValue,symbol)).
 
   .decl BlockComparesCallDataSizeToFour(block: Block, jumpi: Statement, target: Block)
   .decl BlockJumpsOnCallDataSize(block: Block, jumpi: Statement, target: Block)
   .decl BlockHasReceiveAsFallThrough(block: Block, jumpi: Statement, fallthrough:Statement, target: Block)
 
-  BlockComparesCallDataSizeToFour(block, stmt5, @cast_to_symbol(fallthrough)):-
+  BlockComparesCallDataSizeToFour(block, stmt5, as(fallthrough, Block)):-
     PushValue(stmt, "0x4"),
     Statement_Next(stmt, stmt2),
     CALLDATASIZE(stmt2),
@@ -580,7 +580,7 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
     JUMPI(stmt5),
     Statement_Block(stmt5, block).
 
-  BlockJumpsOnCallDataSize(block, jumpi, @cast_to_symbol(fallthrough)):-
+  BlockJumpsOnCallDataSize(block, jumpi, as(fallthrough, Block)):-
     CALLDATASIZE(cds),
     Statement_Next(cds, push),
     PushValue(push, fallthrough),
@@ -648,7 +648,7 @@ insertor.insertOps(pushStmt,
 insertor.insertOps(jumpDestStmt,
   LIST(
     STMT(JUMPDEST, MAKE_LABEL_REFERENCE(jumpDestStmt)),
-    STMT(PUSH4, @cast_to_symbol(jumpDestStmt)),
+    STMT(PUSH4, as(jumpDestStmt,symbol)),
     STMT(JUMP, cat("PublicFunctionJump:", hash))
   )
 ) :-
@@ -656,7 +656,7 @@ insertor.insertOps(jumpDestStmt,
    preTrans.PublicFunction(start, hash),
    preTrans.Statement_Block(jumpDestStmt, start),
    preTrans.JUMPDEST(jumpDestStmt),
-   preTrans.PushValue(pushStmt, @cast_to_symbol(jumpDestStmt)),
+   preTrans.PushValue(pushStmt, as(jumpDestStmt,symbol)),
    preTrans.Statement_Block(pushStmt, block),
    preTrans.Statement_Defines(pushStmt, pushedVar),
    preTrans.Statement_Uses_Local(jumpStmt, pushedVar, 0),

--- a/logic/statement_insertor.dl
+++ b/logic/statement_insertor.dl
@@ -94,7 +94,7 @@ INITIALIZE_STATEMENT_INSERTOR(_insertor, to)
      PreInsertedOpNewStatementNum(_, _, newStmt),
      n = count : { TempPreInsertedOpNewAndMissingStatementNum(_, newStmt) }.
 
-  InsertedOpNewStatement(stmt, order, as(@number_to_hex(newStmt - n + maxStmt + 1),Statement)) :-
+  InsertedOpNewStatement(stmt, order, as(@number_to_hex(newStmt - n + maxStmt + 1), Statement)) :-
     PreInsertedOpNewStatementNum(stmt, order, newStmt),
     MaxStmt(maxStmt),
     WastedSlots(newStmt, n).

--- a/logic/statement_insertor.dl
+++ b/logic/statement_insertor.dl
@@ -94,7 +94,7 @@ INITIALIZE_STATEMENT_INSERTOR(_insertor, to)
      PreInsertedOpNewStatementNum(_, _, newStmt),
      n = count : { TempPreInsertedOpNewAndMissingStatementNum(_, newStmt) }.
 
-  InsertedOpNewStatement(stmt, order, @number_to_hex(newStmt - n + maxStmt + 1)) :-
+  InsertedOpNewStatement(stmt, order, as(@number_to_hex(newStmt - n + maxStmt + 1),Statement)) :-
     PreInsertedOpNewStatementNum(stmt, order, newStmt),
     MaxStmt(maxStmt),
     WastedSlots(newStmt, n).
@@ -130,7 +130,7 @@ INITIALIZE_STATEMENT_INSERTOR(_insertor, to)
     !ISLABEL(value),
     OpcodeIsPush(op).
 
-  Out_PushValue(newStmt, @cast_to_symbol(actualLabel)) :-
+  Out_PushValue(newStmt, as(actualLabel, Value)) :-
     insertOp(stmt, op, label, order),
     OpcodeIsPush(op),
     ISLABEL(label),


### PR DESCRIPTION
The current version of Gigahorse exploited a type bug in the implementation of Souffle 2.0.2 for user-defined functors.  In version 2.0.2, Souffle did not check the result type of functors at all. 

The proposed changes replace the user-defined functors `@cast_to_number` and `@cast_to_symbol`  by the type conversion operator `as(argument, type)`. The type conversion casts the `argument` to the type `type`.

Similar, the user-defined operators `@min2` and `@max2` are not necessary. Souffle has the operators `min(a1,..,an)` and `max(a1,...,an)`. 
 




 

