### PR TITLE
All analysis binaries are now stored in cache

### DIFF
--- a/gigahorse.py
+++ b/gigahorse.py
@@ -290,16 +290,22 @@ def get_souffle_macros():
 
     return souffle_macros
 
+def get_souffle_executable_path(dl_filename):
+    executable_filename = os.path.basename(dl_filename) + SOUFFLE_COMPILED_SUFFIX
+    executable_path = join(args.cache_dir, executable_filename)
+    return executable_path
+
 def write_context_depth_file(filename, max_context_depth):
     context_depth_file = open(filename, "w")
     context_depth_file.write(f"{max_context_depth}\n")
     context_depth_file.close()
 
-def compile_datalog(spec, executable):
-    if args.reuse_datalog_bin and os.path.isfile(executable):
-        return
-
+def compile_datalog(spec):
     pathlib.Path(args.cache_dir).mkdir(exist_ok=True)
+    executable_path = get_souffle_executable_path(spec)
+
+    if args.reuse_datalog_bin and os.path.isfile(executable_path):
+        return
 
     souffle_macros = get_souffle_macros()
 
@@ -326,7 +332,7 @@ def compile_datalog(spec, executable):
         process = subprocess.run(compilation_command, universal_newlines=True, env = souffle_env)
         assert not(process.returncode), "Compilation failed. Stopping."
 
-    shutil.copy2(cache_path, executable)
+    shutil.copy2(cache_path, executable_path)
 
 
     
@@ -358,7 +364,7 @@ def analyze_contract(job_index: int, index: int, contract_filename: str, result_
         for souffle_client in souffle_clients:
             if not args.interpreted:
                 analysis_args = [
-                    join(os.getcwd(), souffle_client+SOUFFLE_COMPILED_SUFFIX),
+                    get_souffle_executable_path(souffle_client),
                     f"--facts={in_dir}", f"--output={out_dir}"
                 ]
             else:
@@ -598,16 +604,16 @@ logging.basicConfig(format='%(message)s', level=log_level)
 
 # Here we compile the decompiler and any of its clients in parallel :)
 compile_processes_args = []
-compile_processes_args.append((DEFAULT_DECOMPILER_DL, DEFAULT_DECOMPILER_DL+SOUFFLE_COMPILED_SUFFIX))
+compile_processes_args.append([DEFAULT_DECOMPILER_DL])
 
 if not args.disable_scalable_fallback:
-    compile_processes_args.append((FALLBACK_SCALABLE_DECOMPILER_DL, FALLBACK_SCALABLE_DECOMPILER_DL+SOUFFLE_COMPILED_SUFFIX))
+    compile_processes_args.append([FALLBACK_SCALABLE_DECOMPILER_DL])
 
 if not args.disable_inline:
-    compile_processes_args.append((DEFAULT_INLINER_DL, DEFAULT_INLINER_DL+SOUFFLE_COMPILED_SUFFIX))
+    compile_processes_args.append([DEFAULT_INLINER_DL])
 
 if not args.disable_precise_fallback:
-    compile_processes_args.append((FALLBACK_PRECISE_DECOMPILER_DL, FALLBACK_PRECISE_DECOMPILER_DL+SOUFFLE_COMPILED_SUFFIX))
+    compile_processes_args.append([FALLBACK_PRECISE_DECOMPILER_DL])
 
 clients_split = [a.strip() for a in args.client.split(',')]
 souffle_clients = [a for a in clients_split if a.endswith('.dl')]
@@ -619,10 +625,10 @@ other_pre_clients = [a for a in pre_clients_split if not (a.endswith('.dl') or a
 
 if not args.interpreted:
     for c in souffle_pre_clients:
-        compile_processes_args.append((c, c+SOUFFLE_COMPILED_SUFFIX))
+        compile_processes_args.append([c])
 
     for c in souffle_clients:
-        compile_processes_args.append((c, c+SOUFFLE_COMPILED_SUFFIX))
+        compile_processes_args.append([c])
 
     running_processes = []
     for compile_args in compile_processes_args:
@@ -639,8 +645,8 @@ if not args.interpreted:
         p.join()
 
     # check all programs have been compiled
-    for _, v in compile_processes_args:
-        open(v, 'r') # check program exists
+    for compile_args in compile_processes_args:
+        open(get_souffle_executable_path(compile_args[0]), 'r') # check program exists
 
 # Extract contract filenames.
 log("Processing contract names.")


### PR DESCRIPTION
Use the cache directory for all analysis binaries in order to better support multiple runs of `gigahorse.py` running at the same time.