### PR TITLE
Switch to relative submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "souffle-addon"]
 	path = souffle-addon
-	url = git@github.com:plast-lab/souffle-addon.git 
+	url = ../../plast-lab/souffle-addon


### PR DESCRIPTION
This allows cloning the project with both the https and git protocols.