### PR TITLE
update ubuntu docker version

### DIFF
--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -5,16 +5,17 @@ USER root
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install some essentials
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get upgrade && apt-get install -y \
     build-essential \
     libboost-all-dev \
-    curl
+    wget
 
 # Install python3
 RUN apt-get install python3-dev python3-pip -y
 
 # Install souffle
-RUN curl -s https://packagecloud.io/install/repositories/souffle-lang/souffle/script.deb.sh | bash
+RUN wget https://souffle-lang.github.io/ppa/souffle-key.public -O /usr/share/keyrings/souffle-archive-keyring.gpg
+RUN echo "deb [signed-by=/usr/share/keyrings/souffle-archive-keyring.gpg] https://souffle-lang.github.io/ppa/ubuntu/ stable main" | tee /etc/apt/sources.list.d/souffle.list
 RUN apt-get update && apt-get install souffle -y
 
 # Dependencies for Gigahorse output viz

--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:22.04
 
 USER root
 

--- a/docker/mac/Dockerfile
+++ b/docker/mac/Dockerfile
@@ -4,8 +4,9 @@ USER root
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+
 # Install some essentials
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get upgrade && apt-get install -y \
     libboost-all-dev 
 
 # Install python3

--- a/docker/mac/Dockerfile
+++ b/docker/mac/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.10
+FROM ubuntu:22.04
 
 USER root
 


### PR DESCRIPTION
From https://fridge.ubuntu.com/2022/01/21/ubuntu-21-04-hirsute-hippo-end-of-life-reached-on-january-20-2022/

> As of January 20, 2022, Ubuntu 21.04 is no longer supported. No more package updates will be accepted to 21.04, and it will be archived to old-releases.ubuntu.com in the coming weeks.