### PR TITLE
Update gigahorse.py to inherit custom LD_LIBRARY_PATH

### DIFF
--- a/gigahorse.py
+++ b/gigahorse.py
@@ -222,7 +222,7 @@ souffle_env = os.environ.copy()
 functor_path = join(GIGAHORSE_DIR, 'souffle-addon')
 for e in ["LD_LIBRARY_PATH", "LIBRARY_PATH"]:
     if e in souffle_env:
-        souffle_env[e] += (os.pathsep + functor_path)
+        souffle_env[e] = functor_path + os.pathsep + souffle_env[e]
     else:
         souffle_env[e] = functor_path
 

--- a/gigahorse.py
+++ b/gigahorse.py
@@ -220,8 +220,11 @@ parser.add_argument("-i",
 
 souffle_env = os.environ.copy()
 functor_path = join(GIGAHORSE_DIR, 'souffle-addon')
-souffle_env["LD_LIBRARY_PATH"] += (os.pathsep + functor_path)
-souffle_env["LIBRARY_PATH"] += (os.pathsep + functor_path)
+for e in ["LD_LIBRARY_PATH", "LIBRARY_PATH"]:
+    if e in souffle_env:
+        souffle_env[e] += (os.pathsep + functor_path)
+    else:
+        souffle_env[e] = functor_path
 
 if not os.path.isfile(join(functor_path, 'libfunctors.so')):
     raise Exception(

--- a/gigahorse.py
+++ b/gigahorse.py
@@ -220,8 +220,8 @@ parser.add_argument("-i",
 
 souffle_env = os.environ.copy()
 functor_path = join(GIGAHORSE_DIR, 'souffle-addon')
-souffle_env["LD_LIBRARY_PATH"] = functor_path
-souffle_env["LIBRARY_PATH"] = functor_path
+souffle_env["LD_LIBRARY_PATH"] += (os.pathsep + functor_path)
+souffle_env["LIBRARY_PATH"] += (os.pathsep + functor_path)
 
 if not os.path.isfile(join(functor_path, 'libfunctors.so')):
     raise Exception(


### PR DESCRIPTION
This PR updates gigahorse.py to inherit custom LD_LIBRARY_PATH and LIBRARY_PATH environment variables. It'll fix the linking issue when gigahorse should use to a custom C++ library for C++17 support on an older OS with no C++17 support. in my case, I want gigahorse to use newer libstdc++ from GCC 8.2.0 build instead of default libstdc++ of CentOS 7.