### PR TITLE
Add missing plans for `TruncateContextIfNeeded`

### DIFF
--- a/logic/context-sensitivity/abstract_context.dl
+++ b/logic/context-sensitivity/abstract_context.dl
@@ -240,13 +240,14 @@
     PrivateContextDepth(ctx, maxDepth),
     MaxContextDepth(pubFun, maxDepth),
     DropLast(ctx, newCtx).
-    .plan 1:(4,1,2,3)
+    .plan 1:(2,1,3,4),2:(4,1,2,3)
 
   TruncateContextIfNeeded(pubFun, ctx, ctx):-
     DecomposeContext(_, pubFun, ctx),
     PrivateContextDepth(ctx, depth),
     MaxContextDepth(pubFun, maxDepth),
     depth < maxDepth.
+    .plan 1:(2,1,3)
 
   Context_PublicFunction(ctx, pubFun):-
     ReachableContext(ctx, _),


### PR DESCRIPTION
Added some missing plans.
Decompilation time on 1000 contracts compiled using `--via-ir`:
```
master: 6071.2163071632385
branch: 4674.224877357483
```