### PR TITLE
Get m1 docker to build.

### DIFF
--- a/docker/mac/Dockerfile
+++ b/docker/mac/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 
 # Install some essentials
-RUN apt-get update && apt-get upgrade && apt-get install -y libboost-all-dev 
+RUN apt-get update && apt-get upgrade -y && apt-get install -y libboost-all-dev 
 
 # Install python3
 RUN apt-get install python3-dev python3-pip -y


### PR DESCRIPTION
Don't know if it works, since it uses souffle 2.2. Will need to obtain an upgraded souffle binary.