### PR TITLE
Minor change in transactional

### DIFF
--- a/logic/context-sensitivity/transactional_context.dl
+++ b/logic/context-sensitivity/transactional_context.dl
@@ -24,6 +24,8 @@
     local.Variable_Value(var, val),
     local.Statement_Defines(stmt, var),
     local.Statement_Block(stmt, block),
+    local.BasicBlock_Tail(block, tail),
+    local.LocalStackContents(tail, _, var), // variable escapes the block
     !BlockUsesLocal(block, var).
 
   // We're only interested in private functions


### PR DESCRIPTION
Ensure possible `BlockPushesLabel` var escapes the block.
This makes no change in current master but helps with optimizations we may want to enable soon.