### PR TITLE
Fix incompleteness caused by dead code elimination opt

### DIFF
--- a/logic/local.dl
+++ b/logic/local.dl
@@ -872,16 +872,18 @@ insertor.insertOps(jumpi,
   preTrans.JUMPI(jumpi),
   preTrans.FallthroughStmt(jumpi, fallthrough).
 
-// This one removes conditional jumps that "always" jump
-insertor.removeOp(jmpi),
-insertor.insertOps(jmpi,
-  LIST(
-    STMT(SWAP1, ""),
-    STMT(POP, ""),
-    STMT(JUMP, "")
-  )
-) :-
-  preTrans.AlwaysJumps(jmpi).
+// SL: Removed this to get more completeness, especially in cases
+// of non-deployed code with uninitialized immutables
+// // This one removes conditional jumps that "always" jump
+// insertor.removeOp(jmpi),
+// insertor.insertOps(jmpi,
+//   LIST(
+//     STMT(SWAP1, ""),
+//     STMT(POP, ""),
+//     STMT(JUMP, "")
+//   )
+// ) :-
+//   preTrans.AlwaysJumps(jmpi).
 
 insertor.removeOp(codeCopy),
 insertor.removeOp(mload),

--- a/tooling/compare-runs.py
+++ b/tooling/compare-runs.py
@@ -187,7 +187,7 @@ for analytic, kind in analytics.items():
     pref = sorted([result[analytic] for result in results_processed_common], key=analytic_comp[kind])[0]
     for i in range(0, len(result_files)):
         diff = results_processed_common[i][analytic] - pref
-        percentage = 100 * (results_processed_common[i][analytic] - pref)/pref
+        percentage = 100 * (results_processed_common[i][analytic] - pref)/pref if pref > 0 else 0
         extra = f" \x1b[31m({percentage:+.4g}%)\x1b[0m" if diff != 0 else ""
         print(f'{result_files_simple[i]} \033[1m(common)\033[0m: {results_processed_common[i][analytic]}{extra}')
 


### PR DESCRIPTION
Disabled an optimization in a transformation eliminating some dead code (JUMPIs with constant `condVar`, transfromed into JUMPs ). This resulted in incomplete decompilation of non deployed code (uninitiallized immutable vars).