### PR TITLE
Slightly stricter `BlockPushesLabel`

### DIFF
--- a/logic/local.dl
+++ b/logic/local.dl
@@ -562,8 +562,8 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
     Statement_Defines(stmt, var),
     Statement_Block(stmt, block),
     BasicBlock_Tail(block, call),
-    LocalStackContents(call, _, var),
-    !BlockUsesLocal(block, var).
+    LocalStackContents(call, _, var).
+    // !BlockUsesLocal(block, var).
 
   // Same reasoning, with more detail. In very rare cases, the continuation will not be found,
   // even though BlockPushesLabel is true.
@@ -575,8 +575,8 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
     CheckIsVariable(var), // unnecessary?
     Variable_Value(var, contVal),
     JUMPDEST(as(contVal, symbol)), // unnecessary?
-    index > 0,
-    !BlockUsesLocal(caller, var). 
+    index > 0.
+    // !BlockUsesLocal(caller, var). 
  
   .decl CallBlockNotEarliestContinuation(caller: Block, callee: Block, cont: Block)
   CallBlockNotEarliestContinuation(caller, callee, cont) :-

--- a/logic/local.dl
+++ b/logic/local.dl
@@ -561,6 +561,8 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
     Variable_Value(var, val),
     Statement_Defines(stmt, var),
     Statement_Block(stmt, block),
+    BasicBlock_Tail(block, call),
+    LocalStackContents(call, _, var),
     !BlockUsesLocal(block, var).
 
   // Same reasoning, with more detail. In very rare cases, the continuation will not be found,

--- a/logic/local.dl
+++ b/logic/local.dl
@@ -562,8 +562,8 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
     Statement_Defines(stmt, var),
     Statement_Block(stmt, block),
     BasicBlock_Tail(block, call),
-    LocalStackContents(call, _, var).
-    // !BlockUsesLocal(block, var).
+    LocalStackContents(call, _, var),
+    !BlockUsesLocal(block, var).
 
   // Same reasoning, with more detail. In very rare cases, the continuation will not be found,
   // even though BlockPushesLabel is true.
@@ -575,8 +575,8 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
     CheckIsVariable(var), // unnecessary?
     Variable_Value(var, contVal),
     JUMPDEST(as(contVal, symbol)), // unnecessary?
-    index > 0.
-    // !BlockUsesLocal(caller, var). 
+    index > 0,
+    !BlockUsesLocal(caller, var). 
  
   .decl CallBlockNotEarliestContinuation(caller: Block, callee: Block, cont: Block)
   CallBlockNotEarliestContinuation(caller, callee, cont) :-

--- a/logic/statement_insertor.dl
+++ b/logic/statement_insertor.dl
@@ -506,15 +506,11 @@ INITIALIZE_STATEMENT_INSERTOR(_insertor, to)
   .override BlockCloningCandidate
 
   .decl PossibleCallerWithReturn(caller: Block, return: Block)
-  PossibleCallerWithReturn(caller, as(val, Block)):-
+  PossibleCallerWithReturn(caller, as(return, Block)):-
     analysis.ImmediateBlockJumpTarget(caller, targetVar),
     analysis.Variable_Value(targetVar, target),
     analysis.JUMPDEST(as(target, symbol)),
-    analysis.Statement_Block(stmt, caller),
-    analysis.Statement_Defines(stmt, var),
-    analysis.Variable_Value(var, val),
-    analysis.JUMPDEST(as(val, symbol)),
-    !analysis.Statement_Uses_Local(_, var, _).
+    analysis.BlockPushesLabel(caller, return).
 
   // SL: Too general, causes slowdown
   BlockCloningCandidate(candidate):-


### PR DESCRIPTION
Minor change to `BlockPushesLabel`. Make sure label escapes the block. Minor improvement for the global analysis. 