### PR TITLE
Souffle2.4 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -102,7 +102,7 @@ jobs:
         run: |
           sudo wget https://souffle-lang.github.io/ppa/souffle-key.public -O /usr/share/keyrings/souffle-archive-keyring.gpg
           echo "deb [signed-by=/usr/share/keyrings/souffle-archive-keyring.gpg] https://souffle-lang.github.io/ppa/ubuntu/ stable main" | sudo tee /etc/apt/sources.list.d/souffle.list
-          sudo apt update && sudo apt install souffle=2.3
+          sudo apt update && sudo apt install souffle=2.4
 
       - name: Test Souffle
         run: souffle --version

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,8 +12,7 @@ env:
 
 
 jobs:
-  test:
-
+  test2.3:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -56,7 +55,69 @@ jobs:
         run: ./gigahorse.py --help
 
       - name: Run gigahorse example
-        run: ./gigahorse.py examples/long_running.hex -i
+        run: ./gigahorse.py examples/long_running.hex -i --disable_inline
+
+      - name: Run tests
+        run: pytest -v test_gigahorse.py --junitxml=test-results.xml
+
+      - name: Upload pytest test results
+        uses: actions/upload-artifact@v3
+        with:
+          name: pytest-results
+          path: test-results.xml
+        # Use always() to always run this step to publish test results when there are test failures
+        if: ${{ always() }}
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: test-results.xml
+
+  test2.4:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      checks: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.7"
+
+      - name: Install pytest
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+
+      - name: Install Souffle
+        run: |
+          sudo wget https://souffle-lang.github.io/ppa/souffle-key.public -O /usr/share/keyrings/souffle-archive-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/souffle-archive-keyring.gpg] https://souffle-lang.github.io/ppa/ubuntu/ stable main" | sudo tee /etc/apt/sources.list.d/souffle.list
+          sudo apt update && sudo apt install souffle=2.3
+
+      - name: Test Souffle
+        run: souffle --version
+
+      - name: Install Boost
+        run: sudo apt install libboost-all-dev
+
+      - name: Build Souffle addon
+        run: cd $GITHUB_WORKSPACE/souffle-addon && make && cd $GITHUB_WORKSPACE
+
+      - name: Run gigahorse help
+        run: ./gigahorse.py --help
+
+      - name: Run gigahorse example
+        run: ./gigahorse.py examples/long_running.hex -i --disable_inline
 
       - name: Run tests
         run: pytest -v test_gigahorse.py --junitxml=test-results.xml

--- a/gigahorse.py
+++ b/gigahorse.py
@@ -184,6 +184,7 @@ parser.add_argument("-cd",
                     "--context_depth",
                     type=int,
                     nargs="?",
+                    default=8,
                     metavar="NUM",
                     help="Override the maximum context depth for decompilation (default is 8).")
 
@@ -485,8 +486,7 @@ def analyze_contract(job_index: int, index: int, contract_filename: str, result_
                 # pre clients should be very light, should never happen
                 raise TimeoutException()
 
-            if args.context_depth is not None:
-                write_context_depth_file(os.path.join(work_dir, 'MaxContextDepth.csv'), args.context_depth)
+            write_context_depth_file(os.path.join(work_dir, 'MaxContextDepth.csv'), args.context_depth)
 
             decomp_start = time.time()
 

--- a/gigahorse.py
+++ b/gigahorse.py
@@ -184,7 +184,6 @@ parser.add_argument("-cd",
                     "--context_depth",
                     type=int,
                     nargs="?",
-                    default=8,
                     metavar="NUM",
                     help="Override the maximum context depth for decompilation (default is 8).")
 
@@ -304,9 +303,10 @@ def get_souffle_executable_path(dl_filename):
     executable_path = join(args.cache_dir, executable_filename)
     return executable_path
 
-def write_context_depth_file(filename, max_context_depth):
+def write_context_depth_file(filename, max_context_depth=None):
     context_depth_file = open(filename, "w")
-    context_depth_file.write(f"{max_context_depth}\n")
+    if max_context_depth is not None:
+        context_depth_file.write(f"{max_context_depth}\n")
     context_depth_file.close()
 
 def compile_datalog(spec):

--- a/tests/context-sensitivity/finite-precise.json
+++ b/tests/context-sensitivity/finite-precise.json
@@ -1,6 +1,6 @@
 {
     "client_path": null,
-    "gigahorse_args": ["-i", "--disable_scalable_fallback", "--disable_precise_fallback", "--disable_inline", "-M", "CONTEXT_SENSITIVITY=FinitePreciseContext"],
+    "gigahorse_args": ["-i", "--disable_scalable_fallback", "--disable_precise_fallback", "--disable_inline", "-M", "CONTEXT_SENSITIVITY=FinitePreciseContext", "-cd", "27"],
     "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 5, 0],
     ["Analytics_BlockHasNoTACBlock", 0, 0]]
 }

--- a/tests/context-sensitivity/finite-precise.json
+++ b/tests/context-sensitivity/finite-precise.json
@@ -1,6 +1,6 @@
 {
     "client_path": null,
-    "gigahorse_args": ["-i", "--disable_scalable_fallback", "--disable_precise_fallback", "--disable_inline", "-M", "CONTEXT_SENSITIVITY=FinitePreciseContext", "-cd", "27"],
+    "gigahorse_args": ["-i", "--disable_scalable_fallback", "--disable_precise_fallback", "--disable_inline", "-M", "CONTEXT_SENSITIVITY=FinitePreciseContext"],
     "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 5, 0],
     ["Analytics_BlockHasNoTACBlock", 0, 0]]
 }


### PR DESCRIPTION
Souffle 2.4 has changes in the way CSV inputs work. This changes the conditional input pattern we use for the max context depth in our context sensitivity algorithms:

```
  .decl InputMaxContextDepth(d: number)
  .input InputMaxContextDepth(filename="MaxContextDepth.csv")

  MaxContextDepth(sigHash, d) :-
    (local.PublicFunction(_, sigHash);
     sigHash = FALLBACK_FUNCTION_SIGHASH),
    InputMaxContextDepth(d).


  MaxContextDepth(sigHash, 8) :-
    (local.PublicFunction(_, sigHash);
     sigHash = FALLBACK_FUNCTION_SIGHASH),
    !InputMaxContextDepth(_).
```
It used to not require the input file to exist. For souffle 2.4 the input file has to exist.