### PR TITLE
prevent symbolic_value from saturating integers

### DIFF
--- a/clientlib/memory_modeling/memory_addresses.dl
+++ b/clientlib/memory_modeling/memory_addresses.dl
@@ -210,9 +210,26 @@ Variable_SymbolicValue(to, val),
 FreePointerBasedValue(val, mload, newDepth, res):-
   ADDFix(_, numVar, freePtrBasedVar, to),
   Variable_NumericValue(numVar, numVal),
+  numVal != 2147483647,
   Variable_SymbolicValue(freePtrBasedVar, freePtrBasedVal),
   FreePointerBasedValue(freePtrBasedVal, mload, depth, numVal2),
   res = numVal + numVal2,
+  (
+  (res != numVal2, newDepth = depth);
+  (res = numVal2, newDepth = depth)
+  ),
+  val = cat(cat(mload, "++"), to_string(res)).
+
+Variable_SymbolicValue(to, val),
+FreePointerBasedValue(val, mload, newDepth, res):-
+  ADDFix(_, numVar, freePtrBasedVar, to),
+  Variable_NumericValue(numVar, numVal),
+  numVal = 2147483647,
+  Variable_Value(numVar, numValL),
+  posNumValL = -@hex_to_number(@add_256("0x1", @not_256(numValL))),
+  Variable_SymbolicValue(freePtrBasedVar, freePtrBasedVal),
+  FreePointerBasedValue(freePtrBasedVal, mload, depth, numVal2),
+  res = posNumValL + numVal2,
   (
   (res != numVal2, newDepth = depth);
   (res = numVal2, newDepth = depth)


### PR DESCRIPTION
This tackles a miss-optimization from Solidity that generates code like this:
```
    0xa50x31: va5V31 = MLOAD va3V31(0x40)
    0xa60x31: va6V31(0x1f) = CONST 
    0xa80x31: va8V31(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0) = NOT va6V31(0x1f)
    0xa90x31: va9V31 = ADD va8V31(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0), va5V31
    0xaa0x31: vaaV31 = MLOAD va9V31
```
with the intention of dereferring (ptr - 0x20). This causes Variable_SymbolicValue to saturate the integer instead of returning the right offsets.

The proposed modification to gigahorse is detecting if the integer gets saturated and make the number negative. Open to other potential solutions.