### PR TITLE
Refactor bytecode metadata extracting logic, add support for vyper

### DIFF
--- a/gigahorse.py
+++ b/gigahorse.py
@@ -452,10 +452,10 @@ def analyze_contract(job_index: int, index: int, contract_filename: str, result_
 
             os.symlink(join(work_dir, 'bytecode.hex'), join(out_dir, 'bytecode.hex'))
 
-            if os.path.exists(join(work_dir, 'solidity_version.csv')):
+            if os.path.exists(join(work_dir, 'compiler_info.csv')):
                 # Create a symlink with a name starting with 'Verbatim_' to be added to results json
-                os.symlink(join(work_dir, 'solidity_version.csv'), join(out_dir, 'Verbatim_solidity_version.csv'))
-                os.symlink(join(work_dir, 'solidity_version.csv'), join(fallback_out_dir, 'Verbatim_solidity_version.csv'))
+                os.symlink(join(work_dir, 'compiler_info.csv'), join(out_dir, 'Verbatim_compiler_info.csv'))
+                os.symlink(join(work_dir, 'compiler_info.csv'), join(fallback_out_dir, 'Verbatim_compiler_info.csv'))
 
             timeouts, _ = run_clients(souffle_pre_clients, other_pre_clients, work_dir, work_dir)
             if timeouts:

--- a/run_tests.py
+++ b/run_tests.py
@@ -32,7 +32,8 @@ class LogicTestCase(unittest.TestCase):
 
         self.gigahorse_args = test_config.get('gigahorse_args', [])
 
-        self.expected_results: List[Tuple[str, int, float]] = test_config.get("expected_results", [])
+        self.expected_analytics: List[Tuple[str, int, float]] = test_config.get("expected_analytics", [])
+        self.expected_verbatim: List[Tuple[str, str]] = test_config.get("expected_verbatim", [])
 
     def id(self) -> str:
         return self.name
@@ -93,8 +94,11 @@ class LogicTestCase(unittest.TestCase):
         for x, y in temp_analytics.items():
             analytics[x] = y
 
-        for metric, expected, margin in self.expected_results:
+        for metric, expected, margin in self.expected_analytics:
             self.assertTrue(within_margin(analytics[metric], expected, margin), f"Value for {metric} ({analytics[metric]}) not within margin of expected value ({expected}).")
+
+        for metric, expected in self.expected_verbatim:
+            self.assertTrue(analytics[metric] == expected, f"Value for {metric} ({analytics[metric]}) not the expected value ({expected}).")
 
 
 def discover_logic_tests(current_config: MutableMapping[str, Any], directory: str) -> Iterator[Tuple[Mapping[str, Any], str]]:

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -115,6 +115,12 @@ class InstructionTsvExporter(Exporter):
         """
         Print basic block info to tsv.
         """
+
+        def get_version_str(metadata_prefix):
+            index = bytecode_hex.rindex(metadata_prefix) + len(metadata_prefix)
+            version_bytes = bytecode_hex[index : index + 6]
+            return f"{int(version_bytes[0:2], 16)}.{int(version_bytes[2:4], 16)}.{int(version_bytes[4:6], 16)}"
+
         if output_dir != "":
             os.makedirs(output_dir, exist_ok=True)
         
@@ -123,19 +129,31 @@ class InstructionTsvExporter(Exporter):
                 assert '\n' not in bytecode_hex
                 f.write(bytecode_hex)
 
-            solidity_version = "unknown"
-            # "64736f6c6343" is 0x64 + "solc" + 0x43 which is followed by the solc version
+            # 0x64 + "solc" + 0x43 which is followed by the solc version
             # only exists in solidity bytecode compiled using solc >= 0.5.9 when it is not explicitly removed
-            if "64736f6c6343" in bytecode_hex:
-                solidity_version_bytes = bytecode_hex[bytecode_hex.rindex("64736f6c6343") + 12 : bytecode_hex.rindex("64736f6c6343") + 18]
-                solidity_version = f"{int(solidity_version_bytes[0:2], 16)}.{int(solidity_version_bytes[2:4], 16)}.{int(solidity_version_bytes[4:6], 16)}"
-            # "a165627a7a7230" is 0xa165 + "bzzr0" which is followed by the swarn hash of the metadata file (useless to us)
+            solidity_metadata_prefix = b"\x64solc\x43".hex()
+            # 0xa165 + "bzzr0" is followed by the swarn hash of the metadata file (useless to us)
             # Was introduced in solc 0.4.7 and changed in 0.5.9
-            elif "a165627a7a7230" in bytecode_hex:
-                solidity_version = "0.4.7<=v<0.5.9"
+            solidity_metadata_prefix_old = b"\xa1\x65bzzr0".hex()
+            # 0xa165 + "vyper" + 0x83 which is followed by the vyper version
+            # works for vyper versions >= 0.3.5
+            vyper_metadata_prefix = b"\xa1\x65vyper\x83".hex()
 
-            with open(output_dir + "/solidity_version.csv", "w") as f:
-                f.write(solidity_version)
+            language = "unknown"
+            compiler_version = "unknown"
+
+            if solidity_metadata_prefix in bytecode_hex:
+                language = "solidity"
+                compiler_version = get_version_str(solidity_metadata_prefix)
+            elif solidity_metadata_prefix_old in bytecode_hex:
+                language = "solidity"
+                compiler_version = "0.4.7<=v<0.5.9"
+            elif vyper_metadata_prefix in bytecode_hex:
+                language = "vyper"
+                compiler_version = get_version_str(vyper_metadata_prefix)
+
+            with open(output_dir + "/compiler_info.csv", "w") as f:
+                f.write(f"{language}\t{compiler_version}")
 
         signatures_filename_in = public_function_signature_filename
         signatures_filename_out = os.path.join(output_dir, 'PublicFunctionSignature.facts')

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -136,7 +136,7 @@ class InstructionTsvExporter(Exporter):
             # Was introduced in solc 0.4.7 and changed in 0.5.9
             solidity_metadata_prefix_old = b"\xa1\x65bzzr0".hex()
             # 0xa165 + "vyper" + 0x83 which is followed by the vyper version
-            # works for vyper versions >= 0.3.5
+            # works for vyper versions >= 0.3.4 (followed by the bytecode length for versions >= 0.3.5)
             vyper_metadata_prefix = b"\xa1\x65vyper\x83".hex()
 
             language = "unknown"

--- a/tests/default-fallback-scalable/2d56cd44e89f2cf76a935c2508f710e7.json
+++ b/tests/default-fallback-scalable/2d56cd44e89f2cf76a935c2508f710e7.json
@@ -1,5 +1,5 @@
 {
     "client_path": null,
     "gigahorse_args": ["-i", "--disable_inline"],
-    "expected_results": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 2, 0]]
+    "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 2, 0]]
 }

--- a/tests/early-cloning/no-jump-to-many/config.json
+++ b/tests/early-cloning/no-jump-to-many/config.json
@@ -1,5 +1,5 @@
 {
     "client_path": null,
     "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback", "--early_cloning"],
-    "expected_results": [["Analytics_JumpToMany", 0, 0]]
+    "expected_analytics": [["Analytics_JumpToMany", 0, 0]]
 }

--- a/tests/guards/external-guards.json
+++ b/tests/guards/external-guards.json
@@ -1,5 +1,5 @@
 {
     "client_path": "clients/analytics_client.dl",
     "gigahorse_args": ["-i", "--disable_scalable_fallback"],
-    "expected_results": [["Analytics_SenderGuard", 2, 0]]
+    "expected_analytics": [["Analytics_SenderGuard", 2, 0]]
 }

--- a/tests/guards/mapping-guard.json
+++ b/tests/guards/mapping-guard.json
@@ -1,5 +1,5 @@
 {
     "client_path": "clients/analytics_client.dl",
     "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback"],
-    "expected_results": [["Analytics_SenderGuard", 1, 0]]
+    "expected_analytics": [["Analytics_SenderGuard", 1, 0]]
 }

--- a/tests/guards/owner-guard.json
+++ b/tests/guards/owner-guard.json
@@ -1,5 +1,5 @@
 {
     "client_path": "clients/analytics_client.dl",
     "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback"],
-    "expected_results": [["Analytics_SenderGuard", 1, 0]]
+    "expected_analytics": [["Analytics_SenderGuard", 1, 0]]
 }

--- a/tests/guards/reentrancy-guard.json
+++ b/tests/guards/reentrancy-guard.json
@@ -1,5 +1,5 @@
 {
     "client_path": "clients/analytics_client.dl",
     "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback"],
-    "expected_results": [["Analytics_ReentrancyGuard", 1, 0]]
+    "expected_analytics": [["Analytics_ReentrancyGuard", 1, 0]]
 }

--- a/tests/memory-modeling/arrays/0117c9ec55e2ac580fa9c9b1c2d1fff9.json
+++ b/tests/memory-modeling/arrays/0117c9ec55e2ac580fa9c9b1c2d1fff9.json
@@ -1,7 +1,7 @@
 {
     "client_path": null,
     "gigahorse_args": ["-i", "--disable_scalable_fallback"],
-    "expected_results": [["Analytics_JumpToMany", 1, 0], ["Analytics_UnreachableBlock", 1, 0],
+    "expected_analytics": [["Analytics_JumpToMany", 1, 0], ["Analytics_UnreachableBlock", 1, 0],
     ["Analytics_BlockHasNoTACBlock", 0, 0], ["Analytics_StmtMissingOperand", 0, 0],
     ["Analytics_NonModeledMLOAD", 0, 0],["Analytics_NonModeledMSTORE", 2, 0]]
 }

--- a/tests/memory-modeling/calls/abiencwithselector.json
+++ b/tests/memory-modeling/calls/abiencwithselector.json
@@ -1,5 +1,5 @@
 {
     "client_path": "clients/analytics_client.dl",
     "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback"],
-    "expected_results": [["Analytics_ERC20ApproveCall", 1, 0], ["Analytics_ERC20TransferFromCall", 1, 0], ["Analytics_ERC20TransferCall", 1, 0]]
+    "expected_analytics": [["Analytics_ERC20ApproveCall", 1, 0], ["Analytics_ERC20TransferFromCall", 1, 0], ["Analytics_ERC20TransferCall", 1, 0]]
 }

--- a/tests/memory-modeling/errors/basic.json
+++ b/tests/memory-modeling/errors/basic.json
@@ -1,5 +1,5 @@
 {
     "client_path": "clients/analytics_client.dl",
     "gigahorse_args": ["-i", "--disable_inline"],
-    "expected_results": [["Analytics_RevertSigUsed", 2, 0]]
+    "expected_analytics": [["Analytics_RevertSigUsed", 2, 0]]
 }

--- a/tests/memory-modeling/events/events1.json
+++ b/tests/memory-modeling/events/events1.json
@@ -1,5 +1,5 @@
 {
     "client_path": "clients/analytics_client.dl",
     "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback"],
-    "expected_results": [["Analytics_EventSignature", 3, 0]]
+    "expected_analytics": [["Analytics_EventSignature", 3, 0]]
 }

--- a/tests/memory-modeling/events/events2.json
+++ b/tests/memory-modeling/events/events2.json
@@ -1,5 +1,5 @@
 {
     "client_path": "clients/analytics_client.dl",
     "gigahorse_args": ["-i", "--disable_scalable_fallback"],
-    "expected_results": [["Analytics_EventSignature", 1, 0], ["Analytics_NonModeledMLOAD", 0, 0], ["Analytics_NonModeledMSTORE", 0, 0]]
+    "expected_analytics": [["Analytics_EventSignature", 1, 0], ["Analytics_NonModeledMLOAD", 0, 0], ["Analytics_NonModeledMSTORE", 0, 0]]
 }

--- a/tests/memory-modeling/structs/array_struct.json
+++ b/tests/memory-modeling/structs/array_struct.json
@@ -1,7 +1,7 @@
 {
     "client_path": null,
     "gigahorse_args": ["-i", "--disable_scalable_fallback"],
-    "expected_results": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 2, 0],
+    "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 2, 0],
     ["Analytics_BlockHasNoTACBlock", 0, 0], ["Analytics_StmtMissingOperand", 0, 0],
     ["Analytics_NonModeledMLOAD", 0, 0],["Analytics_NonModeledMSTORE", 0, 0]]
 }

--- a/tests/memory-modeling/structs/simple_struct.json
+++ b/tests/memory-modeling/structs/simple_struct.json
@@ -1,7 +1,7 @@
 {
     "client_path": null,
     "gigahorse_args": ["-i", "--disable_scalable_fallback"],
-    "expected_results": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 1, 0],
+    "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 1, 0],
     ["Analytics_BlockHasNoTACBlock", 0, 0], ["Analytics_StmtMissingOperand", 0, 0],
     ["Analytics_NonModeledMLOAD", 0, 0],["Analytics_NonModeledMSTORE", 0, 0]]
 }

--- a/tests/memory-modeling/structs/stored_struct.json
+++ b/tests/memory-modeling/structs/stored_struct.json
@@ -1,7 +1,7 @@
 {
     "client_path": null,
     "gigahorse_args": ["-i", "--disable_scalable_fallback"],
-    "expected_results": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 0, 0],
+    "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 0, 0],
     ["Analytics_BlockHasNoTACBlock", 0, 0], ["Analytics_StmtMissingOperand", 0, 0],
     ["Analytics_NonModeledMLOAD", 0, 0],["Analytics_NonModeledMSTORE", 0, 0]]
 }

--- a/tests/precise_fallback/no-jump-to-many/config.json
+++ b/tests/precise_fallback/no-jump-to-many/config.json
@@ -1,5 +1,5 @@
 {
     "client_path": null,
     "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback"],
-    "expected_results": [["Analytics_JumpToMany", 0, 0]]
+    "expected_analytics": [["Analytics_JumpToMany", 0, 0]]
 }

--- a/tests/storage/array1.json
+++ b/tests/storage/array1.json
@@ -1,5 +1,5 @@
 {
     "client_path": "clients/analytics_client.dl",
     "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback"],
-    "expected_results": [["Analytics_StorageArray", 1, 0]]
+    "expected_analytics": [["Analytics_StorageArray", 1, 0]]
 }

--- a/tests/storage/map1.json
+++ b/tests/storage/map1.json
@@ -1,5 +1,5 @@
 {
     "client_path": "clients/analytics_client.dl",
     "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback"],
-    "expected_results": [["Analytics_Map", 1, 0]]
+    "expected_analytics": [["Analytics_Map", 1, 0]]
 }

--- a/tests/storage/merged.json
+++ b/tests/storage/merged.json
@@ -1,5 +1,5 @@
 {
     "client_path": "clients/analytics_client.dl",
     "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback"],
-    "expected_results": [["Analytics_GlobalVariable", 3, 0]]
+    "expected_analytics": [["Analytics_GlobalVariable", 3, 0]]
 }

--- a/tests/vyper/blind.json
+++ b/tests/vyper/blind.json
@@ -1,5 +1,6 @@
 {
     "client_path": null,
     "gigahorse_args": ["-i", "--disable_inline"],
-    "expected_results": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 0, 0], ["Analytics_PublicFunction", 10, 0]]
+    "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 0, 0], ["Analytics_PublicFunction", 10, 0]],
+    "expected_verbatim": [["Verbatim_compiler_info", "vyper\t0.3.7"]]
 }

--- a/tests/vyper/simple_open.json
+++ b/tests/vyper/simple_open.json
@@ -1,5 +1,6 @@
 {
     "client_path": null,
     "gigahorse_args": ["-i", "--disable_inline"],
-    "expected_results": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 0, 0], ["Analytics_PublicFunction", 10, 0]]
+    "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 0, 0], ["Analytics_PublicFunction", 10, 0]],
+    "expected_verbatim": [["Verbatim_compiler_info", "vyper\t0.3.7"]]
 }


### PR DESCRIPTION
Data now available under `Verbatim_compiler_info.csv`.

Also had to make small changes to the testing logic.