### PR TITLE
Small fixes to improve results for bytecode generated using the `--via-ir` pipeline

### DIFF
--- a/clientlib/memory_modeling/uses_defs_abstractions.dl
+++ b/clientlib/memory_modeling/uses_defs_abstractions.dl
@@ -343,6 +343,7 @@ ABIEncodedArrayWFunctionSelector(abiArr):-
   ABIEncodedArrayVar_ClassRep(abiArrVar, abiArr).
 
 StatementUsesMemory_ActualMemoryArg(stmt, kind, index, actual):-
+  StatementUsesMemoryReadsABIEnc(stmt, _),
   StatementUsesMemory_StartVar(stmt, kind, abiArrVar),
   ABIEncodedArrayVar_ClassRep(abiArrVar, abiArrRep),
   ABIEncodedArrayNoFunctionSelector(abiArrRep),
@@ -351,6 +352,7 @@ StatementUsesMemory_ActualMemoryArg(stmt, kind, index, actual):-
   index = relativeIndex/32.
 
 StatementUsesMemory_ActualMemoryArg(stmt, kind, index, actual):-
+  StatementUsesMemoryReadsABIEncWSelector(stmt, _),
   StatementUsesMemory_StartVar(stmt, kind, abiArrVar),
   ABIEncodedArrayVar_ClassRep(abiArrVar, abiArrRep),
   ABIEncodedArrayWFunctionSelector(abiArrRep),
@@ -359,6 +361,7 @@ StatementUsesMemory_ActualMemoryArg(stmt, kind, index, actual):-
   index = 1 + relativeIndex/32.
 
 StatementUsesMemory_ActualMemoryArg(stmt, kind, 0, actual):-
+  StatementUsesMemoryReadsABIEncWSelector(stmt, _),
   StatementUsesMemory_StartVar(stmt, kind, abiArrVar),
   ABIEncodedArrayVar_ClassRep(abiArrVar, abiArrRep),
   ABIEncodedArrayWFunctionSelector(abiArrRep),

--- a/logic/decompiler_output.dl
+++ b/logic/decompiler_output.dl
@@ -96,6 +96,25 @@ TAC_Variable_Value(as(tacvar, TACVariable), value) :-
    postTrans.Variable_Value(var, value),
    STARTSWITH(value, "0x").
 
+/**
+  __HACK__ to get around the patterns produced by the new `--via-ir` compilation pipeline.
+  These patterns will pass arguments to public functions (in the function selector code) the same way
+  they are passed to private functions. These are often constants used all over the place.
+*/
+.decl PublicFunctionFormalIsConstant(irFunc: IRFunction, formal: TACVariable, value: symbol)
+
+PublicFunctionFormalIsConstant(publicFunc, formalArg, value):-
+  IRPublicFunction(publicFunc, _),
+  FormalArgs(publicFunc, formalArg, n),
+  IRFunctionCall(fromIrBlock, publicFunc),
+  IRBasicBlock_Tail(fromIrBlock, callStmt),
+  TAC_Use(callStmt, actualArg, n + 1),
+  TAC_Variable_Value(actualArg, value),
+  1 = count : IRFunctionCall(_, publicFunc).
+
+TAC_Variable_Value(formalArg, value):-
+  PublicFunctionFormalIsConstant(_, formalArg, value).
+
 // New Instructions
 // *returnArgs = CALLPRIVATE(stmt, function, *args)
 // RETURNPRIVATE(stmt, *args)

--- a/logic/functions.dl
+++ b/logic/functions.dl
@@ -419,14 +419,21 @@ IRInFunction(irblock, irFunc) :-
 // Now let's settle the edges of the graph: which
 // block is connected to which next one.
 
-.decl IRFunction_Return_Edge(block: IRBlock, next: IRBlock)
+
+/**
+  Contains the (callee-side) return block `ret` of __private__ function `fn`
+*/
 .decl IRFunction_Return(fn: IRFunction, ret: IRBlock)
+
+/**
+  Block `caller` makes a call to __private__ function `func`, with control-flow resuming to
+  the caller-side block `retcaller`.
+*/
 .decl IRFunctionCallReturn(caller: IRBlock, func: IRFunction, retcaller: IRBlock)
 
 // Be strict in our precision demands for recognizing a call
 IRFunction_Return(irfunc, retir),
-IRFunctionCallReturn(callerir, irfunc, callerretir),
-IRFunction_Return_Edge(retir, callerretir) :-
+IRFunctionCallReturn(callerir, irfunc, callerretir):-
   IsFunctionCallReturn(ctx, caller, func, _, ret, callerret), //REVIEW: take advantage of retCtx
   MaybeInFunctionUnderContext(ctx, caller, prevfunc),
   Block_IRBlock(ret, func, retir),
@@ -436,10 +443,10 @@ IRFunction_Return_Edge(retir, callerretir) :-
   //!BlockToClone(func, prevfunc).
 
 
-// REVIEW: IRFunctionCall will include the IRFunctionCallReturn
-// edges, i.e., the fully resolved calls, all the way to returns
-// to the same caller function. Seems later stages can handle this?
-
+/**
+  `IRFunctionCall` includes the results of `IRFunctionCallReturn` (__private__ function calls).  
+  In addition it includes the "calls" to the contract's own __public__ functions inside the function selector.
+*/
 .decl IRFunctionCall(from: IRBlock, func: IRFunction)
 
 IRFunctionCall(callerir, irfunc) :-


### PR DESCRIPTION
The `--via-ir` pipeline allows for much deeper optimizations to be performed, it will require a lot of work to improve our output for it.
This PR includes a couple of small improvements:
* Constant propagation for "private" arguments to public functions.
* Making some memory argument inference rules more strict, to prevent spurious argument inference.

I benchmarked the changes on a dataset of 372 smart contracts compiled with solc 0.8.17 using `--via-ir`:

```
ANALYTIC: Analytics_NonModeledMSTORE
config1: 38985
config2: 24964
config1(both): 38347
config2(both): 24454

ANALYTIC: Analytics_NonModeledSSTORE
config1: 3166
config2: 1842
config1(both): 2882
config2(both): 1634

ANALYTIC: Analytics_PublicFunctionArrayArg
config1: 1275
config2: 1627
config1(both): 1233
config2(both): 1585

ANALYTIC: Analytics_NonModeledMLOAD
config1: 17944
config2: 13625
config1(both): 17484
config2(both): 13165

ANALYTIC: Analytics_NonModeledSLOAD
config1: 5839
config2: 2768
config1(both): 5520
config2(both): 2528

ANALYTIC: Analytics_PublicFunctionArg
config1: 10247
config2: 10861
config1(both): 10058
config2(both): 10672
```
