### PR TITLE
Various small memory modeling improvements

### DIFF
--- a/clientlib/function_inliner.dl
+++ b/clientlib/function_inliner.dl
@@ -571,17 +571,21 @@
     ( LocalFlows(loaded, formalRet);
       LocalFlows(formalArg, formalRet)),
     In_FormalReturnArgs(fun, formalRet, _),
+    !Struct_WordWidth(formalArg, _),
+    // !Struct_WordWidth(formalRet, _),
     !VarIsArray(formalArg, _).
 
   InlineCandidate(fun):-
     MLOADFreePtr_To(_, loadedAddr),
     In_FormalReturnArgs(fun, loadedAddr, _),
+    !Struct_WordWidth(loadedAddr, _),
     !VarIsArray(loadedAddr, _).
 
   InlineCandidate(fun):-
     In_FormalArgs(fun, formalArg, _),
     LocalFlows(formalArg, storeAddr),
     MSTORE(_, storeAddr, _),
+    !Struct_WordWidth(formalArg, _),
     !VarIsArray(formalArg, _).
 
   .decl FunctionContainsExternalCall(fun:Function)

--- a/clientlib/loops.dl
+++ b/clientlib/loops.dl
@@ -43,7 +43,9 @@ InnermostStructuredLoop(loophead) :-
 
 // condVar determines whether a loop is exited
 .decl LoopExitCond(condVar: Variable, loop: Block)
-.decl TrueLoopExitCond(condVar: Variable, loop: Block, if_head: Block)
+.decl LoopExitCondPredicateTrue(condVar: Variable, loop: Block, if_head: Block)
+.decl LoopExitCondPredicateFalse(condVar: Variable, loop: Block, if_head: Block)
+
 // control flows to other block within the same function
 // TODO: need more info on consequent and alternative branches
 LoopExitCond(condVar, loop) :-
@@ -56,13 +58,22 @@ LoopExitCond(condVar, loop) :-
    BlockInStructuredLoop(in, loop).
 
 
-TrueLoopExitCond(condVar, loop, jmpiBlock) :-
+LoopExitCondPredicateTrue(condVar, loop, jmpiBlock) :-
    BlockInStructuredLoop(jmpiBlock, loop),
    Block_Tail(jmpiBlock, jmpi),
    JUMPI(jmpi, _, condVar),
    LocalBlockEdge(jmpiBlock, out),
    !BlockInStructuredLoop(out, loop),
    FallthroughEdge(jmpiBlock, in),
+   BlockInStructuredLoop(in, loop).
+
+LoopExitCondPredicateFalse(condVar, loop, jmpiBlock) :-
+   BlockInStructuredLoop(jmpiBlock, loop),
+   Block_Tail(jmpiBlock, jmpi),
+   JUMPI(jmpi, _, condVar),
+   FallthroughEdge(jmpiBlock, out),
+   !BlockInStructuredLoop(out, loop),
+   LocalBlockEdge(jmpiBlock, in),
    BlockInStructuredLoop(in, loop).
 
 

--- a/clientlib/loops_semantics.dl
+++ b/clientlib/loops_semantics.dl
@@ -156,24 +156,42 @@ InductionVariableStartsAtConst(loop, [beforeLoopVar, inLoopVar], const):-
   BasicVariable_Value(beforeLoopVar, const).
 
 InductionVariableLowerBoundVar(loop, [beforeLoopVar, inLoopVar], boundVar):-
-  LoopExitCond(condVar, loop),
+  LoopExitCondPredicateTrue(condVar, loop, _),
   WellFormedLoopInductionVariable(loop, _, [beforeLoopVar, inLoopVar]),
   PHIStmtTwoUses(_, beforeLoopVar, inLoopVar, phiVar),
   LT(_, phiVar, boundVar, condVar).
 
-InductionVariableUpperBoundVar(loop, [beforeLoopVar, inLoopVar], boundVar):-
-  LoopExitCond(condVar, loop),
+InductionVariableLowerBoundVar(loop, [beforeLoopVar, inLoopVar], boundVar):-
+  LoopExitCondPredicateFalse(condVar, loop, _),
   WellFormedLoopInductionVariable(loop, _, [beforeLoopVar, inLoopVar]),
   PHIStmtTwoUses(_, beforeLoopVar, inLoopVar, phiVar),
   GT(_, phiVar, boundVar, condVar).
 
 InductionVariableUpperBoundVar(loop, [beforeLoopVar, inLoopVar], boundVar):-
-  LoopExitCond(condVar, loop),
+  LoopExitCondPredicateTrue(condVar, loop, _),
+  WellFormedLoopInductionVariable(loop, _, [beforeLoopVar, inLoopVar]),
+  PHIStmtTwoUses(_, beforeLoopVar, inLoopVar, phiVar),
+  GT(_, phiVar, boundVar, condVar).
+
+InductionVariableUpperBoundVar(loop, [beforeLoopVar, inLoopVar], boundVar):-
+  LoopExitCondPredicateFalse(condVar, loop, _),
+  WellFormedLoopInductionVariable(loop, _, [beforeLoopVar, inLoopVar]),
+  PHIStmtTwoUses(_, beforeLoopVar, inLoopVar, phiVar),
+  LT(_, phiVar, boundVar, condVar).
+
+InductionVariableUpperBoundVar(loop, [beforeLoopVar, inLoopVar], boundVar):-
+  LoopExitCondPredicateTrue(condVar, loop, _),
   WellFormedLoopInductionVariable(loop, _, [beforeLoopVar, inLoopVar]),
   PHIStmtTwoUses(_, beforeLoopVar, inLoopVar, phiVar),
   LT(_, phiVar, boundVar, ltVar),
   ISZERO(_, ltVar, condVar).
 
+InductionVariableUpperBoundVar(loop, [beforeLoopVar, inLoopVar], boundVar):-
+  LoopExitCondPredicateFalse(condVar, loop, _),
+  WellFormedLoopInductionVariable(loop, _, [beforeLoopVar, inLoopVar]),
+  PHIStmtTwoUses(_, beforeLoopVar, inLoopVar, phiVar),
+  GT(_, phiVar, boundVar, gtVar),
+  ISZERO(_, gtVar, condVar).
 
 
 .decl VariableDefinedInLoopUsedAfter(loop: Block, variable: Variable, useStmt: Statement)

--- a/clientlib/memory_modeling/arrays.dl
+++ b/clientlib/memory_modeling/arrays.dl
@@ -95,7 +95,7 @@ Array_ElementLength(array, elementSize):-
   IsArgCallDataArrayVar(array, _),
   ArrayDataStartVar(array, dataStartVar),
   ADDFix(_, dataStartVar, indexTimesCons, cdlIndex),
-  VarTimesConstant(_, elementSize, indexTimesCons),
+  VarTimesConstantNoIdentity(_, elementSize, indexTimesCons),
   CALLDATALOAD(_, cdlIndex, _).
 
 

--- a/clientlib/memory_modeling/arrays.dl
+++ b/clientlib/memory_modeling/arrays.dl
@@ -107,6 +107,7 @@ ArrayDataStartVar(array, dataStartVar):-
 
 IsRegularArrayVar(memArrayTo),
 Array_ElementLength(memArrayTo, "0x1"),
+Array_ElementLength(callDataArrayFrom, "0x1"),
 CallDataCopyArgInfo(callDataCopy, memArrayTo, callDataArrayFrom):-
   CallDataLoadReadsLength(_, callDataArrayFrom, lenVar),
   CALLDATACOPY(callDataCopy, arrayDataStart, _, lenVar),
@@ -116,6 +117,7 @@ CallDataCopyArgInfo(callDataCopy, memArrayTo, callDataArrayFrom):-
 
 IsRegularArrayVar(memArrayTo),
 Array_ElementLength(memArrayTo, elemSize),
+Array_ElementLength(callDataArrayFrom, elemSize),
 CallDataCopyArgInfo(callDataCopy, memArrayTo, callDataArrayFrom):-
   CallDataLoadReadsLength(_, callDataArrayFrom, lenVar),
   VarTimesConstant(lenVar, elemSize, lenBytes),

--- a/clientlib/memory_modeling/memory_addresses.dl
+++ b/clientlib/memory_modeling/memory_addresses.dl
@@ -211,6 +211,12 @@ FreePointerBasedValue(val, as(formal, Statement), 0, 0):-
   PossibleStructArg(_, _,formal),
   val = cat(cat(formal, "++"), "0").
 
+// SL: HACK here. casting arg to statement.
+Variable_SymbolicValue(actual, val),
+FreePointerBasedValue(val, as(actual, Statement), 0, 0):-
+  PossibleStructRet(_, actual,_),
+  val = cat(cat(actual, "++"), "0").
+
 /**
  The depth is not used to limit the new values being created but to count how
  many times a constant has been added to the value for arg inference.

--- a/clientlib/memory_modeling/metrics.dl
+++ b/clientlib/memory_modeling/metrics.dl
@@ -236,3 +236,19 @@ Verbatim_CDLAllVSStaticVSArr(allnum, staticAddr, arrGet):-
   allnum = count : CALLDATALOAD(_, _, _),
   staticAddr = count : CALLDATALOADOfStaticAddr(_),
   arrGet = count : CALLDATALOADArrayRelated(_).
+
+.decl Analytics_ArrayHasTwoElementLengths(array: Variable)
+.output Analytics_ArrayHasTwoElementLengths
+
+Analytics_ArrayHasTwoElementLengths(array):-
+  Array_ElementLength(array, elementSize1),
+  Array_ElementLength(array, elementSize2),
+  elementSize1 != elementSize2.
+
+.decl Analytics_StructHasTwoWidths(struct: Variable)
+.output Analytics_StructHasTwoWidths
+
+Analytics_StructHasTwoWidths(struct):-
+  Struct_WordWidth(struct, width1),
+  Struct_WordWidth(struct, width2),
+  width1 != width2.

--- a/clientlib/memory_modeling/misc.dl
+++ b/clientlib/memory_modeling/misc.dl
@@ -153,6 +153,7 @@ Variable_Value(to, val):-
   Statement_Block(store, storeBlock),
   Statement_Block(load, loadBlock),
   Dominates(storeBlock, loadBlock),
+  storeBlock != loadBlock,
   Variable_Value(from, val).
 
 /**

--- a/clientlib/memory_modeling/structs.dl
+++ b/clientlib/memory_modeling/structs.dl
@@ -71,10 +71,29 @@ InitialStoreToPossibleStruct(mstore, structBaseVar, storedVar, memOffset / 32):-
 ProbablyConstantArray(probablyArrayVar):-
   PossibleStructAllocation(_, _, probablyArrayVar, _),
   stores =  count : InitialStoreToPossibleStruct(_, probablyArrayVar, _, _),
+  stores > 0,
   stores =  count : {
     InitialStoreToPossibleStruct(_, probablyArrayVar, storedVar, _),
     BasicVariable_Value(storedVar, _)
   }.
+
+/**
+  Memory bounds check for struct allocations
+  Present in code produced by the viaIR pipeline
+*/
+.decl StructAllocationCheck(structBase: Variable)
+DEBUG_OUTPUT(StructAllocationCheck)
+
+StructAllocationCheck(structBase):-
+  PossibleStructAllocation(_, freePtrUpdStore, structBase, _),
+  MSTORE(freePtrUpdStore, _, storedVar),
+  LT(_, storedVar, structBase, pt1),
+  GT(_, storedVar, memLimitVar, pt2),
+  Variable_Value(memLimitVar, "0xffffffffffffffff"),
+  (OR(_, pt1, pt2, condVar); OR(_, pt2, pt1, condVar)),
+  JUMPI(jmpi, _, condVar),
+  ControlsWith(jmpi, throwBlock, condVar),
+  ThrowBlock(throwBlock).
 
 // REVIEW: it requires at least as many InitialStoreToPossibleStruct as the struct's words
 // it may possibly not be the case in optimized code
@@ -83,6 +102,13 @@ ProbablyConstantArray(probablyArrayVar):-
 StructAllocation(freePtrUpdStore, structBaseVar, wordWidth):-
   PossibleStructAllocation(_, freePtrUpdStore, structBaseVar, wordWidth),
   wordWidth >= count : InitialStoreToPossibleStruct(_, structBaseVar, _, _),
+  DataFlows(structBaseVar, argOrRet),
+  (ActualArgs(_, argOrRet, _) ; ActualReturnArgs(_, argOrRet, _)),
+  !ProbablyConstantArray(structBaseVar).
+
+StructAllocation(freePtrUpdStore, structBaseVar, wordWidth):-
+  PossibleStructAllocation(_, freePtrUpdStore, structBaseVar, wordWidth),
+  StructAllocationCheck(structBaseVar),
   DataFlows(structBaseVar, argOrRet),
   (ActualArgs(_, argOrRet, _) ; ActualReturnArgs(_, argOrRet, _)),
   !ProbablyConstantArray(structBaseVar).
@@ -128,20 +154,46 @@ MemoryModelingTempStmt(mstore):-
   StructAllocation(mstore, _, _).
 
 /**
-  PossibleStructArg is used to add new symbolic values for memory addresses to the formal variables
-  TODO: Add the same for returns
+  Hack to model structs passed through function args/rets
+*/
+.decl PossibleStruct(structVar: Variable)
+DEBUG_OUTPUT(PossibleStruct)
+
+/**
+  PossibleStructArg is used to add new symbolic values for memory addresses to the formal argument variables
 */
 .decl PossibleStructArg(function: Function, actual: Variable, formal: Variable)
 DEBUG_OUTPUT(PossibleStructArg)
 
+/**
+  PossibleStructRet is used to add new symbolic values for memory addresses to the actual return variables
+*/
+.decl PossibleStructRet(function: Function, actual: Variable, formal: Variable)
+DEBUG_OUTPUT(PossibleStructRet)
+
+PossibleStruct(possibleStruct):-
+  PossibleStructAllocation(_, _, possibleStruct, _);
+  PossibleStructRet(_, possibleStruct, _);
+  PossibleStructArg(_, _, possibleStruct).
+
 PossibleStructArg(function, actual, formal):-
   ActualArgs(caller, actual, pos),
-  PossibleStructAllocation(_, _, actual, _),
+  PossibleStruct(actual),
   CallGraphEdge(caller, function),
   FormalArgs(function, formal, pos).
 
+PossibleStructRet(function, actual, formal):-
+  FormalReturnArgs(function, formal, pos),
+  PossibleStruct(formal),
+  CallGraphEdge(caller, function),
+  ActualReturnArgs(caller, actual, pos).
+
+
 .decl StructArg(caller: Block, function: Function, pos: number, actual: Variable, formal: Variable)
 DEBUG_OUTPUT(StructArg)
+
+.decl StructRet(caller: Block, function: Function, pos: number, actual: Variable, formal: Variable)
+DEBUG_OUTPUT(StructRet)
 
 StructArg(caller, function, pos, actual, formal):-
   ActualArgs(caller, actual, pos),
@@ -149,9 +201,19 @@ StructArg(caller, function, pos, actual, formal):-
   CallGraphEdge(caller, function),
   FormalArgs(function, formal, pos).
 
+StructRet(caller, function, pos, actual, formal):-
+  FormalReturnArgs(function, formal, pos),
+  Struct_WordWidth(formal, _),
+  CallGraphEdge(caller, function),
+  ActualReturnArgs(caller, actual, pos).
+
 Struct_WordWidth(formal, wordWidth):-
   StructArg(_, _, _, actual, formal),
   Struct_WordWidth(actual, wordWidth).
+
+Struct_WordWidth(actual, wordWidth):-
+  StructRet(_, _, _, actual, formal),
+  Struct_WordWidth(formal, wordWidth).
 
 StructContainsArray(formal, wordOffset, elementSize):-
   StructArg(_, _, _, actual, formal),


### PR DESCRIPTION
For the dataset of 1600 ir contracts in [viair-june23](https://github.com/sifislag/evm-bytecode-datasets/tree/main/viair-june23):
```
For has_output 1 not detected by config master: {'beb8211f1c7ebabe5078f525b25b9eac'}
For has_output 0 not detected by config branch: set()

ANALYTIC: client_time
master (common): 1465.3665297031403 (+3.72%)
branch (common): 1412.8065841197968

ANALYTIC: Analytics_NonModeledMSTORE
master (common): 153563 (+15.72%)
branch (common): 132702

ANALYTIC: Analytics_NonModeledMLOAD
master (common): 102068 (+4.478%)
branch (common): 97693
```

For the dataset of 2000 large solc0.8 contracts in [solc08-over10k](https://github.com/sifislag/evm-bytecode-datasets/tree/main/solc08-over10k):
```
ANALYTIC: client_time
master (common): 689.9880311489105
branch (common): 692.4097990989685

ANALYTIC: Analytics_NonModeledMSTORE
master (common): 52084 (+10.36%)
branch (common): 47193

ANALYTIC: Analytics_NonModeledMLOAD
master (common): 30825 (+10.01%)
branch (common): 28021
```