### PR TITLE
Better dead code reporting via `Analytics_UnreachableBlock`

### DIFF
--- a/logic/decompiler_analytics.dl
+++ b/logic/decompiler_analytics.dl
@@ -35,6 +35,27 @@ Analytics_Jumps(block) :-
 .decl Analytics_BlockHasNoTACBlock(block: Block)
 .output Analytics_BlockHasNoTACBlock
 
+// Blocks that are data
+.decl BlockIsData(block: Block)
+
+// Blocks with MISSING opcode are data
+BlockIsData(block):-
+  revertCloner.analysis.Statement_Block(stmt, block),
+  revertCloner.analysis.Statement_Opcode(stmt, "MISSING").
+
+// OriginalBlockIsData(block):-
+//   postTrans.Statement_Block(stmt, block),
+//   postTrans.Statement_Opcode(stmt, "CREATE").
+
+.decl Analytics_JUMPDESTNeverPushed(block: Block)
+.output Analytics_JUMPDESTNeverPushed
+
+Analytics_JUMPDESTNeverPushed(block):-
+  revertCloner.analysis.Statement_Opcode(stmt, "JUMPDEST"),
+  revertCloner.analysis.Statement_Block(stmt, block),
+  !revertCloner.BlockPushedToStack(_, _, block),
+  !BlockIsData(block).
+
 #ifdef BLOCK_CLONING
 
 Analytics_ReachableBlocks(originalBlock):-
@@ -45,6 +66,7 @@ Analytics_ReachableBlocks(originalBlock):-
 Analytics_UnreachableBlock(originalBlock):-
   postTrans.Statement_Block(_, block),
   blockCloner.Block_OriginalBlock(block, originalBlock),
+  !BlockIsData(originalBlock),
   !Analytics_ReachableBlocks(originalBlock).
 
 Analytics_ReachableBlocksInTAC(originalBlock):-
@@ -67,6 +89,7 @@ Analytics_ReachableBlocks(originalBlock):-
 Analytics_UnreachableBlock(originalBlock):-
   postTrans.Statement_Block(_, block),
   revertCloner.Block_OriginalBlock(block, originalBlock),
+  !BlockIsData(originalBlock),
   !Analytics_ReachableBlocks(originalBlock).
 
 Analytics_ReachableBlocksInTAC(originalBlock):-

--- a/logic/decompiler_analytics.dl
+++ b/logic/decompiler_analytics.dl
@@ -43,9 +43,11 @@ BlockIsData(block):-
   revertCloner.analysis.Statement_Block(stmt, block),
   revertCloner.analysis.Statement_Opcode(stmt, "MISSING").
 
-// OriginalBlockIsData(block):-
-//   postTrans.Statement_Block(stmt, block),
-//   postTrans.Statement_Opcode(stmt, "CREATE").
+BlockIsData(block):-
+  revertCloner.analysis.CODECOPYStatement(_, codeOffsetNumHex, smallNumHex),
+  revertCloner.analysis.Statement_Block(_, block),
+  @lt_256(codeOffsetNumHex, block) = "0x1",
+  @lt_256(block, @add_256(codeOffsetNumHex, smallNumHex)) = "0x1".
 
 .decl Analytics_JUMPDESTNeverPushed(block: Block)
 .output Analytics_JUMPDESTNeverPushed

--- a/tests/memory-modeling/arrays/0117c9ec55e2ac580fa9c9b1c2d1fff9.json
+++ b/tests/memory-modeling/arrays/0117c9ec55e2ac580fa9c9b1c2d1fff9.json
@@ -1,7 +1,7 @@
 {
     "client_path": null,
     "gigahorse_args": ["-i", "--disable_scalable_fallback"],
-    "expected_analytics": [["Analytics_JumpToMany", 1, 0], ["Analytics_UnreachableBlock", 1, 0],
+    "expected_analytics": [["Analytics_JumpToMany", 1, 0], ["Analytics_UnreachableBlock", 0, 0],
     ["Analytics_BlockHasNoTACBlock", 0, 0], ["Analytics_StmtMissingOperand", 0, 0],
     ["Analytics_NonModeledMLOAD", 0, 0],["Analytics_NonModeledMSTORE", 2, 0]]
 }


### PR DESCRIPTION
`Analytics_UnreachableBlock` now tries to disregard data blocks. To report more precise numbers for dead code. 