### PR TITLE
Better mapping to original bytecode statements + Flow API change

### DIFF
--- a/clientlib/decompiler_imports.dl
+++ b/clientlib/decompiler_imports.dl
@@ -15,6 +15,10 @@
 .type Chunk <: number
 .type OriginalStatement <: symbol
 
+.type StringList = [x: symbol, y: StringList]
+// Removed the definition in order to use the stateless functor on lists
+// .type OriginalStatementList = [stmt: OriginalStatement, rest: OriginalStatementList]
+.type OriginalStatementList = StringList
 
 
 #include "tac_instructions.dl"
@@ -152,8 +156,6 @@ IsPublicFunction(func) :- PublicFunctionSelector(func, _).
 .decl Statement_OriginalStatement(stmt: Statement, originalStatement: OriginalStatement)
 .input Statement_OriginalStatement(IO="file", filename="TAC_Statement_OriginalStatement.csv", delimiter="\t")
 
-
-.type OriginalStatementList = [stmt: OriginalStatement, rest: OriginalStatementList]
 
 .decl Statement_OriginalStatementList(irstmt: Statement, stmtList: OriginalStatementList)
 .input Statement_OriginalStatementList(IO="file", filename="TAC_Statement_OriginalStatementList.csv", delimiter="\t")

--- a/clientlib/decompiler_imports.dl
+++ b/clientlib/decompiler_imports.dl
@@ -15,9 +15,12 @@
 .type Chunk <: number
 .type OriginalStatement <: symbol
 
-.type StringList = [x: symbol, y: StringList]
+// Defined in souffle-addon/functor_includes.dl
+// .type StringList = [x: symbol, y: StringList]
+
 // Removed the definition in order to use the stateless functor on lists
 // .type OriginalStatementList = [stmt: OriginalStatement, rest: OriginalStatementList]
+
 .type OriginalStatementList = StringList
 
 

--- a/clientlib/decompiler_imports.dl
+++ b/clientlib/decompiler_imports.dl
@@ -152,6 +152,12 @@ IsPublicFunction(func) :- PublicFunctionSelector(func, _).
 .decl Statement_OriginalStatement(stmt: Statement, originalStatement: OriginalStatement)
 .input Statement_OriginalStatement(IO="file", filename="TAC_Statement_OriginalStatement.csv", delimiter="\t")
 
+
+.type OriginalStatementList = [stmt: OriginalStatement, rest: OriginalStatementList]
+
+.decl Statement_OriginalStatementList(irstmt: Statement, stmtList: OriginalStatementList)
+.input Statement_OriginalStatementList(IO="file", filename="TAC_Statement_OriginalStatementList.csv", delimiter="\t")
+
 // Code chunks accessed
 .decl Block_CodeChunkAccessed(block: Block, chunk_id: Chunk)
 .input Block_CodeChunkAccessed(IO="file", filename="TAC_Block_CodeChunkAccessed.csv", delimiter="\t")

--- a/clientlib/dominators.dl
+++ b/clientlib/dominators.dl
@@ -290,6 +290,9 @@ DEBUG_OUTPUT(FunctionReachableFromPublic)
 // Can we ever have recursion? Deal with it the lazy way
 .limitsize FunctionReachableFromPublic(n=50000)
 
+.decl CallStackToOriginalStatementList(callStack: CallStack, originals: OriginalStatementList)
+DEBUG_OUTPUT(CallStackToOriginalStatementList)
+
 FunctionReachableFromPublic(function, selectorNorm, nil):-
   PublicFunctionSelector(function, selector),
   ConstantPossibleSigHash(selector, selectorNorm, _).
@@ -298,3 +301,11 @@ FunctionReachableFromPublic(callee, selector, [callerBlock, callerStack]):-
   FunctionReachableFromPublic(caller, selector, callerStack),
   InFunction(callerBlock, caller),
   CallGraphEdge(callerBlock, callee).
+
+CallStackToOriginalStatementList(nil, nil).
+
+CallStackToOriginalStatementList([caller, rest], [original, restOriginal]):-
+  FunctionReachableFromPublic(_, _, [caller, rest]),
+  CallStackToOriginalStatementList(rest, restOriginal),
+  Block_Tail(caller, call),
+  Statement_OriginalStatement(call, original).

--- a/clientlib/dominators.dl
+++ b/clientlib/dominators.dl
@@ -282,3 +282,17 @@ LocalStatementPathInBlock(stmt1, stmt3):-
     beforeToBetween.MayHappenBefore(before, between),
     betweenToAfter.MayHappenBefore(between, after).
 }
+
+.type CallStack = [callerBlock: Block, rest: CallStack]
+
+.decl FunctionReachableFromPublic(function: Function, selector: symbol, callStack: CallStack)
+// Can we ever have recursion? Deal with it the lazy way
+.limitsize FunctionReachableFromPublic(n=50000)
+
+FunctionReachableFromPublic(function, selector, nil):-
+  PublicFunctionSelector(function, selector).
+
+FunctionReachableFromPublic(callee, selector, [callerBlock, callerStack]):-
+  FunctionReachableFromPublic(caller, selector, callerStack),
+  InFunction(callerBlock, caller),
+  CallGraphEdge(callerBlock, callee).

--- a/clientlib/dominators.dl
+++ b/clientlib/dominators.dl
@@ -286,11 +286,13 @@ LocalStatementPathInBlock(stmt1, stmt3):-
 .type CallStack = [callerBlock: Block, rest: CallStack]
 
 .decl FunctionReachableFromPublic(function: Function, selector: symbol, callStack: CallStack)
+DEBUG_OUTPUT(FunctionReachableFromPublic)
 // Can we ever have recursion? Deal with it the lazy way
 .limitsize FunctionReachableFromPublic(n=50000)
 
-FunctionReachableFromPublic(function, selector, nil):-
-  PublicFunctionSelector(function, selector).
+FunctionReachableFromPublic(function, selectorNorm, nil):-
+  PublicFunctionSelector(function, selector),
+  ConstantPossibleSigHash(selector, selectorNorm, _).
 
 FunctionReachableFromPublic(callee, selector, [callerBlock, callerStack]):-
   FunctionReachableFromPublic(caller, selector, callerStack),

--- a/clientlib/flows.dl
+++ b/clientlib/flows.dl
@@ -85,6 +85,25 @@ standardflowanalysis.TransferBoundary(b) :- IsBlock(b).
 
 #define DataFlows standardflowanalysis.GlobalFlows
 
+.init constantOpFlows = GlobalFlowAnalysis
+constantOpFlows.TransferStmt(stmt):-
+  UnaryArith(op),
+  Statement_Opcode(stmt, op).
+
+constantOpFlows.TransferStmt(stmt):-
+  BinArith(op),
+  Statement_Opcode(stmt, op),
+  Statement_Uses(stmt, var, _),
+  Variable_Value(var, _). // Maybe replace with BasicVariable_Value
+
+constantOpFlows.TransferStmt(stmt):-
+  Statement_Opcode(stmt, "PHI").
+
+constantOpFlows.InitialFlowVar(v):- isVariable(v).
+constantOpFlows.TransferBoundary(b):- IsBlock(b).
+
+#define DataFlowsThroughConstOps constantOpFlows.GlobalFlows
+
 // Need a custom data flow analysis? Of course you do!
 // Initialise this component and indicate with opcodes to use as transfer functions.
 // Also indicate the transfer boundary (e.g. Loop blocks for induction variables)

--- a/clientlib/flows.dl
+++ b/clientlib/flows.dl
@@ -6,7 +6,7 @@
 //
 
 .comp GlobalFlowAnalysis {
-  .decl TransferOpcode(op: Opcode)
+  .decl TransferStmt(stmt: Statement)
   .decl InitialFlowVar(var: Variable)
   .decl Flows(from:Variable, to:Variable)
   .decl TransferBoundary(block: Block)
@@ -24,8 +24,7 @@
      Flows(_, x),
      Statement_Uses(stmt, x, _),
      Statement_Defines(stmt, y, _),
-     Statement_Opcode(stmt, op),
-     TransferOpcode(op),
+     TransferStmt(stmt),
      Statement_Block(stmt, block),
      TransferBoundary(block).
 
@@ -80,7 +79,7 @@
 }
 
 .init standardflowanalysis = GlobalFlowAnalysis
-standardflowanalysis.TransferOpcode(op) :- FlowOp(op).
+standardflowanalysis.TransferStmt(stmt) :- FlowOp(op), Statement_Opcode(stmt, op).
 standardflowanalysis.InitialFlowVar(v) :- isVariable(v).
 standardflowanalysis.TransferBoundary(b) :- IsBlock(b).
 
@@ -107,8 +106,7 @@ standardflowanalysis.TransferBoundary(b) :- IsBlock(b).
   
   NonTransitiveFlows(x, y),
   Flows(x, y) :-
-    TransferOpcode(op),
-    Statement_Opcode(stmt, op),
+    TransferStmt(stmt),
     Statement_Block(stmt, block),
     TransferBoundary(block),
     Statement_Defines(stmt, y, _),
@@ -140,8 +138,10 @@ standardflowanalysis.TransferBoundary(b) :- IsBlock(b).
   .decl TransferOpcodeArgument(op: Opcode, argument: number)
   TransferOpcodeArgument(op, n) :- TransferOpcodeArgument(op, n). // suppress warning
 
-  .decl TransferOpcode(op: Opcode)
-  TransferOpcode("PHI"). // PHI instructions should always transfer
+  .decl TransferStmt(stmt: Statement)
+
+  // PHI instructions should always transfer
+  TransferStmt(stmt):- Statement_Opcode(stmt, "PHI").
 
   .decl TransferBoundary(block: Block)
 }
@@ -152,14 +152,14 @@ standardflowanalysis.TransferBoundary(b) :- IsBlock(b).
 // that defined x, or transitively.
 .init dependencyAnalysis = LocalFlowAnalysis
 
-dependencyAnalysis.TransferOpcode(op) :- Statement_Opcode(_, op).
+dependencyAnalysis.TransferStmt(stmt) :- Statement_Opcode(stmt, _).
 dependencyAnalysis.TransferBoundary(block) :- IsBlock(block).
 
 #define DependsOn dependencyAnalysis.Flows
 
 .init localFlowAnalysis = LocalFlowAnalysis
 
-localFlowAnalysis.TransferOpcode(op) :- FlowOp(op).
+localFlowAnalysis.TransferStmt(stmt) :- FlowOp(op), Statement_Opcode(stmt, op).
 localFlowAnalysis.TransferBoundary(block) :- IsBlock(block).
 
 #define LocalFlows localFlowAnalysis.Flows

--- a/clientlib/function_inliner.dl
+++ b/clientlib/function_inliner.dl
@@ -28,6 +28,7 @@
   .decl In_Block_Gas(block:Block, gas:number)
   .decl In_Block_CodeChunkAccessed(block:Block, chunk:Chunk)
   .decl In_Statement_OriginalStatement(irstmt: Statement, stmt: symbol)
+  .decl In_Statement_OriginalStatementList(irstmt: Statement, stmtList: OriginalStatementList)
   .decl In_OriginalStatement_Block(stmt:symbol, block:Block)
   .decl In_FormalArgs(fn: Function, a: Variable, pos: number)
   .decl In_Statement_Uses(stmt: Statement, var: Variable, i: number)
@@ -50,6 +51,7 @@
   .decl Out_Block_Gas(block:Block, gas:number)  //CHECK
   .decl Out_Block_CodeChunkAccessed(block:Block, chunk:Chunk)  //CHECK
   .decl Out_Statement_OriginalStatement(irstmt: Statement, stmt: symbol)
+  .decl Out_Statement_OriginalStatementList(irstmt: Statement, stmtList: OriginalStatementList)
   .decl Out_OriginalStatement_Block(stmt:symbol, block:Block)
   .decl Out_FormalArgs(fn: Function, a: Variable, pos: number) //CHECK
   .decl Out_Statement_Uses(stmt: Statement, var: Variable, i: number)  //CHECK
@@ -277,6 +279,17 @@
   Out_Statement_OriginalStatement(outStmt, stmt):-
     In_Statement_OriginalStatement(inStmt, stmt),
     InStatement_OutStatement(inStmt, _, outStmt).
+
+  Out_Statement_OriginalStatementList(outStmt, stmtList):-
+    In_Statement_OriginalStatementList(inStmt, stmtList),
+    InStatement_OutStatement(inStmt, "", outStmt).
+
+  Out_Statement_OriginalStatementList(outStmt, [originalCall, stmtList]):-
+    In_Statement_OriginalStatementList(inStmt, stmtList),
+    StatementToClone(inStmt, _, callerBlock, _, outStmt),
+    In_Statement_Block(callStmt, callerBlock),
+    In_Statement_Opcode(callStmt, "CALLPRIVATE"),
+    In_Statement_OriginalStatement(callStmt, originalCall).
 
   Out_OriginalStatement_Block(stmt, outBlock):-
     In_OriginalStatement_Block(stmt, inBlock),
@@ -599,6 +612,7 @@ inliner.In_IsFunction(func):- IsFunction(func).
 inliner.In_Block_Gas(block, gas):- Block_Gas(block, gas).
 inliner.In_Block_CodeChunkAccessed(block, chunk):- Block_CodeChunkAccessed(block, chunk).
 inliner.In_Statement_OriginalStatement(stmt, original):- Statement_OriginalStatement(stmt, original).
+inliner.In_Statement_OriginalStatementList(stmt, original):- Statement_OriginalStatementList(stmt, original).
 inliner.In_OriginalStatement_Block(stmt, block):- OriginalStatement_Block(stmt, block).
 inliner.In_FormalArgs(fn, a, pos):- FormalArgs(fn, a, pos).
 inliner.In_Statement_Uses(stmt, var, i):- Statement_Uses(stmt, var, i).
@@ -625,6 +639,7 @@ inliner.In_ActualReturnArgs(caller, arg, pos):- ActualReturnArgs(caller, arg, po
 .output inliner.Out_Block_Gas(IO="file", filename="TAC_Block_Gas.csv", delimiter="\t")
 .output inliner.Out_Block_CodeChunkAccessed(IO="file", filename="TAC_Block_CodeChunkAccessed.csv", delimiter="\t")
 .output inliner.Out_Statement_OriginalStatement(IO="file", filename="TAC_Statement_OriginalStatement.csv", delimiter="\t")
+.output inliner.Out_Statement_OriginalStatementList(IO="file", filename="TAC_Statement_OriginalStatementList.csv", delimiter="\t")
 .output inliner.Out_OriginalStatement_Block(IO="file", filename="TAC_OriginalStatement_Block.csv", delimiter="\t")
 .output inliner.Out_FormalArgs(IO="file", filename="FormalArgs.csv", delimiter="\t")
 .output inliner.Out_Statement_Uses(IO="file", filename="TAC_Use.csv", delimiter="\t")

--- a/clientlib/loops_semantics.dl
+++ b/clientlib/loops_semantics.dl
@@ -4,7 +4,7 @@
 
 .init inductionVariableFlow = LocalFlowAnalysis
 
-inductionVariableFlow.TransferOpcode("AND").
+inductionVariableFlow.TransferStmt(stmt):- Statement_Opcode(stmt, "AND").
 inductionVariableFlow.TransferBoundary(block) :- BlockInStructuredLoop(block, _).
 
 // A variable that is monotonically increasing with each successive iteration in loop

--- a/clientlib/vulnerability_macros.dl
+++ b/clientlib/vulnerability_macros.dl
@@ -5,7 +5,7 @@
 
 #ifndef FIRST_CLIENT_ANALYSIS
 .input ProtoVulnerability(IO="file", filename="proto_vulnerability.csv", delimiter="\t")
-.input Vulnerability(IO="file", filename="vulnerability.csv", delimiter="\t")
+.input VulnerabilityProcessed(IO="file", filename="vulnerability.csv", delimiter="\t")
 #endif
 
 .decl ProtoVulnerability(
@@ -18,6 +18,19 @@
 
 
 .decl Vulnerability(
+    vulnerability_type: symbol,
+    confidence: symbol,
+    visibility: symbol,
+    key_statement: OriginalStatement,
+    key_selector: symbol,
+    debug_template: symbol,
+    debug_arg0: symbol,
+    debug_arg1: symbol,
+    debug_arg2: symbol,
+    debug_arg3: symbol
+)
+
+.decl VulnerabilityProcessed(
     vulnerability_type: symbol,
     confidence: symbol,
     visibility: symbol,
@@ -48,10 +61,18 @@ Vulnerability(
    VulnerabilitySimple(vulnerability_type, template, statement),
    Statement_OriginalStatement(statement, original_statement).
 
-   
+
+VulnerabilityProcessed(vulnerability_type, confidence, visibility, as(key_statement, OriginalStatement), key_selector, debug_template, debug_arg0, debug_arg1, debug_arg2, debug_arg3):-
+  Vulnerability(vulnerability_type, confidence, visibility, originalStatement, key_selector, debug_template, debug_arg0, debug_arg1, debug_arg2, debug_arg3),
+  Statement_OriginalStatement(tacStmt, originalStatement),
+  Statement_Function(tacStmt, function),
+  FunctionReachableFromPublic(function, key_selector, _),
+  Statement_OriginalStatementList(tacStmt, originalList),
+  originalList = [key_statement, rest], rest = rest.
+
 
 .output ProtoVulnerability(IO="file", filename="proto_vulnerability.csv", delimiter="\t")
-.output Vulnerability(IO="file", filename="vulnerability.csv", delimiter="\t")
+.output VulnerabilityProcessed(IO="file", filename="vulnerability.csv", delimiter="\t")
 
 #define PREPARE_JSON1(arg1) cat("{ ", cat(arg1, " }"))
 #define PREPARE_JSON2(arg1, arg2) cat("{ ", cat(cat(arg1, ", "), cat(arg2, " }")))

--- a/logic/decompiler_output.dl
+++ b/logic/decompiler_output.dl
@@ -217,7 +217,7 @@ TAC_Block(phiStmt, block) :-
 /***********
  *  Function-discovery outputs to visualization scripts
  ***********/
-
+// The following contain "Dead" results
 .output IRFunctionCall
 .output IRFunctionCallReturn
 .output IRFunction_Return
@@ -241,8 +241,14 @@ ActualReturnArgs(caller, var_rep, n) :-
 .output HighLevelFunctionName
 .output IRFallthroughEdge
 
+.decl IRInFunctionFiltered(block: IRBlock, func: IRFunction)
+
+IRInFunctionFiltered(block, func):-
+  IRInFunction(block, func),
+  ReachableFromFunHead(block).
+
 .output Mask_Length
-.output IRInFunction(IO="file", filename="InFunction.csv", delimiter="\t")
+.output IRInFunctionFiltered(IO="file", filename="InFunction.csv", delimiter="\t")
 .output IRFunctionEntry
 
 /*****
@@ -278,14 +284,22 @@ TAC_Block_Head(block, irstmt) :-
    Statement_IRStatement(stmt, _, irstmt),
    postTrans.IsBasicBlockHead(stmt).
 
+// TODO: Account for cloning. Shouldn't matter as it's all low-level stuff
 .decl TAC_Statement_OriginalStatement(irstmt: IRStatement, stmt: Statement)
 
+.type StatementList = [stmt: Statement, rest: StatementList]
+
+.decl TAC_Statement_OriginalStatementList(irstmt: IRStatement, stmtList: StatementList)
+
+
 // unmodified statements
+TAC_Statement_OriginalStatementList(irstmt, [stmt, nil]),
 TAC_Statement_OriginalStatement(irstmt, stmt) :-
   Statement_IRStatement(stmt, _, irstmt),
   preTrans.Statement_Block(stmt, _).
 
 // Inserted statements that didn't exist before
+TAC_Statement_OriginalStatementList(irstmt, [stmt_nexthead, nil]),
 TAC_Statement_OriginalStatement(irstmt, stmt_nexthead) :-
   Statement_IRStatement(stmt, _, irstmt),
   !preTrans.Statement_Block(stmt, _), // didn't exist
@@ -294,7 +308,7 @@ TAC_Statement_OriginalStatement(irstmt, stmt_nexthead) :-
   Block_IRBlock(block_next, _, irblock_next),
   stmt_nexthead = as(block_next, Statement).
 
-.output TAC_Statement_OriginalStatement
+.output TAC_Statement_OriginalStatement, TAC_Statement_OriginalStatementList
 
 .decl TAC_OriginalStatement_Block(original_stmt: Statement, irblock: IRBlock)
 .output TAC_OriginalStatement_Block


### PR DESCRIPTION
Introduced a few different ways to better map from our TAC statements to source:
* Added relation `.decl Statement_OriginalStatementList(irstmt: Statement, stmtList: OriginalStatementList)` that maps TAC statements to sequences of call-sites in the original bytecode. This accounts for inlined functions.
* Defined a new type `.type CallStack = [callerBlock: Block, rest: CallStack]` and computed the different ways a function can be reachable from a public entry point in `.decl FunctionReachableFromPublic(function: Function, selector: symbol, callStack: CallStack)`. CallStack can be converted to OriginalStatementList for mapping to bytecode.

In addition, the Flows components APIs were changed, moving from defining `TransferOp(op: Opcode)` as input to `TransferStmt(stmt: Statement)`. This allows us to define more fine-grained data-flow analyses as demonstrated in `constantOpFlows`.