### PR TITLE
Add support for PUSH0 (EIP-3855), to be added with the Shangai fork

### DIFF
--- a/logic/decompiler_input_opcodes.dl
+++ b/logic/decompiler_input_opcodes.dl
@@ -247,6 +247,7 @@ OpcodeLogLen("PC", 0).
 OpcodeLogLen("MSIZE", 0).
 OpcodeLogLen("GAS", 0).
 OpcodeLogLen("JUMPDEST", 0).
+OpcodeLogLen("PUSH0", 0).
 OpcodeLogLen("PUSH1", 0).
 OpcodeLogLen("PUSH2", 0).
 OpcodeLogLen("PUSH3", 0).
@@ -398,6 +399,7 @@ OpcodePushLen("PC", 0).
 OpcodePushLen("MSIZE", 0).
 OpcodePushLen("GAS", 0).
 OpcodePushLen("JUMPDEST", 0).
+OpcodePushLen("PUSH0", 0).
 OpcodePushLen("PUSH1", 1).
 OpcodePushLen("PUSH2", 2).
 OpcodePushLen("PUSH3", 3).
@@ -543,6 +545,7 @@ OpcodeStackDelta("PC", 1).
 OpcodeStackDelta("MSIZE", 1).
 OpcodeStackDelta("GAS", 1).
 OpcodeStackDelta("JUMPDEST", 0).
+OpcodeStackDelta("PUSH0", 1).
 OpcodeStackDelta("PUSH1", 1).
 OpcodeStackDelta("PUSH2", 1).
 OpcodeStackDelta("PUSH3", 1).
@@ -688,6 +691,7 @@ OpcodePopWords("PC", 0).
 OpcodePopWords("MSIZE", 0).
 OpcodePopWords("GAS", 0).
 OpcodePopWords("JUMPDEST", 0).
+OpcodePopWords("PUSH0", 0).
 OpcodePopWords("PUSH1", 0).
 OpcodePopWords("PUSH2", 0).
 OpcodePopWords("PUSH3", 0).
@@ -833,6 +837,7 @@ OpcodePushWords("PC", 1).
 OpcodePushWords("MSIZE", 1).
 OpcodePushWords("GAS", 1).
 OpcodePushWords("JUMPDEST", 0).
+OpcodePushWords("PUSH0", 1).
 OpcodePushWords("PUSH1", 1).
 OpcodePushWords("PUSH2", 1).
 OpcodePushWords("PUSH3", 1).
@@ -978,6 +983,7 @@ OpcodeGas("PC", 2).
 OpcodeGas("MSIZE", 2).
 OpcodeGas("GAS", 2).
 OpcodeGas("JUMPDEST", 1).
+OpcodeGas("PUSH0", 2).
 OpcodeGas("PUSH1", 3).
 OpcodeGas("PUSH2", 3).
 OpcodeGas("PUSH3", 3).
@@ -1123,6 +1129,7 @@ OpcodeOrd("PC", 88).
 OpcodeOrd("MSIZE", 89).
 OpcodeOrd("GAS", 90).
 OpcodeOrd("JUMPDEST", 91).
+OpcodeOrd("PUSH0", 95).
 OpcodeOrd("PUSH1", 96).
 OpcodeOrd("PUSH2", 97).
 OpcodeOrd("PUSH3", 98).

--- a/logic/decompiler_input_statements.dl
+++ b/logic/decompiler_input_statements.dl
@@ -177,6 +177,9 @@ GAS(stmt) :- Statement_Opcode(stmt, "GAS").
 .decl JUMPDEST(stmt: Statement)
 JUMPDEST(stmt) :- Statement_Opcode(stmt, "JUMPDEST").
 
+.decl PUSH0(stmt: Statement)
+PUSH0(stmt) :- Statement_Opcode(stmt, "PUSH0").
+
 .decl PUSH1(stmt: Statement, value: Value)
 PUSH1(stmt, value) :- Statement_Opcode(stmt, "PUSH1"), PushValue(stmt, value).
 

--- a/logic/decompiler_output.dl
+++ b/logic/decompiler_output.dl
@@ -138,7 +138,11 @@ TAC_Op(irstmt, op) :-
 
 TAC_Op(irstmt, "CONST") :-
    Statement_IRStatement(stmt, _, irstmt),
-   (postTrans.PushValue(stmt, _) ; postTrans.PC(stmt)).
+   (
+    postTrans.PushValue(stmt, _);
+    postTrans.PC(stmt);
+    postTrans.PUSH0(stmt)
+  ).
 
 TAC_Op(irstmt, "THROW") :-
    Statement_IRStatement(stmt, _, irstmt),

--- a/logic/local.dl
+++ b/logic/local.dl
@@ -330,7 +330,12 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
   Variable_Value(var, value) :-
     PushValue(stmt, value),
     Statement_Defines(stmt, var).
-  
+
+  // Added to the Shanghai fork, EIP-3855
+  Variable_Value(var, "0x0") :-
+    PUSH0(stmt),
+    Statement_Defines(stmt, var).
+
   // Get current program counter
   Variable_Value(var, as(stmt, Value)) :-
     PC(stmt),

--- a/src/opcodes.py
+++ b/src/opcodes.py
@@ -225,6 +225,7 @@ MSIZE    = OpCode("MSIZE",    0x59, 0, 1, 2)
 GAS      = OpCode("GAS",      0x5a, 0, 1, 2)
 JUMPDEST = OpCode("JUMPDEST", 0x5b, 0, 0, 1)
 
+PUSH0  = OpCode("PUSH0",  0x5f, 0, 1, 2)
 PUSH1  = OpCode("PUSH1",  0x60, 0, 1, 3)
 PUSH2  = OpCode("PUSH2",  0x61, 0, 1, 3)
 PUSH3  = OpCode("PUSH3",  0x62, 0, 1, 3)


### PR DESCRIPTION
Added support for the [PUSH0 EVM instruction](https://eips.ethereum.org/EIPS/eip-3855).