### PR TITLE
Optimize block cloning by cloning per statement instead of per block

### DIFF
--- a/logic/statement_insertor.dl
+++ b/logic/statement_insertor.dl
@@ -281,7 +281,7 @@ INITIALIZE_STATEMENT_INSERTOR(_insertor, to)
     Basic way to compute this would be to only inline blocks for direct jumps
   */
 
-  // Create a new instance of `blockToClone` for its definition in `pushBlock`
+  // Create a new instance of `blockToClone` for its definition in `pushStmt`
   .decl BlockToClone(pushStmt: Statement, blockToClone: Block)
 
   // For each fact of `BlockToClone` we create an identifier (`opID`) and order them based on it
@@ -293,7 +293,7 @@ INITIALIZE_STATEMENT_INSERTOR(_insertor, to)
   */
   .decl BlockToCloneNewInstance(pushStmt: Statement, blockToClone: Block, generatedBlock: Block)
 
-  // `generatedStatement` will be the `stmt` of `blockToClone` when cloned in `pushBlock`
+  // `generatedStatement` will be the `stmt` of `blockToClone` when cloned in `pushStmt`
   .decl StatementToClonedStatement(pushStmt: Statement, blockToClone: Block, stmt: Statement, generatedStatement: Statement)
   DEBUG_OUTPUT(StatementToClonedStatement)
 
@@ -326,9 +326,7 @@ INITIALIZE_STATEMENT_INSERTOR(_insertor, to)
   //Maybe change it to only consider direct block edges again?
   ClonedBlockAddressPushedBy(pushBlock, pushStmt, blockToClone):-
     BlockToClone(pushStmt, blockToClone),
-    BlockPushesBlockToStack(pushBlock, pushStmt, blockToClone),
-    BlockPushedToStack(pushStmt, _, blockToClone), // todo: simplify rule
-    analysis.Statement_Block(pushStmt, pushBlock).
+    BlockPushesBlockToStack(pushBlock, pushStmt, blockToClone).
 
   BlockPushesBlockToStack(block, pushStmt, pushedBlock):-
     BlockPushedToStack(pushStmt, _, pushedBlock),

--- a/logic/statement_insertor.dl
+++ b/logic/statement_insertor.dl
@@ -264,7 +264,7 @@ INITIALIZE_STATEMENT_INSERTOR(_insertor, to)
     to fit their different safety guarantee levels.
   */
   .decl BlockPushedToStack(pushStmt: Statement, pushedVar: Variable, pushedBlock: Block)
-  .decl BlockPushesBlockToStack(from: Block, pushedBlock: Block)
+  .decl BlockPushesBlockToStack(from: Block, pushStmt: Statement, pushedBlock: Block)
 
   /**
     Candidate blocks to be cloned.
@@ -282,19 +282,19 @@ INITIALIZE_STATEMENT_INSERTOR(_insertor, to)
   */
 
   // Create a new instance of `blockToClone` for its definition in `pushBlock`
-  .decl BlockToClone(pushBlock: Block, blockToClone: Block)
+  .decl BlockToClone(pushStmt: Statement, blockToClone: Block)
 
   // For each fact of `BlockToClone` we create an identifier (`opID`) and order them based on it
-  .decl BlockToCloneOpID(pushBlock: Block, blockToClone: Block, opID: symbol)
+  .decl BlockToCloneOpID(pushStmt: Statement, blockToClone: Block, opID: symbol)
 
   /**
     After we compute the order of the inserted clone blocks,
     we assign each cloned instance to a starting bytecode offset (`generatedBlock`).
   */
-  .decl BlockToCloneNewInstance(pushBlock: Block, blockToClone: Block, generatedBlock: Block)
+  .decl BlockToCloneNewInstance(pushStmt: Statement, blockToClone: Block, generatedBlock: Block)
 
   // `generatedStatement` will be the `stmt` of `blockToClone` when cloned in `pushBlock`
-  .decl StatementToClonedStatement(pushBlock: Block, blockToClone: Block, stmt: Statement, generatedStatement: Statement)
+  .decl StatementToClonedStatement(pushStmt: Statement, blockToClone: Block, stmt: Statement, generatedStatement: Statement)
   DEBUG_OUTPUT(StatementToClonedStatement)
 
   .init cloneOpSorter = OrdAscentingSorter
@@ -325,12 +325,12 @@ INITIALIZE_STATEMENT_INSERTOR(_insertor, to)
   
   //Maybe change it to only consider direct block edges again?
   ClonedBlockAddressPushedBy(pushBlock, pushStmt, blockToClone):-
-    BlockToClone(pushBlock, blockToClone),
-    BlockPushesBlockToStack(pushBlock, blockToClone),
-    BlockPushedToStack(pushStmt, _, blockToClone),
+    BlockToClone(pushStmt, blockToClone),
+    BlockPushesBlockToStack(pushBlock, pushStmt, blockToClone),
+    BlockPushedToStack(pushStmt, _, blockToClone), // todo: simplify rule
     analysis.Statement_Block(pushStmt, pushBlock).
 
-  BlockPushesBlockToStack(block, pushedBlock):-
+  BlockPushesBlockToStack(block, pushStmt, pushedBlock):-
     BlockPushedToStack(pushStmt, _, pushedBlock),
     analysis.Statement_Block(pushStmt, block).
 
@@ -340,46 +340,46 @@ INITIALIZE_STATEMENT_INSERTOR(_insertor, to)
     analysis.FallthroughStmt(fallthrough, _).
 
 
-.decl BlockPushesCloningCandidate(pushBlk: Block, candidate: Block)
+.decl BlockPushesCloningCandidate(pushBlk: Block, pushStmt: Statement, candidate: Block)
 
-  BlockPushesCloningCandidate(pushBlk, candidate):-
-    BlockPushesBlockToStack(pushBlk, candidate),
+  BlockPushesCloningCandidate(pushBlk, pushStmt, candidate):-
+    BlockPushesBlockToStack(pushBlk, pushStmt, candidate),
     BlockCloningCandidate(candidate).
 
   // Clone all candidate blocks  for all the blocks that push them
   // Make sure they can be cloned safely 
   BlockToClone(from, to):-
-    BlockPushesBlockToStack(from, to),
-    BlockPushesBlockToStack(otherFrom, to),
+    BlockPushesBlockToStack(_, from, to),
+    BlockPushesBlockToStack(_, otherFrom, to),
     BlockCloningCandidate(to),
     from != otherFrom,
-    !BlockPushesCloningCandidate(to, _),
+    !BlockPushesCloningCandidate(to, _, _),
     !FallthroughBlock(to),
     // Make sure we don't break any CODECOPY stmts
     !analysis.CODECOPYStatement(_, as(to,Value), _).
 
 
-  BlockToCloneOpID(pushBlock, blockToClone, cat(pushBlock, blockToClone)):-
-    BlockToClone(pushBlock, blockToClone).
+  BlockToCloneOpID(pushStmt, blockToClone, cat(pushStmt, blockToClone)):-
+    BlockToClone(pushStmt, blockToClone).
 
   cloneOpSorter.Input(opID):- BlockToCloneOpID(_, _, opID).
 
-  BlockToCloneNewInstance(pushBlock, blockToClone, as(generatedBlock, Block)):-
-    BlockToCloneOpID(pushBlock, blockToClone, opID),
+  BlockToCloneNewInstance(pushStmt, blockToClone, as(generatedBlock, Block)):-
+    BlockToCloneOpID(pushStmt, blockToClone, opID),
     !cloneOpSorter.Input_Next(_, opID),
     MaxOriginalStatement(maxStmt),
     generatedBlock = @add_256(maxStmt, "0x20").
 
-  BlockToCloneNewInstance(pushBlock, blockToClone, as(generatedBlock, Block)):-
-    BlockToCloneOpID(prevPushBlock, prevBlockToClone, prevOpID),
+  BlockToCloneNewInstance(pushStmt, blockToClone, as(generatedBlock, Block)):-
+    BlockToCloneOpID(prevPushStmt, prevBlockToClone, prevOpID),
     cloneOpSorter.Input_Next(prevOpID, opID),
-    BlockToCloneNewInstance(prevPushBlock, prevBlockToClone, prevCloneInstance),
-    BlockToCloneOpID(pushBlock, blockToClone, opID),
+    BlockToCloneNewInstance(prevPushStmt, prevBlockToClone, prevCloneInstance),
+    BlockToCloneOpID(pushStmt, blockToClone, opID),
     BlockSize(prevBlockToClone, prevCloneBlockSize),
     generatedBlock = @add_256(prevCloneInstance, @number_to_hex(prevCloneBlockSize + 32)).
 
-  StatementToClonedStatement(pushBlock, blockToClone, stmt, as(generatedStatement, Statement)):-
-    BlockToCloneNewInstance(pushBlock, blockToClone, generatedBlock),
+  StatementToClonedStatement(pushStmt, blockToClone, stmt, as(generatedStatement, Statement)):-
+    BlockToCloneNewInstance(pushStmt, blockToClone, generatedBlock),
     analysis.Statement_Block(stmt, blockToClone),
     generatedStatement = @add_256(generatedBlock, @sub_256(stmt, blockToClone)).
 
@@ -390,24 +390,24 @@ INITIALIZE_STATEMENT_INSERTOR(_insertor, to)
 
   Out_Statement_Next(lastOriginalStmt, clonedHead):-
     MaxOriginalStatement(lastOriginalStmt),
-    BlockToCloneOpID(pushBlock, blockToClone, opID),
+    BlockToCloneOpID(pushStmt, blockToClone, opID),
     !cloneOpSorter.Input_Next(_, opID),
     analysis.BasicBlock_Head(blockToClone, oldHead),
-    StatementToClonedStatement(pushBlock, blockToClone, oldHead, clonedHead).
+    StatementToClonedStatement(pushStmt, blockToClone, oldHead, clonedHead).
 
   Out_Statement_Next(genStmt, nextGenStmt):-
-    StatementToClonedStatement(pushBlock, blockToClone, stmt, genStmt),
+    StatementToClonedStatement(pushStmt, blockToClone, stmt, genStmt),
     Statement_Next(stmt, nextStmt),
-    StatementToClonedStatement(pushBlock, blockToClone, nextStmt, nextGenStmt).
+    StatementToClonedStatement(pushStmt, blockToClone, nextStmt, nextGenStmt).
 
   Out_Statement_Next(prevClonedTail, nextClonedHead):-
     cloneOpSorter.Input_Next(prevOpID, nextOpID),
-    BlockToCloneOpID(prevPushBlock, prevBlockToClone, prevOpID),
-    BlockToCloneOpID(nextPushBlock, nextBlockToClone, nextOpID),
+    BlockToCloneOpID(prevPushStmt, prevBlockToClone, prevOpID),
+    BlockToCloneOpID(nextPushStmt, nextBlockToClone, nextOpID),
     analysis.BasicBlock_Tail(prevBlockToClone, oldTail),
     analysis.BasicBlock_Head(nextBlockToClone, oldHead),
-    StatementToClonedStatement(prevPushBlock, prevBlockToClone, oldTail, prevClonedTail),
-    StatementToClonedStatement(nextPushBlock, nextBlockToClone, oldHead, nextClonedHead).
+    StatementToClonedStatement(prevPushStmt, prevBlockToClone, oldTail, prevClonedTail),
+    StatementToClonedStatement(nextPushStmt, nextBlockToClone, oldHead, nextClonedHead).
 
   Out_Statement_Opcode(oldStmt, op):-
     Statement_Opcode(oldStmt, op).
@@ -420,10 +420,10 @@ INITIALIZE_STATEMENT_INSERTOR(_insertor, to)
     PushValue(oldStmt, oldVal),
     !ClonedBlockAddressPushedBy(_, oldStmt, _).
 
-  Out_PushValue(oldStmt, as(newVal, Value)):-
-    PushValue(oldStmt, _),
-    ClonedBlockAddressPushedBy(pushBlock, oldStmt, blockToClone),
-    BlockToCloneNewInstance(pushBlock, blockToClone, newVal).
+  Out_PushValue(pushStmt, as(newVal, Value)):-
+    PushValue(pushStmt, _),
+    ClonedBlockAddressPushedBy(_, pushStmt, blockToClone),
+    BlockToCloneNewInstance(pushStmt, blockToClone, newVal).
 
   // Note: For now the cloned blocks should have no pushes
   Out_PushValue(clonedStmt, val):-


### PR DESCRIPTION
This change can give a very significant precision improvement in some datasets (taken from [here](https://github.com/sifislag/evm-bytecode-datasets/)).

solc08-over10k:
```
ANALYTIC: decomp_time
nov23-10k-master (common): 11398.259241819382 (+0.1186%)
nov23-10k-more-pre (common): 11384.759516000748

ANALYTIC: Analytics_JumpToMany
nov23-10k-master (common): 471 (+8.028%)
nov23-10k-more-pre (common): 436

ANALYTIC: Analytics_DeadBlocks
nov23-10k-master (common): 2090 (+1.802%)
nov23-10k-more-pre (common): 2053

ANALYTIC: Analytics_StmtMissingOperand
nov23-10k-master (common): 85 (+4.938%)
nov23-10k-more-pre (common): 81
```

viair-june23:
```
ANALYTIC: decomp_time
nov23-ir-master (common): 9764.224865198135
nov23-ir-more-pre (common): 9766.088721513748 (+0.01909%)

ANALYTIC: Analytics_JumpToMany
nov23-ir-master (common): 3968 (+23.19%)
nov23-ir-more-pre (common): 3221

ANALYTIC: Analytics_BlockHasNoTACBlock
nov23-ir-master (common): 948
nov23-ir-more-pre (common): 949 (+0.1055%)

ANALYTIC: Analytics_DeadBlocks
nov23-ir-master (common): 8158
nov23-ir-more-pre (common): 8184 (+0.3187%)

ANALYTIC: Analytics_StmtMissingOperand
nov23-ir-master (common): 376 (+2.174%)
nov23-ir-more-pre (common): 368
```

metadata-dataset1:
```
ANALYTIC: decomp_time
nov23-meta-master (common): 9153.032186985016 (+0.09607%)
nov23-meta-more-pre (common): 9144.247057914734

ANALYTIC: Analytics_JumpToMany
nov23-meta-master (common): 419 (+17.04%)
nov23-meta-more-pre (common): 358

ANALYTIC: Analytics_StmtMissingOperand
nov23-meta-master (common): 109 (+29.76%)
nov23-meta-more-pre (common): 84

ANALYTIC: Analytics_PrivateFunctionMatchesMetadataIncorrectArgs
nov23-meta-master (common): 533 (+7.243%)
nov23-meta-more-pre (common): 497

ANALYTIC: Analytics_PrivateFunctionMatchesMetadataIncorrectReturnArgs
nov23-meta-master (common): 718 (+1.269%)
nov23-meta-more-pre (common): 709
```