### PR TITLE
Introduce `incompleteGlobal` analysis round, other changes

### DIFF
--- a/logic/context-sensitivity/abstract_context.dl
+++ b/logic/context-sensitivity/abstract_context.dl
@@ -50,13 +50,13 @@
   .input InputMaxContextDepth(filename="MaxContextDepth.csv")
 
   MaxContextDepth(sigHash, d) :-
-    (local.PublicFunction(_, sigHash);
+    (local.PublicFunction(_, sigHash, _);
      sigHash = FALLBACK_FUNCTION_SIGHASH),
     InputMaxContextDepth(d).
 
 
   MaxContextDepth(sigHash, 10) :-
-    (local.PublicFunction(_, sigHash);
+    (local.PublicFunction(_, sigHash, _);
      sigHash = FALLBACK_FUNCTION_SIGHASH),
     !InputMaxContextDepth(_).
 }
@@ -282,14 +282,14 @@
   #ifndef NO_PUBLIC_CONTEXT
   MergeContext(ctx, caller, ctx) :-
     ReachableContext(ctx, caller),
-    local.PublicFunction(caller, sigHash),
+    local.PublicFunction(caller, sigHash, _),
     !MaxContextDepth(sigHash, -1),
     DecomposeContext(ctx, prevSigHash, _),
     prevSigHash != FALLBACK_FUNCTION_SIGHASH.
   .plan 1:(3,1,2)
   MergeContext(ctx, caller, newContext):-
     ReachableContext(ctx, caller),
-    local.PublicFunction(caller, sigHash),
+    local.PublicFunction(caller, sigHash, _),
     !MaxContextDepth(sigHash, -1),
     DecomposeContext(ctx, prevSigHash, pri),
     prevSigHash = FALLBACK_FUNCTION_SIGHASH,

--- a/logic/context-sensitivity/abstract_context.dl
+++ b/logic/context-sensitivity/abstract_context.dl
@@ -280,21 +280,43 @@
   */
 
   #ifndef NO_PUBLIC_CONTEXT
-  MergeContext(ctx, caller, ctx) :-
-    ReachableContext(ctx, caller),
+  // MergeContext(ctx, caller, ctx) :-
+  //   ReachableContext(ctx, caller),
+  //   local.PublicFunctionJump(caller, sigHash, _),
+  //   !MaxContextDepth(sigHash, -1),
+  //   DecomposeContext(ctx, prevSigHash, _),
+  //   prevSigHash != FALLBACK_FUNCTION_SIGHASH.
+  // .plan 1:(3,1,2)
+  // MergeContext(ctx, caller, newContext):-
+  //   ReachableContext(ctx, caller),
+  //   local.PublicFunctionJump(caller, sigHash, _),
+  //   !MaxContextDepth(sigHash, -1),
+  //   DecomposeContext(ctx, prevSigHash, pri),
+  //   prevSigHash = FALLBACK_FUNCTION_SIGHASH,
+  //   newContext = [sigHash, pri].
+  // .plan 1:(3,1,2)
+
+  MergeContextResponse(ctx, caller, funcStart, ctx) :-
+    MergeContextRequest(ctx, caller, funcStart),
     local.PublicFunctionJump(caller, sigHash, _),
+    local.PublicFunction(funcStart, sigHash, _),
     !MaxContextDepth(sigHash, -1),
     DecomposeContext(ctx, prevSigHash, _),
     prevSigHash != FALLBACK_FUNCTION_SIGHASH.
-  .plan 1:(3,1,2)
-  MergeContext(ctx, caller, newContext):-
-    ReachableContext(ctx, caller),
+  .plan 1:(4,1,2,3)
+  MergeContextResponse(ctx, caller, funcStart, newContext) :-
+    MergeContextRequest(ctx, caller, funcStart),
     local.PublicFunctionJump(caller, sigHash, _),
+    local.PublicFunction(funcStart, sigHash, _),
     !MaxContextDepth(sigHash, -1),
-    DecomposeContext(ctx, prevSigHash, pri),
-    prevSigHash = FALLBACK_FUNCTION_SIGHASH,
+    DecomposeContext(ctx, FALLBACK_FUNCTION_SIGHASH, pri),
     newContext = [sigHash, pri].
-  .plan 1:(3,1,2)
+  MergeContextResponse(ctx, caller, funcStart, ctx) :-
+    MergeContextRequest(ctx, caller, funcStart),
+    local.PublicFunctionJump(caller, sigHash, _),
+    !local.PublicFunction(funcStart, sigHash, _),
+    !MaxContextDepth(sigHash, -1).
+
 #endif
 }
 

--- a/logic/context-sensitivity/abstract_context.dl
+++ b/logic/context-sensitivity/abstract_context.dl
@@ -282,14 +282,14 @@
   #ifndef NO_PUBLIC_CONTEXT
   MergeContext(ctx, caller, ctx) :-
     ReachableContext(ctx, caller),
-    local.PublicFunction(caller, sigHash, _),
+    local.PublicFunctionJump(caller, sigHash, _),
     !MaxContextDepth(sigHash, -1),
     DecomposeContext(ctx, prevSigHash, _),
     prevSigHash != FALLBACK_FUNCTION_SIGHASH.
   .plan 1:(3,1,2)
   MergeContext(ctx, caller, newContext):-
     ReachableContext(ctx, caller),
-    local.PublicFunction(caller, sigHash, _),
+    local.PublicFunctionJump(caller, sigHash, _),
     !MaxContextDepth(sigHash, -1),
     DecomposeContext(ctx, prevSigHash, pri),
     prevSigHash = FALLBACK_FUNCTION_SIGHASH,

--- a/logic/context-sensitivity/abstract_context.dl
+++ b/logic/context-sensitivity/abstract_context.dl
@@ -311,6 +311,7 @@
     !MaxContextDepth(sigHash, -1),
     DecomposeContext(ctx, FALLBACK_FUNCTION_SIGHASH, pri),
     newContext = [sigHash, pri].
+  .plan 1:(4,1,2,3)
   MergeContextResponse(ctx, caller, funcStart, ctx) :-
     MergeContextRequest(ctx, caller, funcStart),
     local.PublicFunctionJump(caller, sigHash, _),

--- a/logic/context-sensitivity/callsite_context.dl
+++ b/logic/context-sensitivity/callsite_context.dl
@@ -20,7 +20,7 @@
     ReachableContext(ctx, caller),
     DecomposeContext(ctx, pub, pri),
     TruncateContextIfNeeded(pub, pri, cutDownPri),
-    !local.PublicFunction(caller, _),
+    !local.PublicFunction(caller, _, _),
     newPrivateContext = [caller, cutDownPri].
     .plan 1:(2,1,3), 2:(3,2,1)
 }

--- a/logic/context-sensitivity/callsite_context.dl
+++ b/logic/context-sensitivity/callsite_context.dl
@@ -20,7 +20,7 @@
     ReachableContext(ctx, caller),
     DecomposeContext(ctx, pub, pri),
     TruncateContextIfNeeded(pub, pri, cutDownPri),
-    !local.PublicFunction(caller, _, _),
+    !local.PublicFunctionJump(caller, _, _),
     newPrivateContext = [caller, cutDownPri].
     .plan 1:(2,1,3), 2:(3,2,1)
 }

--- a/logic/context-sensitivity/finite_precise_context.dl
+++ b/logic/context-sensitivity/finite_precise_context.dl
@@ -13,13 +13,13 @@
   .input InputMaxContextDepth(filename="MaxContextDepth.csv")
 
   MaxContextDepth(sigHash, d) :-
-    (local.PublicFunction(_, sigHash);
+    (local.PublicFunction(_, sigHash, _);
      sigHash = FALLBACK_FUNCTION_SIGHASH),
     InputMaxContextDepth(d).
 
   // HERE: much deeper
   MaxContextDepth(sigHash, 27) :-
-    (local.PublicFunction(_, sigHash);
+    (local.PublicFunction(_, sigHash, _);
      sigHash = FALLBACK_FUNCTION_SIGHASH),
     !InputMaxContextDepth(_).
 
@@ -135,14 +135,14 @@
   #ifndef NO_PUBLIC_CONTEXT
   MergeContext(ctx, caller, ctx) :-
     ReachableContext(ctx, caller),
-    local.PublicFunction(caller, sigHash),
+    local.PublicFunction(caller, sigHash, _),
     !MaxContextDepth(sigHash, -1),
     DecomposeContext(ctx, prevSigHash, _),
     prevSigHash != FALLBACK_FUNCTION_SIGHASH.
   .plan 1:(3,1,2)
   MergeContext(ctx, caller, newContext):-
     ReachableContext(ctx, caller),
-    local.PublicFunction(caller, sigHash),
+    local.PublicFunction(caller, sigHash, _),
     !MaxContextDepth(sigHash, -1),
     DecomposeContext(ctx, prevSigHash, pri),
     prevSigHash = FALLBACK_FUNCTION_SIGHASH,
@@ -163,14 +163,14 @@
   MergeContext(ctx, caller, ctx):-
     ReachableContext(ctx, caller),
     #ifndef NO_PUBLIC_CONTEXT
-    !local.PublicFunction(caller, _),
+    !local.PublicFunction(caller, _, _),
     #endif
     !local.PrivateFunctionCallOrReturn(caller).
 
   MergeContext(ctx, caller, ctx):-
     ReachableContext(ctx, caller),
     #ifndef NO_PUBLIC_CONTEXT
-    !local.PublicFunction(caller, _),
+    !local.PublicFunction(caller, _, _),
     #endif
     DecomposeContext(ctx, pub, _),
     MaxContextDepth(pub, 0).
@@ -184,7 +184,7 @@
     DecomposeContext(ctx, pub, pri),
     TruncateContextIfNeeded(pub, pri, cutDownPri),
     #ifndef NO_PUBLIC_CONTEXT
-    !local.PublicFunction(caller, _),
+    !local.PublicFunction(caller, _, _),
     #endif
     newPrivateContext = [caller, cutDownPri].
     .plan 1:(3,1,2,4), 2:(4,3,1,2)

--- a/logic/context-sensitivity/finite_shrinking_context.dl
+++ b/logic/context-sensitivity/finite_shrinking_context.dl
@@ -13,13 +13,13 @@
   .input InputMaxContextDepth(filename="MaxContextDepth.csv")
 
   MaxContextDepth(sigHash, d) :-
-    (local.PublicFunction(_, sigHash);
+    (local.PublicFunction(_, sigHash, _);
      sigHash = FALLBACK_FUNCTION_SIGHASH),
     InputMaxContextDepth(d).
 
   // HERE: much deeper
   MaxContextDepth(sigHash, 10) :-
-    (local.PublicFunction(_, sigHash);
+    (local.PublicFunction(_, sigHash, _);
      sigHash = FALLBACK_FUNCTION_SIGHASH),
     !InputMaxContextDepth(_).
 
@@ -97,14 +97,14 @@
   #ifndef NO_PUBLIC_CONTEXT
   MergeContext(ctx, caller, ctx) :-
     ReachableContext(ctx, caller),
-    local.PublicFunction(caller, sigHash),
+    local.PublicFunction(caller, sigHash, _),
     !MaxContextDepth(sigHash, -1),
     DecomposeContext(ctx, prevSigHash, _),
     prevSigHash != FALLBACK_FUNCTION_SIGHASH.
   .plan 1:(3,1,2)
   MergeContext(ctx, caller, newContext):-
     ReachableContext(ctx, caller),
-    local.PublicFunction(caller, sigHash),
+    local.PublicFunction(caller, sigHash, _),
     !MaxContextDepth(sigHash, -1),
     DecomposeContext(ctx, prevSigHash, pri),
     prevSigHash = FALLBACK_FUNCTION_SIGHASH,
@@ -123,12 +123,12 @@
   // Split into two rules to add plan.
   MergeContext(ctx, caller, ctx):-
     ReachableContext(ctx, caller),
-    !local.PublicFunction(caller, _),
+    !local.PublicFunction(caller, _, _),
     !local.PrivateFunctionCallOrReturn(caller).
 
   MergeContext(ctx, caller, ctx):-
     ReachableContext(ctx, caller),
-    !local.PublicFunction(caller, _),
+    !local.PublicFunction(caller, _, _),
     DecomposeContext(ctx, pub, _),
     MaxContextDepth(pub, 0).
     .plan 1:(2,3,1)
@@ -147,7 +147,7 @@
     ReachableContext(ctx, caller),
     local.PrivateFunctionCall(caller, _, _, _),
     DecomposeAndTruncateIfNeeded(ctx, pub, cutDownAtEndPri),
-    !local.PublicFunction(caller, _),
+    !local.PublicFunction(caller, _, _),
     newPrivateContext = [caller, cutDownAtEndPri].
     .plan 1:(3,1,2)
 
@@ -196,7 +196,7 @@
     MergeContextRequest(ctx, block, cont),
     PrivateFunctionReturn(block),
     DecomposeContext(ctx, pub, priCtx),
-    !local.PublicFunction(block, _),
+    !local.PublicFunction(block, _, _),
     CutToCaller(priCtx, cont, cutPri).
     .plan 1:(3,1,2,4), 2:(4,3,1,2)
 
@@ -207,7 +207,7 @@
     DecomposeContext(ctx, pub, priCtx),
     DecomposeAndTruncateIfNeeded(ctx, pub, cutDownAtEndPri),
     NoCutToCaller(priCtx, cont),
-    !local.PublicFunction(block, _),
+    !local.PublicFunction(block, _, _),
     newPrivateContext = [block, cutDownAtEndPri].
     .plan 1:(3,1,2,4,5), 2:(4,3,1,2,5), 3:(5,3,1,2,4)
 

--- a/logic/context-sensitivity/hybrid_precise_context.dl
+++ b/logic/context-sensitivity/hybrid_precise_context.dl
@@ -16,19 +16,19 @@
   .input InputMaxImpreciseContextDepth(filename="MaxContextDepth.csv")
 
   MaxImpreciseContextDepth(sigHash, d) :-
-    (local.PublicFunction(_, sigHash);
+    (local.PublicFunction(_, sigHash, _);
      sigHash = FALLBACK_FUNCTION_SIGHASH),
     InputMaxImpreciseContextDepth(d).
 
   MaxImpreciseContextDepth(sigHash, 7) :-
-    (local.PublicFunction(_, sigHash);
+    (local.PublicFunction(_, sigHash, _);
      sigHash = FALLBACK_FUNCTION_SIGHASH),
     !InputMaxImpreciseContextDepth(_).
 
   // Not yet configurable via input file
   .decl MaxPreciseContextDepth(sigHash: symbol, d: number)
   MaxPreciseContextDepth(sigHash, 27) :-
-    (local.PublicFunction(_, sigHash);
+    (local.PublicFunction(_, sigHash, _);
      sigHash = FALLBACK_FUNCTION_SIGHASH).
 
   //
@@ -253,14 +253,14 @@
   #ifndef NO_PUBLIC_CONTEXT
   MergeContext(ctx, caller, ctx) :-
     ReachableContext(ctx, caller),
-    local.PublicFunction(caller, sigHash),
+    local.PublicFunction(caller, sigHash, _),
     !MaxImpreciseContextDepth(sigHash, -1),
     DecomposeContext(ctx, prevSigHash, _),
     prevSigHash != FALLBACK_FUNCTION_SIGHASH.
   .plan 1:(3,1,2)
   MergeContext(ctx, caller, newContext) :-
     ReachableContext(ctx, caller),
-    local.PublicFunction(caller, sigHash),
+    local.PublicFunction(caller, sigHash, _),
     !MaxImpreciseContextDepth(sigHash, -1),
     DecomposeContext(ctx, prevSigHash, pri),
     prevSigHash = FALLBACK_FUNCTION_SIGHASH,
@@ -280,14 +280,14 @@
   MergeContext(ctx, caller, ctx) :-
     ReachableContext(ctx, caller),
     #ifndef NO_PUBLIC_CONTEXT
-    !local.PublicFunction(caller, _),
+    !local.PublicFunction(caller, _, _),
     #endif
     !local.PrivateFunctionCallOrReturn(caller).
 
   MergeContext(ctx, caller, ctx) :-
     ReachableContext(ctx, caller),
     #ifndef NO_PUBLIC_CONTEXT
-    !local.PublicFunction(caller, _),
+    !local.PublicFunction(caller, _, _),
     #endif
     DecomposeContext(ctx, pub, _),
     MaxImpreciseContextDepth(pub, 0).
@@ -301,7 +301,7 @@
     DecomposeContext(ctx, pub, pri),
     TruncateContextIfNeeded(pub, pri, cutDownPri),
     #ifndef NO_PUBLIC_CONTEXT
-    !local.PublicFunction(caller, _),
+    !local.PublicFunction(caller, _, _),
     #endif
     newPrivateContext = [caller, cutDownPri].
     .plan 1:(3,1,2,4), 2:(4,3,1,2)

--- a/logic/context-sensitivity/selective_context.dl
+++ b/logic/context-sensitivity/selective_context.dl
@@ -23,20 +23,20 @@
   MergeContext(ctx, caller, ctx):-
     ReachableContext(ctx, caller),
     local.BlockHasTrivialControl(caller),
-    !local.PublicFunction(caller, _, _).
+    !local.PublicFunctionJump(caller, _, _).
 
   MergeContext(ctx, caller, [pub, newPrivateContext]):-
     ReachableContext(ctx, caller),
     DecomposeContext(ctx, pub, pri),
     TruncateContextIfNeeded(pub, pri, cutDownPri),
-    !local.PublicFunction(caller, _, _),
+    !local.PublicFunctionJump(caller, _, _),
     !local.BlockHasTrivialControl(caller),
     newPrivateContext = [caller, cutDownPri].
     .plan 1:(2,1,3), 2:(3,2,1)
 
   MergeContext(ctx, caller, newContext) :-
     ReachableContext(ctx, caller),
-    local.PublicFunction(caller, sigHash, _),
+    local.PublicFunctionJump(caller, sigHash, _),
     !MaxContextDepth(sigHash, -1),
     DecomposeContext(ctx, _, callCtx),
     newContext = [sigHash, callCtx].

--- a/logic/context-sensitivity/selective_context.dl
+++ b/logic/context-sensitivity/selective_context.dl
@@ -23,20 +23,20 @@
   MergeContext(ctx, caller, ctx):-
     ReachableContext(ctx, caller),
     local.BlockHasTrivialControl(caller),
-    !local.PublicFunction(caller, _).
+    !local.PublicFunction(caller, _, _).
 
   MergeContext(ctx, caller, [pub, newPrivateContext]):-
     ReachableContext(ctx, caller),
     DecomposeContext(ctx, pub, pri),
     TruncateContextIfNeeded(pub, pri, cutDownPri),
-    !local.PublicFunction(caller, _),
+    !local.PublicFunction(caller, _, _),
     !local.BlockHasTrivialControl(caller),
     newPrivateContext = [caller, cutDownPri].
     .plan 1:(2,1,3), 2:(3,2,1)
 
   MergeContext(ctx, caller, newContext) :-
     ReachableContext(ctx, caller),
-    local.PublicFunction(caller, sigHash),
+    local.PublicFunction(caller, sigHash, _),
     !MaxContextDepth(sigHash, -1),
     DecomposeContext(ctx, _, callCtx),
     newContext = [sigHash, callCtx].

--- a/logic/context-sensitivity/transactional_context.dl
+++ b/logic/context-sensitivity/transactional_context.dl
@@ -5,14 +5,14 @@
   MergeContext(ctx, caller, ctx):-
     ReachableContext(ctx, caller),
     #ifndef NO_PUBLIC_CONTEXT
-    !local.PublicFunction(caller, _, _),
+    !local.PublicFunctionJump(caller, _, _),
     #endif
     !local.PrivateFunctionCallOrReturn(caller).
 
   MergeContext(ctx, caller, ctx):-
     ReachableContext(ctx, caller),
     #ifndef NO_PUBLIC_CONTEXT
-    !local.PublicFunction(caller, _, _),
+    !local.PublicFunctionJump(caller, _, _),
     #endif
     DecomposeContext(ctx, pub, _),
     MaxContextDepth(pub, 0).
@@ -26,7 +26,7 @@
     DecomposeContext(ctx, pub, pri),
     TruncateContextIfNeeded(pub, pri, cutDownPri),
     #ifndef NO_PUBLIC_CONTEXT
-    !local.PublicFunction(caller, _, _),
+    !local.PublicFunctionJump(caller, _, _),
     #endif
     newPrivateContext = [caller, cutDownPri].
     .plan 1:(3,1,2,4), 2:(4,3,1,2)

--- a/logic/context-sensitivity/transactional_context.dl
+++ b/logic/context-sensitivity/transactional_context.dl
@@ -5,14 +5,14 @@
   MergeContext(ctx, caller, ctx):-
     ReachableContext(ctx, caller),
     #ifndef NO_PUBLIC_CONTEXT
-    !local.PublicFunction(caller, _),
+    !local.PublicFunction(caller, _, _),
     #endif
     !local.PrivateFunctionCallOrReturn(caller).
 
   MergeContext(ctx, caller, ctx):-
     ReachableContext(ctx, caller),
     #ifndef NO_PUBLIC_CONTEXT
-    !local.PublicFunction(caller, _),
+    !local.PublicFunction(caller, _, _),
     #endif
     DecomposeContext(ctx, pub, _),
     MaxContextDepth(pub, 0).
@@ -26,7 +26,7 @@
     DecomposeContext(ctx, pub, pri),
     TruncateContextIfNeeded(pub, pri, cutDownPri),
     #ifndef NO_PUBLIC_CONTEXT
-    !local.PublicFunction(caller, _),
+    !local.PublicFunction(caller, _, _),
     #endif
     newPrivateContext = [caller, cutDownPri].
     .plan 1:(3,1,2,4), 2:(4,3,1,2)

--- a/logic/context-sensitivity/transactional_shrinking_context.dl
+++ b/logic/context-sensitivity/transactional_shrinking_context.dl
@@ -5,12 +5,12 @@
   // Split into two rules to add plan.
   MergeContext(ctx, caller, ctx):-
     ReachableContext(ctx, caller),
-    !local.PublicFunction(caller, _),
+    !local.PublicFunction(caller, _, _),
     !local.PrivateFunctionCallOrReturn(caller).
 
   MergeContext(ctx, caller, ctx):-
     ReachableContext(ctx, caller),
-    !local.PublicFunction(caller, _),
+    !local.PublicFunction(caller, _, _),
     DecomposeContext(ctx, pub, _),
     MaxContextDepth(pub, 0).
     .plan 1:(2,3,1)
@@ -29,7 +29,7 @@
     ReachableContext(ctx, caller),
     local.PrivateFunctionCall(caller, _, _, _),
     DecomposeAndTruncateIfNeeded(ctx, pub, cutDownAtEndPri),
-    !local.PublicFunction(caller, _),
+    !local.PublicFunction(caller, _, _),
     newPrivateContext = [caller, cutDownAtEndPri].
     .plan 1:(3,1,2)
 
@@ -78,7 +78,7 @@
     MergeContextRequest(ctx, block, cont),
     PrivateFunctionReturn(block),
     DecomposeContext(ctx, pub, priCtx),
-    !local.PublicFunction(block, _),
+    !local.PublicFunction(block, _, _),
     CutToCaller(priCtx, cont, cutPri).
     .plan 1:(3,1,2,4), 2:(4,3,1,2)
 
@@ -89,7 +89,7 @@
     DecomposeContext(ctx, pub, priCtx),
     DecomposeAndTruncateIfNeeded(ctx, pub, cutDownAtEndPri),
     NoCutToCaller(priCtx, cont),
-    !local.PublicFunction(block, _),
+    !local.PublicFunction(block, _, _),
     newPrivateContext = [block, cutDownAtEndPri].
     .plan 1:(3,1,2,4,5), 2:(4,3,1,2,5), 3:(5,3,1,2,4)
 

--- a/logic/context-sensitivity/transactional_shrinking_context.dl
+++ b/logic/context-sensitivity/transactional_shrinking_context.dl
@@ -5,12 +5,12 @@
   // Split into two rules to add plan.
   MergeContext(ctx, caller, ctx):-
     ReachableContext(ctx, caller),
-    !local.PublicFunction(caller, _, _),
+    !local.PublicFunctionJump(caller, _, _),
     !local.PrivateFunctionCallOrReturn(caller).
 
   MergeContext(ctx, caller, ctx):-
     ReachableContext(ctx, caller),
-    !local.PublicFunction(caller, _, _),
+    !local.PublicFunctionJump(caller, _, _),
     DecomposeContext(ctx, pub, _),
     MaxContextDepth(pub, 0).
     .plan 1:(2,3,1)
@@ -29,7 +29,7 @@
     ReachableContext(ctx, caller),
     local.PrivateFunctionCall(caller, _, _, _),
     DecomposeAndTruncateIfNeeded(ctx, pub, cutDownAtEndPri),
-    !local.PublicFunction(caller, _, _),
+    !local.PublicFunctionJump(caller, _, _),
     newPrivateContext = [caller, cutDownAtEndPri].
     .plan 1:(3,1,2)
 
@@ -78,7 +78,7 @@
     MergeContextRequest(ctx, block, cont),
     PrivateFunctionReturn(block),
     DecomposeContext(ctx, pub, priCtx),
-    !local.PublicFunction(block, _, _),
+    !local.PublicFunctionJump(block, _, _),
     CutToCaller(priCtx, cont, cutPri).
     .plan 1:(3,1,2,4), 2:(4,3,1,2)
 
@@ -89,7 +89,7 @@
     DecomposeContext(ctx, pub, priCtx),
     DecomposeAndTruncateIfNeeded(ctx, pub, cutDownAtEndPri),
     NoCutToCaller(priCtx, cont),
-    !local.PublicFunction(block, _, _),
+    !local.PublicFunctionJump(block, _, _),
     newPrivateContext = [block, cutDownAtEndPri].
     .plan 1:(3,1,2,4,5), 2:(4,3,1,2,5), 3:(5,3,1,2,4)
 

--- a/logic/debug.dl
+++ b/logic/debug.dl
@@ -82,55 +82,55 @@ MaybeInFunctionUnderContextOrd(ord(ctx), block, func):-
   MaybeInFunctionUnderContext(ctx, block, func).
 
 
-.decl CFGImprecisionPersists(srcCtx: global.sens.Context, srcBlk: Block, currCtx: global.sens.Context, currBlk: Block, targetVar1: Variable, targetVar2: Variable, pathLen: number)
-.output CFGImprecisionPersists
+// .decl CFGImprecisionPersists(srcCtx: global.sens.Context, srcBlk: Block, currCtx: global.sens.Context, currBlk: Block, targetVar1: Variable, targetVar2: Variable, pathLen: number)
+// .output CFGImprecisionPersists
 
-.decl CFGImprecisionInstance(ctx: global.sens.Context, blk: Block, targetVar1: Variable, targetVar2: Variable)
+// .decl CFGImprecisionInstance(ctx: global.sens.Context, blk: Block, targetVar1: Variable, targetVar2: Variable)
 
-CFGImprecisionPersists(ctx, block, ctx, block, targetVar1, targetVar2, 0),
-CFGImprecisionInstance(ctx, block, targetVar1, targetVar2):-
-  global.BlockJumpValidTarget(ctx, block, targetVar1, _),
-  global.BlockJumpValidTarget(ctx, block, targetVar2, _),
-  targetVar1 < targetVar2.
+// CFGImprecisionPersists(ctx, block, ctx, block, targetVar1, targetVar2, 0),
+// CFGImprecisionInstance(ctx, block, targetVar1, targetVar2):-
+//   global.BlockJumpValidTarget(ctx, block, targetVar1, _),
+//   global.BlockJumpValidTarget(ctx, block, targetVar2, _),
+//   targetVar1 < targetVar2.
 
-CFGImprecisionPersists(srcCtx, srcBlock, prevCtx, prevBlock, targetVar1, targetVar2, pathLen + 1):-
-  CFGImprecisionPersists(srcCtx, srcBlock, ctx, block, targetVar1, targetVar2, pathLen),
-  global.BlockEdge(prevCtx, prevBlock, ctx, block),
-  global.BlockInputContents(prevCtx, prevBlock, someIndex, targetVar1),
-  global.BlockInputContents(prevCtx, prevBlock, someIndex, targetVar2),
-  pathLen < 30.
+// CFGImprecisionPersists(srcCtx, srcBlock, prevCtx, prevBlock, targetVar1, targetVar2, pathLen + 1):-
+//   CFGImprecisionPersists(srcCtx, srcBlock, ctx, block, targetVar1, targetVar2, pathLen),
+//   global.BlockEdge(prevCtx, prevBlock, ctx, block),
+//   global.BlockInputContents(prevCtx, prevBlock, someIndex, targetVar1),
+//   global.BlockInputContents(prevCtx, prevBlock, someIndex, targetVar2),
+//   pathLen < 30.
 
-.decl CFGImprecisionPersistsOrd(srcCtx: number, srcBlk: Block, currCtx: number, currBlk: Block, targetVar1: Variable, targetVar2: Variable, pathLen: number)
-.output CFGImprecisionPersistsOrd
+// .decl CFGImprecisionPersistsOrd(srcCtx: number, srcBlk: Block, currCtx: number, currBlk: Block, targetVar1: Variable, targetVar2: Variable, pathLen: number)
+// .output CFGImprecisionPersistsOrd
 
-CFGImprecisionPersistsOrd(ord(srcCtx), srcBlock, ord(ctx), block, targetVar1, targetVar2, pathLen):-
-  CFGImprecisionPersists(srcCtx, srcBlock, ctx, block, targetVar1, targetVar2, pathLen).
+// CFGImprecisionPersistsOrd(ord(srcCtx), srcBlock, ord(ctx), block, targetVar1, targetVar2, pathLen):-
+//   CFGImprecisionPersists(srcCtx, srcBlock, ctx, block, targetVar1, targetVar2, pathLen).
 
-.decl CFGImprecisionIntroducedOrd(srcCtx: number, srcBlk: Block, prevCtx: number, prevBlock: Block, currCtx: number, currBlk: Block, targetVar1: Variable, targetVar2: Variable, pathLen: number)
-.output CFGImprecisionIntroducedOrd
+// .decl CFGImprecisionIntroducedOrd(srcCtx: number, srcBlk: Block, prevCtx: number, prevBlock: Block, currCtx: number, currBlk: Block, targetVar1: Variable, targetVar2: Variable, pathLen: number)
+// .output CFGImprecisionIntroducedOrd
 
-CFGImprecisionIntroducedOrd(ord(srcCtx), srcBlock, ord(prevCtx), prevBlock, ord(ctx), block, targetVar1, targetVar2, pathLen):-
-  CFGImprecisionPersists(srcCtx, srcBlock, ctx, block, targetVar1, targetVar2, pathLen),
-  global.BlockEdge(prevCtx, prevBlock, ctx, block),
-  pathLen != 30,
-  !CFGImprecisionPersists(srcCtx, srcBlock, prevCtx, prevBlock, targetVar1, targetVar2, _).
+// CFGImprecisionIntroducedOrd(ord(srcCtx), srcBlock, ord(prevCtx), prevBlock, ord(ctx), block, targetVar1, targetVar2, pathLen):-
+//   CFGImprecisionPersists(srcCtx, srcBlock, ctx, block, targetVar1, targetVar2, pathLen),
+//   global.BlockEdge(prevCtx, prevBlock, ctx, block),
+//   pathLen != 30,
+//   !CFGImprecisionPersists(srcCtx, srcBlock, prevCtx, prevBlock, targetVar1, targetVar2, _).
 
-.decl CFGImprecisionIntroducedForwardOrd(ctx: number, block: Block, targetVar1: Variable, targetVar2: Variable)
-.output CFGImprecisionIntroducedForwardOrd
+// .decl CFGImprecisionIntroducedForwardOrd(ctx: number, block: Block, targetVar1: Variable, targetVar2: Variable)
+// .output CFGImprecisionIntroducedForwardOrd
 
-.decl CFGImprecisionExists(ctx: global.sens.Context, block: Block, targetVar1: Variable, targetVar2: Variable)
+// .decl CFGImprecisionExists(ctx: global.sens.Context, block: Block, targetVar1: Variable, targetVar2: Variable)
 
-CFGImprecisionExists(ctx, block, targetVar1, targetVar2):-
-  CFGImprecisionInstance(_, _, targetVar1, targetVar2),
-  global.BlockInputContents(ctx, block, someIndex, targetVar1),
-  global.BlockInputContents(ctx, block, someIndex, targetVar2).
+// CFGImprecisionExists(ctx, block, targetVar1, targetVar2):-
+//   CFGImprecisionInstance(_, _, targetVar1, targetVar2),
+//   global.BlockInputContents(ctx, block, someIndex, targetVar1),
+//   global.BlockInputContents(ctx, block, someIndex, targetVar2).
 
-.decl CFGImprecisionExistsInPrev(ctx: global.sens.Context, block: Block, prevCtx: global.sens.Context, prevBlock: Block, targetVar1: Variable, targetVar2: Variable)
+// .decl CFGImprecisionExistsInPrev(ctx: global.sens.Context, block: Block, prevCtx: global.sens.Context, prevBlock: Block, targetVar1: Variable, targetVar2: Variable)
 
-CFGImprecisionExistsInPrev(ctx, block, prevCtx, prevBlock, targetVar1, targetVar2):-
-  CFGImprecisionExists(prevCtx, prevBlock, targetVar1, targetVar2),
-  global.BlockEdge(prevCtx, prevBlock, ctx, block).
+// CFGImprecisionExistsInPrev(ctx, block, prevCtx, prevBlock, targetVar1, targetVar2):-
+//   CFGImprecisionExists(prevCtx, prevBlock, targetVar1, targetVar2),
+//   global.BlockEdge(prevCtx, prevBlock, ctx, block).
 
-CFGImprecisionIntroducedForwardOrd(ord(ctx), block, targetVar1, targetVar2):-
-  CFGImprecisionExists(ctx, block, targetVar1, targetVar2),
-  !CFGImprecisionExistsInPrev(ctx, block, _, _, targetVar1, targetVar2).
+// CFGImprecisionIntroducedForwardOrd(ord(ctx), block, targetVar1, targetVar2):-
+//   CFGImprecisionExists(ctx, block, targetVar1, targetVar2),
+//   !CFGImprecisionExistsInPrev(ctx, block, _, _, targetVar1, targetVar2).

--- a/logic/functions.dl
+++ b/logic/functions.dl
@@ -262,8 +262,8 @@ IsFunctionCallReturn(ctx, caller, func, retCtx, retBlock, retTarget) :-
 .decl PublicFunctionFiltered(block: Block, sigHash: Value)
 
 PublicFunctionFiltered(func, sigHash):-
-   postTrans.PublicFunctionJump(prev, sigHash),
-   postTrans.PublicFunction(func, sigHash),
+   postTrans.PublicFunctionJump(prev, sigHash, _),
+   postTrans.PublicFunction(func, sigHash, _),
    global.BlockEdge(_, prev, _, func).
 
 // NOTE the philosophy!  MaybeFunctionCallReturn intends to be
@@ -284,7 +284,7 @@ IsFunctionEntry(func) :- IsFunctionCallReturn(_, _, func, _, _, _).
 
 IsFunctionCall(prev, func),
 IsPublicFunctionCall(prev, func) :-
-   postTrans.PublicFunctionJump(prev, sigHash),
+   postTrans.PublicFunctionJump(prev, sigHash, _),
    PublicFunctionFiltered(func, sigHash),
    global.BlockEdge(_, prev, _, func).
 
@@ -1078,7 +1078,7 @@ SighashIntermediate(sigIn, cat("0x0",substr(sigOut,2,8))) :-
    strlen(sigOut) < 10.
 
 SighashIntermediate(sig, sig) :-
-   postTrans.PublicFunction(_, sig).
+   postTrans.PublicFunction(_, sig, _).
 
 .decl IRPublicFunction(irfunc: IRFunction, sigHash: Value)
 IRPublicFunction(irfunc, sigHash) :-

--- a/logic/functions.dl
+++ b/logic/functions.dl
@@ -262,8 +262,9 @@ IsFunctionCallReturn(ctx, caller, func, retCtx, retBlock, retTarget) :-
 .decl PublicFunctionFiltered(block: Block, sigHash: Value)
 
 PublicFunctionFiltered(func, sigHash):-
-   postTrans.PublicFunctionJump(prev, sigHash, _),
+   postTrans.PublicFunctionJump(prev, sigHash, selector),
    postTrans.PublicFunction(func, sigHash, _),
+   global.ValidPublicFunctionJump(prev, sigHash, selector),
    global.BlockEdge(_, prev, _, func).
 
 // NOTE the philosophy!  MaybeFunctionCallReturn intends to be

--- a/logic/functions.dl
+++ b/logic/functions.dl
@@ -262,9 +262,8 @@ IsFunctionCallReturn(ctx, caller, func, retCtx, retBlock, retTarget) :-
 .decl PublicFunctionFiltered(block: Block, sigHash: Value)
 
 PublicFunctionFiltered(func, sigHash):-
-   postTrans.PublicFunctionJump(prev, sigHash, selector),
+   postTrans.PublicFunctionJump(prev, sigHash, _),
    postTrans.PublicFunction(func, sigHash, _),
-   global.ValidPublicFunctionJump(prev, sigHash, selector),
    global.BlockEdge(_, prev, _, func).
 
 // NOTE the philosophy!  MaybeFunctionCallReturn intends to be

--- a/logic/global.dl
+++ b/logic/global.dl
@@ -7,7 +7,7 @@
 
 #define MAX_NUM_PRIVATE_FUNCTION_ARGS 50
 #define MAX_NUM_PRIVATE_FUNCTION_RETS 50
-// #define ENABLE_LIMITSIZE
+#define ENABLE_LIMITSIZE
 #define LIMITSIZE_BLOCK_OUTPUT_CONTENTS 1000000
 #define CheckIsVariable(v) ((v) < 0)
 #define CheckIsStackIndex(v) ((v) >= 0, (v) < MAX_STACK_HEIGHT)
@@ -40,6 +40,10 @@
 .type Statement <: symbol
 .type FunctionSignature <: symbol
 
+.type OptionalSelector = NoSelector{}
+                      | SelectorVariable{selector: Variable}
+                      | SelectorStackIndex{block: Block, selector: StackIndex}
+
 .init incompleteGlobal = IncompleteOptimizedGlobalAnalysis<CONTEXT_SENSITIVITY, LocalAnalysis>
 
 COPY_CODE_FULL(incompleteGlobal, postTrans)
@@ -50,7 +54,13 @@ global.StatementPushesUsedLabel(stmt):-
   incompleteGlobal.VariableUsedInAsJumpdest(pushedVar),
   postTrans.Statement_Defines(stmt, pushedVar).
 
-COPY_CODE_FULL(global, postTrans)
+COPY_CODE(global, postTrans)
+global.PublicFunctionJump(block, hex, selector):-
+  incompleteGlobal.ValidPublicFunctionJump(block, hex, selector).
+
+global.PublicFunction(block, hex, selector):-
+  incompleteGlobal.ValidPublicFunctionJump(_, hex, selector),
+  incompleteGlobal.PublicFunction(block, hex, selector).
 
 // Masks with all 1s
 .decl Mask_Length(mask: Value, bytes: number)
@@ -85,8 +95,8 @@ PreMask_Length(cat(mask, "ff"), bytes+1) :-
   sens.local.PushValue(push, val):- PushValue(push, val).
   sens.local.Statement_Opcode(stmt, op):- Statement_Opcode(stmt, op).
   sens.local.Statement_Next(stmt, stmtNext):- Statement_Next(stmt, stmtNext).
-  sens.local.PublicFunction(block, hex):- PublicFunction(block, hex).
-  sens.local.PublicFunctionJump(block, hex):- PublicFunctionJump(block, hex).
+  sens.local.PublicFunction(block, hex, selector):- PublicFunction(block, hex, selector).
+  sens.local.PublicFunctionJump(block, hex, selector):- PublicFunctionJump(block, hex, selector).
 
   // `block` is reachable under `context`
   .decl ReachableContext(context: sens.Context, block: Block)
@@ -251,6 +261,23 @@ PreMask_Length(cat(mask, "ff"), bytes+1) :-
   VariableAlwaysUsedAsJumpTarget(var):-
     VariableContainsJumpTarget(var),
     !VariableUsedInOperation(var).
+
+  .decl ValidPublicFunctionJump(jumpBlock: Block, hex: Value, selector: OptionalSelector)
+  .decl ValidPublicFunction(startBlock: Block, hex: Value, selector: OptionalSelector)
+  DEBUG_OUTPUT(ValidPublicFunctionJump)
+
+  ValidPublicFunctionJump(jumpBlock, hex, $SelectorStackIndex(block, selectorStackIndex)):-
+    PublicFunctionJump(jumpBlock, hex, $SelectorStackIndex(block, selectorStackIndex)),
+    BlockInputContents(_, block, selectorStackIndex, selectorVariable),
+    FunctionSelectorVariable(selectorVariable).
+
+  ValidPublicFunctionJump(jumpBlock, hex, $SelectorVariable(selectorVariable)):-
+    PublicFunctionJump(jumpBlock, hex, $SelectorVariable(selectorVariable)),
+    FunctionSelectorVariable(selectorVariable).
+
+  ValidPublicFunctionJump(jumpBlock, hex, $NoSelector()):-
+    PublicFunctionJump(jumpBlock, hex, $NoSelector()).
+
 }
 
 /**
@@ -261,13 +288,13 @@ PreMask_Length(cat(mask, "ff"), bytes+1) :-
   .override BlockInputContents
 
   /**
-    Cut down `BlockOutputContents`, only containing jump targets.
+    Cut down `BlockOutputContents`, only containing jump targets (and the function selector var).
     Stack contents at end of a `block`, given its calling `context`.
   */
   .decl AuxBlockOutputContentsJumpTarget(context:sens.Context, block:Block, index:StackIndex, var:Variable)
   AuxBlockOutputContentsJumpTarget(context, block, index, var) :-
     BlockOutputContents(context, block, index, var),
-    VariableContainsJumpTarget(var).
+    (VariableContainsJumpTarget(var); FunctionSelectorVariable(var)).
 
   BlockInputContents(calleeCtx, callee, index, variable) :-
     AuxBlockOutputContentsJumpTarget(callerCtx, caller, index, variable),
@@ -292,6 +319,8 @@ PreMask_Length(cat(mask, "ff"), bytes+1) :-
   #endif
 }
 
+// copying of PublicFunction from postTrans causes issues. Need to filter imprecision of the local function inference.
+// Perhaps post incomplete would be the best place to do that.
 .comp ExperimentalCompleteOptimizedGlobalAnalysis <AbstractContextSensitivity> : CompleteOptimizedGlobalAnalysis <AbstractContextSensitivity, PostIncompleteGlobalLocalAnalysis> {
 
   .decl StatementPushesUsedLabel(stmt: Statement)

--- a/logic/global.dl
+++ b/logic/global.dl
@@ -54,12 +54,12 @@ global.StatementPushesUsedLabel(stmt):-
   incompleteGlobal.VariableUsedInAsJumpdest(pushedVar),
   postTrans.Statement_Defines(stmt, pushedVar).
 
-COPY_CODE(global, postTrans)
-global.PublicFunctionJump(block, hex, selector):-
-  incompleteGlobal.ValidPublicFunctionJump(block, hex, selector).
+COPY_CODE_FULL(global, postTrans)
+// global.PublicFunctionJump(block, hex, selector):-
+//   incompleteGlobal.ValidPublicFunctionJump(block, hex, selector).
 
-global.PublicFunction(start, hex, selector):-
-  incompleteGlobal.ValidPublicFunction(start, hex, selector).
+// global.PublicFunction(start, hex, selector):-
+//   incompleteGlobal.ValidPublicFunction(start, hex, selector).
 
 // Masks with all 1s
 .decl Mask_Length(mask: Value, bytes: number)

--- a/logic/global.dl
+++ b/logic/global.dl
@@ -115,11 +115,16 @@ PreMask_Length(cat(mask, "ff"), bytes+1) :-
   .decl BlockJumpValidTarget(ctx: sens.Context, block: Block, var: Variable, target: Block)
 
   /**
+    Under `ctx`, `next` can follow the execution of `block`.
+    Includes both fallthrough edges and jumps.
+  */
+  .decl BlockValidNext(ctx: sens.Context, block: Block, next: Block)
+
+  /**
     When `block` is analyzed under `callerCtx`, there will be a CFG edge
     from `block` to `callee`, causing it to be reachable under `calleeCtx`
   */
   .decl BlockEdge(callerCtx: sens.Context, caller: Block, calleeCtx: sens.Context, callee: Block)
-  
 
 
   /*
@@ -183,31 +188,34 @@ PreMask_Length(cat(mask, "ff"), bytes+1) :-
 
   ReachableContext(calleeCtx, callee) :-
     BlockEdge(_, _, calleeCtx, callee).
-    
+
   ReachableContext(initCtx, FUNCTION_SELECTOR) :-
     sens.InitialContext(initCtx).
 
-  .decl FallthroughEdge(caller: Block, fallthroughBlock: Block)
+  BlockValidNext(ctx, block, next):-
+    BlockJumpValidTarget(ctx, block, _, next).
 
-  FallthroughEdge(caller, as(fallthrough, Block)),
-  BlockEdge(callerCtx, caller, calleeCtx, as(fallthrough, Block)) :-
-    sens.MergeContext(callerCtx, caller, calleeCtx),  // implies reachable
-    Statement_Block(stmt, caller),
-    FallthroughStmt(stmt, fallthrough),
-    IsBasicBlockHead(fallthrough).
+  BlockValidNext(ctx, block, fallthrough):-
+    ReachableContext(ctx, block),
+    FallthroughEdge(block, fallthrough).
+
+  // BlockEdge(callerCtx, caller, calleeCtx, fallthrough) :-
+  //   sens.MergeContext(callerCtx, caller, calleeCtx),  // implies reachable
+  //   FallthroughEdge(caller, fallthrough).
 
   // There may be an unconditional context computed by the algorithm. Use it.
   BlockEdge(callerCtx, caller, calleeCtx, callee) :-
-    BlockJumpValidTarget(callerCtx, caller, _, callee),
+    // BlockJumpValidTarget(callerCtx, caller, _, callee),
+    BlockValidNext(callerCtx, caller, callee),
     sens.MergeContext(callerCtx, caller, calleeCtx).
     .plan 1:(2,1)
 
   // Also check if there is a conditional (on-request) context for this case
-  sens.MergeContextRequest(callerCtx, block, continuation) :-
-    BlockJumpValidTarget(callerCtx, block, _, continuation).
+  sens.MergeContextRequest(callerCtx, block, next) :-
+    BlockValidNext(callerCtx, block, next).
 
   BlockEdge(callerCtx, caller, calleeCtx, callee) :-
-    BlockJumpValidTarget(callerCtx, caller, _, callee),
+    BlockValidNext(callerCtx, caller, callee),
     sens.MergeContextResponse(callerCtx, caller, callee, calleeCtx).
     .plan 1:(2,1)
 
@@ -256,6 +264,9 @@ PreMask_Length(cat(mask, "ff"), bytes+1) :-
     VariableContainsJumpTarget(var),
     !VariableUsedInOperation(var).
 
+  /**
+    Used to verify which variables/stack indexes that seem to be used as selectors, are actually selectors
+  */
   .decl ValidSelector(selector: OptionalSelector)
 
   ValidSelector($NoSelector()).

--- a/logic/global.dl
+++ b/logic/global.dl
@@ -55,11 +55,6 @@ global.StatementPushesUsedLabel(stmt):-
   postTrans.Statement_Defines(stmt, pushedVar).
 
 COPY_CODE_FULL(global, postTrans)
-// global.PublicFunctionJump(block, hex, selector):-
-//   incompleteGlobal.ValidPublicFunctionJump(block, hex, selector).
-
-// global.PublicFunction(start, hex, selector):-
-//   incompleteGlobal.ValidPublicFunction(start, hex, selector).
 
 // Masks with all 1s
 .decl Mask_Length(mask: Value, bytes: number)
@@ -260,26 +255,6 @@ PreMask_Length(cat(mask, "ff"), bytes+1) :-
   VariableAlwaysUsedAsJumpTarget(var):-
     VariableContainsJumpTarget(var),
     !VariableUsedInOperation(var).
-
-  .decl ValidPublicFunctionJump(jumpBlock: Block, hex: Value, selector: OptionalSelector)
-  .decl ValidPublicFunction(startBlock: Block, hex: Value, selector: OptionalSelector)
-  DEBUG_OUTPUT(ValidPublicFunctionJump)
-
-  ValidPublicFunctionJump(jumpBlock, hex, $SelectorStackIndex(block, selectorStackIndex)):-
-    PublicFunctionJump(jumpBlock, hex, $SelectorStackIndex(block, selectorStackIndex)),
-    BlockInputContents(_, block, selectorStackIndex, selectorVariable),
-    FunctionSelectorVariable(selectorVariable).
-
-  ValidPublicFunctionJump(jumpBlock, hex, $SelectorVariable(selectorVariable)):-
-    PublicFunctionJump(jumpBlock, hex, $SelectorVariable(selectorVariable)),
-    FunctionSelectorVariable(selectorVariable).
-
-  ValidPublicFunctionJump(jumpBlock, hex, $NoSelector()):-
-    PublicFunctionJump(jumpBlock, hex, $NoSelector()).
-
-  ValidPublicFunction(startBlock, hex, selector):-
-    ValidPublicFunctionJump(_, hex, selector),
-    PublicFunction(startBlock, hex, selector).
 
   .decl ValidSelector(selector: OptionalSelector)
 

--- a/logic/global.dl
+++ b/logic/global.dl
@@ -281,6 +281,19 @@ PreMask_Length(cat(mask, "ff"), bytes+1) :-
     ValidPublicFunctionJump(_, hex, selector),
     PublicFunction(startBlock, hex, selector).
 
+  .decl ValidSelector(selector: OptionalSelector)
+
+  ValidSelector($NoSelector()).
+
+  ValidSelector($SelectorVariable(selectorVariable)):-
+    IsOptionalSelector($SelectorVariable(selectorVariable)),
+    FunctionSelectorVariable(selectorVariable).
+
+  ValidSelector($SelectorStackIndex(block, selectorStackIndex)):-
+    IsOptionalSelector($SelectorStackIndex(block, selectorStackIndex)),
+    BlockInputContents(_, block, selectorStackIndex, selectorVariable),
+    FunctionSelectorVariable(selectorVariable).
+
 }
 
 /**
@@ -290,6 +303,11 @@ PreMask_Length(cat(mask, "ff"), bytes+1) :-
 
   .override BlockInputContents
 
+  .decl VariableToModel(var: Variable)
+  VariableToModel(var):-
+    VariableContainsJumpTarget(var); FunctionSelectorVariable(var).
+
+
   /**
     Cut down `BlockOutputContents`, only containing jump targets (and the function selector var).
     Stack contents at end of a `block`, given its calling `context`.
@@ -297,7 +315,7 @@ PreMask_Length(cat(mask, "ff"), bytes+1) :-
   .decl AuxBlockOutputContentsJumpTarget(context:sens.Context, block:Block, index:StackIndex, var:Variable)
   AuxBlockOutputContentsJumpTarget(context, block, index, var) :-
     BlockOutputContents(context, block, index, var),
-    (VariableContainsJumpTarget(var); FunctionSelectorVariable(var)).
+    VariableToModel(var).
 
   BlockInputContents(calleeCtx, callee, index, variable) :-
     AuxBlockOutputContentsJumpTarget(callerCtx, caller, index, variable),

--- a/logic/global.dl
+++ b/logic/global.dl
@@ -58,9 +58,8 @@ COPY_CODE(global, postTrans)
 global.PublicFunctionJump(block, hex, selector):-
   incompleteGlobal.ValidPublicFunctionJump(block, hex, selector).
 
-global.PublicFunction(block, hex, selector):-
-  incompleteGlobal.ValidPublicFunctionJump(_, hex, selector),
-  incompleteGlobal.PublicFunction(block, hex, selector).
+global.PublicFunction(start, hex, selector):-
+  incompleteGlobal.ValidPublicFunction(start, hex, selector).
 
 // Masks with all 1s
 .decl Mask_Length(mask: Value, bytes: number)
@@ -277,6 +276,10 @@ PreMask_Length(cat(mask, "ff"), bytes+1) :-
 
   ValidPublicFunctionJump(jumpBlock, hex, $NoSelector()):-
     PublicFunctionJump(jumpBlock, hex, $NoSelector()).
+
+  ValidPublicFunction(startBlock, hex, selector):-
+    ValidPublicFunctionJump(_, hex, selector),
+    PublicFunction(startBlock, hex, selector).
 
 }
 

--- a/logic/global.dl
+++ b/logic/global.dl
@@ -7,8 +7,8 @@
 
 #define MAX_NUM_PRIVATE_FUNCTION_ARGS 50
 #define MAX_NUM_PRIVATE_FUNCTION_RETS 50
-
-#define LIMITSIZE_BLOCK_OUTPUT_CONTENTS 5000000
+// #define ENABLE_LIMITSIZE
+#define LIMITSIZE_BLOCK_OUTPUT_CONTENTS 1000000
 #define CheckIsVariable(v) ((v) < 0)
 #define CheckIsStackIndex(v) ((v) >= 0, (v) < MAX_STACK_HEIGHT)
 
@@ -285,9 +285,9 @@ PreMask_Length(cat(mask, "ff"), bytes+1) :-
 .comp ExperimentalCompleteOptimizedGlobalAnalysis <AbstractContextSensitivity> : CompleteOptimizedGlobalAnalysis <AbstractContextSensitivity> {
 
   .decl StatementPushesUsedLabel(stmt: Statement)
-
-  .override BlockPushesLabel
-  BlockPushesLabel(block, val) :-
+  .output sens.local.BlockPushesLabel, StatementPushesUsedLabel, sens.local.PrivateFunctionCall
+  
+  sens.local.ExtBlockPushesLabel(block, val) :-
     JUMPDEST(as(val, symbol)),
     Variable_Value(var, val),
     Statement_Defines(stmt, var),

--- a/logic/global.dl
+++ b/logic/global.dl
@@ -7,7 +7,7 @@
 
 #define MAX_NUM_PRIVATE_FUNCTION_ARGS 50
 #define MAX_NUM_PRIVATE_FUNCTION_RETS 50
-#define ENABLE_LIMITSIZE
+
 #define LIMITSIZE_BLOCK_OUTPUT_CONTENTS 1000000
 #define CheckIsVariable(v) ((v) < 0)
 #define CheckIsStackIndex(v) ((v) >= 0, (v) < MAX_STACK_HEIGHT)

--- a/logic/global.dl
+++ b/logic/global.dl
@@ -40,9 +40,9 @@
 .type Statement <: symbol
 .type FunctionSignature <: symbol
 
-.init incompleteGlobal = IncompleteOptimizedGlobalAnalysis<CONTEXT_SENSITIVITY>
+.init incompleteGlobal = IncompleteOptimizedGlobalAnalysis<CONTEXT_SENSITIVITY, LocalAnalysis>
 
-COPY_CODE(incompleteGlobal, postTrans)
+COPY_CODE_FULL(incompleteGlobal, postTrans)
 
 .init global = ExperimentalCompleteOptimizedGlobalAnalysis<CONTEXT_SENSITIVITY>
 
@@ -50,7 +50,7 @@ global.StatementPushesUsedLabel(stmt):-
   incompleteGlobal.VariableUsedInAsJumpdest(pushedVar),
   postTrans.Statement_Defines(stmt, pushedVar).
 
-COPY_CODE(global, postTrans)
+COPY_CODE_FULL(global, postTrans)
 
 // Masks with all 1s
 .decl Mask_Length(mask: Value, bytes: number)
@@ -73,18 +73,20 @@ PreMask_Length(cat(mask, "ff"), bytes+1) :-
   bytes < 32.
 
 
-.comp GlobalAnalysis <AbstractContextSensitivity> : PreTransLocalAnalysis {
+.comp GlobalAnalysis <AbstractContextSensitivity, LocalAnalysis> : LocalAnalysis {
   /*
   ***********
   * Key dataflow definitions
   ***********
   */
 
-  .init sens = AbstractContextSensitivity<PreTransLocalAnalysis>
+  .init sens = AbstractContextSensitivity<LocalAnalysis>
 
   sens.local.PushValue(push, val):- PushValue(push, val).
   sens.local.Statement_Opcode(stmt, op):- Statement_Opcode(stmt, op).
   sens.local.Statement_Next(stmt, stmtNext):- Statement_Next(stmt, stmtNext).
+  sens.local.PublicFunction(block, hex):- PublicFunction(block, hex).
+  sens.local.PublicFunctionJump(block, hex):- PublicFunctionJump(block, hex).
 
   // `block` is reachable under `context`
   .decl ReachableContext(context: sens.Context, block: Block)
@@ -254,7 +256,7 @@ PreMask_Length(cat(mask, "ff"), bytes+1) :-
 /**
   A global analysis component optimized by only modeling the stack locations containing jump targets
 */
-.comp OptimizedGlobalAnalysis <AbstractContextSensitivity> : GlobalAnalysis <AbstractContextSensitivity> {
+.comp OptimizedGlobalAnalysis <AbstractContextSensitivity, LocalAnalysis> : GlobalAnalysis <AbstractContextSensitivity, LocalAnalysis> {
 
   .override BlockInputContents
 
@@ -277,25 +279,26 @@ PreMask_Length(cat(mask, "ff"), bytes+1) :-
 /**
   Used whenever a best effort is good enough
 */
-.comp IncompleteOptimizedGlobalAnalysis <AbstractContextSensitivity> : OptimizedGlobalAnalysis <AbstractContextSensitivity> {
+.comp IncompleteOptimizedGlobalAnalysis <AbstractContextSensitivity, LocalAnalysis> : OptimizedGlobalAnalysis <AbstractContextSensitivity, LocalAnalysis> {
   .limitsize BlockOutputContents(n=LIMITSIZE_BLOCK_OUTPUT_CONTENTS)
 }
 
 /**
   Used for the main global analysis. Only has a limitsize if the `--enable_limitsize` flag is set.
 */
-.comp CompleteOptimizedGlobalAnalysis <AbstractContextSensitivity> : OptimizedGlobalAnalysis <AbstractContextSensitivity> {
+.comp CompleteOptimizedGlobalAnalysis <AbstractContextSensitivity, LocalAnalysis> : OptimizedGlobalAnalysis <AbstractContextSensitivity, LocalAnalysis> {
   #ifdef ENABLE_LIMITSIZE
   .limitsize BlockOutputContents(n=LIMITSIZE_BLOCK_OUTPUT_CONTENTS)
   #endif
 }
 
-.comp ExperimentalCompleteOptimizedGlobalAnalysis <AbstractContextSensitivity> : CompleteOptimizedGlobalAnalysis <AbstractContextSensitivity> {
+.comp ExperimentalCompleteOptimizedGlobalAnalysis <AbstractContextSensitivity> : CompleteOptimizedGlobalAnalysis <AbstractContextSensitivity, PostIncompleteGlobalLocalAnalysis> {
 
   .decl StatementPushesUsedLabel(stmt: Statement)
   // .output sens.local.BlockPushesLabel, StatementPushesUsedLabel, sens.local.PrivateFunctionCall
   // .output BlockPushesLabel
-  sens.local.ExtBlockPushesLabel(block, val) :-
+  ExtBlockPushesLabel(block, val),
+  sens.local.ExtBlockPushesLabel(block, val):-
     JUMPDEST(as(val, symbol)),
     Variable_Value(var, val),
     Statement_Defines(stmt, var),
@@ -307,8 +310,9 @@ PreMask_Length(cat(mask, "ff"), bytes+1) :-
 }
 
 /**
-  Declared just so it can be used as a parameter in another component
+  Declared just so it can be used as a parameter in another component.
+  Used by the SafeBlockCloner so it uses `PreTransLocalAnalysis`
 */
-.comp DefaultIncompleteOptimizedGlobalAnalysis : IncompleteOptimizedGlobalAnalysis <TransactionalWithShrinkingContext> {
+.comp DefaultIncompleteOptimizedGlobalAnalysis : IncompleteOptimizedGlobalAnalysis <TransactionalWithShrinkingContext, PreTransLocalAnalysis> {
 
 }

--- a/logic/global.dl
+++ b/logic/global.dl
@@ -47,7 +47,7 @@ COPY_CODE(incompleteGlobal, postTrans)
 .init global = ExperimentalCompleteOptimizedGlobalAnalysis<CONTEXT_SENSITIVITY>
 
 global.StatementPushesUsedLabel(stmt):-
-  incompleteGlobal.VariableAlwaysUsedAsJumpTarget(pushedVar),
+  incompleteGlobal.VariableUsedInAsJumpdest(pushedVar),
   postTrans.Statement_Defines(stmt, pushedVar).
 
 COPY_CODE(global, postTrans)
@@ -232,6 +232,14 @@ PreMask_Length(cat(mask, "ff"), bytes+1) :-
     op != "JUMP",
     op != "JUMPI".
 
+  .decl VariableUsedInAsJumpdest(var: Variable)
+
+  VariableUsedInAsJumpdest(var):-
+    Statement_Uses(stmt, var, 0),
+    Statement_Opcode(stmt, op),
+    (op = "JUMP"; op = "JUMPI").
+
+
   VariableUsedInOperation(var):-
     Statement_Uses(stmt, var, 1),
     Statement_Opcode(stmt, "JUMPI").
@@ -285,8 +293,8 @@ PreMask_Length(cat(mask, "ff"), bytes+1) :-
 .comp ExperimentalCompleteOptimizedGlobalAnalysis <AbstractContextSensitivity> : CompleteOptimizedGlobalAnalysis <AbstractContextSensitivity> {
 
   .decl StatementPushesUsedLabel(stmt: Statement)
-  .output sens.local.BlockPushesLabel, StatementPushesUsedLabel, sens.local.PrivateFunctionCall
-  
+  // .output sens.local.BlockPushesLabel, StatementPushesUsedLabel, sens.local.PrivateFunctionCall
+  // .output BlockPushesLabel
   sens.local.ExtBlockPushesLabel(block, val) :-
     JUMPDEST(as(val, symbol)),
     Variable_Value(var, val),

--- a/logic/global.dl
+++ b/logic/global.dl
@@ -40,7 +40,15 @@
 .type Statement <: symbol
 .type FunctionSignature <: symbol
 
-.init global = OptimizedGlobalAnalysis<CONTEXT_SENSITIVITY>
+.init incompleteGlobal = IncompleteOptimizedGlobalAnalysis<CONTEXT_SENSITIVITY>
+
+COPY_CODE(incompleteGlobal, postTrans)
+
+.init global = ExperimentalCompleteOptimizedGlobalAnalysis<CONTEXT_SENSITIVITY>
+
+global.StatementPushesUsedLabel(stmt):-
+  incompleteGlobal.VariableAlwaysUsedAsJumpTarget(pushedVar),
+  postTrans.Statement_Defines(stmt, pushedVar).
 
 COPY_CODE(global, postTrans)
 
@@ -83,12 +91,8 @@ PreMask_Length(cat(mask, "ff"), bytes+1) :-
 
   // Stack contents at end of a `block`, given its calling `context`.
   .decl BlockOutputContents(context: sens.Context, block: Block, index: StackIndex, var: Variable)
-  #ifdef ENABLE_LIMITSIZE
-  .limitsize BlockOutputContents(n=LIMITSIZE_BLOCK_OUTPUT_CONTENTS)
-  #endif
-
   DEBUG_OUTPUT(BlockOutputContents)
-  
+
   /**
     Stack contents at start of a `block`, given its calling `context`.
     Added overridable flag to override it in the optimized variant of the component
@@ -261,9 +265,42 @@ PreMask_Length(cat(mask, "ff"), bytes+1) :-
     .plan 1:(2,1)
 }
 
+
+/**
+  Used whenever a best effort is good enough
+*/
+.comp IncompleteOptimizedGlobalAnalysis <AbstractContextSensitivity> : OptimizedGlobalAnalysis <AbstractContextSensitivity> {
+  .limitsize BlockOutputContents(n=LIMITSIZE_BLOCK_OUTPUT_CONTENTS)
+}
+
+/**
+  Used for the main global analysis. Only has a limitsize if the `--enable_limitsize` flag is set.
+*/
+.comp CompleteOptimizedGlobalAnalysis <AbstractContextSensitivity> : OptimizedGlobalAnalysis <AbstractContextSensitivity> {
+  #ifdef ENABLE_LIMITSIZE
+  .limitsize BlockOutputContents(n=LIMITSIZE_BLOCK_OUTPUT_CONTENTS)
+  #endif
+}
+
+.comp ExperimentalCompleteOptimizedGlobalAnalysis <AbstractContextSensitivity> : CompleteOptimizedGlobalAnalysis <AbstractContextSensitivity> {
+
+  .decl StatementPushesUsedLabel(stmt: Statement)
+
+  .override BlockPushesLabel
+  BlockPushesLabel(block, val) :-
+    JUMPDEST(as(val, symbol)),
+    Variable_Value(var, val),
+    Statement_Defines(stmt, var),
+    StatementPushesUsedLabel(stmt),
+    Statement_Block(stmt, block),
+    BasicBlock_Tail(block, call),
+    LocalStackContents(call, _, var),
+    !BlockUsesLocal(block, var). 
+}
+
 /**
   Declared just so it can be used as a parameter in another component
 */
-.comp DefaultOptimizedGlobalAnalysis : OptimizedGlobalAnalysis <TransactionalWithShrinkingContext> {
+.comp DefaultIncompleteOptimizedGlobalAnalysis : IncompleteOptimizedGlobalAnalysis <TransactionalWithShrinkingContext> {
 
 }

--- a/logic/local.dl
+++ b/logic/local.dl
@@ -554,8 +554,10 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
     StaticBlockJumpTarget(caller2, target),
     caller != caller2.
 
+  .decl ExtBlockPushesLabel(block: Block, val: Value)
+
   // pushes a label for later use. A return addr?
-  .decl BlockPushesLabel(block: Block, val: Value) overridable
+  .decl BlockPushesLabel(block: Block, val: Value)
   BlockPushesLabel(block, val) :-
     JUMPDEST(as(val, symbol)),
     Variable_Value(var, val),
@@ -563,7 +565,8 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
     Statement_Block(stmt, block),
     BasicBlock_Tail(block, call),
     LocalStackContents(call, _, var),
-    !BlockUsesLocal(block, var).
+    !BlockUsesLocal(block, var),
+    !ExtBlockPushesLabel(_, _).
 
   // Same reasoning, with more detail. In very rare cases, the continuation will not be found,
   // even though BlockPushesLabel is true.

--- a/logic/local.dl
+++ b/logic/local.dl
@@ -773,7 +773,11 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
     JUMPI(jumpiStmt),
     Statement_Uses_Local(jumpiStmt, pred, 1).
 
-  PublicFunctionJump(block, sigHash, selectorVarOrIndex) :-   BlockComparesSig(block, sigHash, selectorVarOrIndex).
+  PublicFunctionJump(block, sigHash, selectorVarOrIndex) :-
+    BlockComparesSig(block, sigHash, selectorVarOrIndex);
+    BlockComparesSigVyper(block, sigHash, selectorVarOrIndex);
+    BlockComparesSigFallthroughSolidity(block, sigHash, selectorVarOrIndex).
+
 
   PublicFunction(as(targetValue, Block), sigHash, selectorVarOrIndex) :-
     BlockComparesSig(block, sigHash, selectorVarOrIndex),
@@ -781,6 +785,11 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
     Statement_Defines(push, var),
     PushValue(push, targetValue),
     JUMPDEST(as(targetValue, symbol)).
+
+  PublicFunction(fallthrough, sigHash, selectorVarOrIndex) :-
+    (BlockComparesSigVyper(block, sigHash, selectorVarOrIndex);
+    BlockComparesSigFallthroughSolidity(block, sigHash, selectorVarOrIndex)),
+    FallthroughEdge(block, fallthrough).
 
   .decl BlockComparesCallDataSizeToFour(block: Block, jumpi: Statement, lessThanFourTarget: Block)
   .decl BlockJumpsOnCallDataSize(block: Block, jumpi: Statement, noCallDataBranch: Block, callDataBranch: Block)
@@ -947,7 +956,7 @@ insertor.insertOps(jumpDestStmt,
     STMT(JUMP, cat("PublicFunctionJump:", hash))
   )
 ) :-
-   preTrans.PublicFunctionJump(block, hash, selector),
+   preTrans.BlockComparesSig(block, hash, selector),
    preTrans.PublicFunction(start, hash, selector),
    ValidSelector(selector),
    preTrans.Statement_Block(jumpDestStmt, start),
@@ -1086,7 +1095,7 @@ postTrans.PublicFunctionJump(block, hash, selector) :-
    insertor.PublicFunctionJumpMetadata(meta, hash),
    postTrans.Statement_Block(stmt, block),
    ValidSelector(selector),
-   (preTrans.PublicFunctionJump(_, hash, selector);
+   (preTrans.BlockComparesSig(_, hash, selector);
    preTrans.BlockComparesSigVyper(_, hash, selector);
    preTrans.BlockComparesSigFallthroughSolidity(_, hash, selector);
    (preTrans.BlockHasReceiveAsFallThrough(_, _, _, _), hash = RECEIVE_FUNCTION_SIGHASH, selector = $NoSelector())

--- a/logic/local.dl
+++ b/logic/local.dl
@@ -654,6 +654,17 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
     SHR(shift),
     Statement_Defines(shift, selector).
 
+  FunctionSelectorVariable(selector):-
+    CALLDATALOAD(stmt),
+    Statement_Uses_Local(stmt, zeroVar, 0),
+    Variable_Value(zeroVar, "0x0"),
+    Statement_Defines(stmt, variable),
+    Statement_Uses_Local(shift, variable, 0),
+    Statement_Uses_Local(shift, shiftConst, 1),
+    Variable_Value(shiftConst, "0x100000000000000000000000000000000000000000000000000000000"),
+    DIV(shift),
+    Statement_Defines(shift, selector).
+
 }
 
 .comp PreTransLocalAnalysis : LocalAnalysis {

--- a/logic/local.dl
+++ b/logic/local.dl
@@ -568,6 +568,9 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
     !BlockUsesLocal(block, var),
     !ExtBlockPushesLabel(_, _).
 
+  BlockPushesLabel(block, val):-
+    ExtBlockPushesLabel(block, val).
+
   // Same reasoning, with more detail. In very rare cases, the continuation will not be found,
   // even though BlockPushesLabel is true.
   .decl CallBlockPushesContinuation(caller: Block, callee: Block, cont: Block, index: number)

--- a/logic/local.dl
+++ b/logic/local.dl
@@ -1130,7 +1130,10 @@ postTrans.PublicFunction(block, hash, $NoSelector()) :-
    postTrans.JUMPDEST(stmt),
    postTrans.Statement_Block(stmt, block).
 
-postTrans.PublicFunction(b, h, s) :- preTrans.PublicFunction(b, h, s), ValidSelector(s).
+postTrans.PublicFunction(block , hash, selector):- 
+  preTrans.BlockComparesSig(_, hash, selector),
+  preTrans.PublicFunction(block, hash, selector),
+  ValidSelector(selector).
 
 .output postTrans.PublicFunction, preTrans.PublicFunction, preTrans.BlockComparesSigFallthroughSolidity, preTrans.BlockComparesSigVyper, insertor.MetaData
 .output postTrans.PublicFunctionJump

--- a/logic/local.dl
+++ b/logic/local.dl
@@ -794,6 +794,7 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
   .decl BlockComparesCallDataSizeToFour(block: Block, jumpi: Statement, lessThanFourTarget: Block)
   .decl BlockJumpsOnCallDataSize(block: Block, jumpi: Statement, noCallDataBranch: Block, callDataBranch: Block)
   .decl BlockHasReceiveAsFallThrough(block: Block, jumpi: Statement, fallthrough: Block, target: Block)
+  .decl FallBackFunctionInfo(caller: Block, startBlock: Block, sigHash: Value, selector: OptionalSelector)
 
   BlockComparesCallDataSizeToFour(block, stmt5, as(target, Block)):-
     PushValue(stmt, "0x4"),
@@ -846,11 +847,14 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
     JUMPDEST(as(noCallDataSizeBranch, Statement)).
 
   // Fallback functions
-  PublicFunctionJump(block, FALLBACK_FUNCTION_SIGHASH, $NoSelector()),
-  PublicFunction(fallbackStart, FALLBACK_FUNCTION_SIGHASH, $NoSelector()):-
+  FallBackFunctionInfo(block, fallbackStart, FALLBACK_FUNCTION_SIGHASH, $NoSelector()):-
     BlockComparesCallDataSizeToFour(block, _, fallbackStart),
     1 = count : BlockComparesCallDataSizeToFour(_, _, _),
     !BlockJumpsOnCallDataSize(fallbackStart, _, _, _).
+
+  PublicFunctionJump(block, sigHash, selector),
+  PublicFunction(fallbackStart, sigHash, selector):-
+    FallBackFunctionInfo(block, fallbackStart, sigHash, selector).
 
   BlockHasReceiveAsFallThrough(block, jumpi, noCallDataSizeBranch, callDataSizeBranch):-
     BlockComparesCallDataSizeToFour(_, _, block),
@@ -956,7 +960,8 @@ insertor.insertOps(jumpDestStmt,
     STMT(JUMP, cat("PublicFunctionJump:", hash))
   )
 ) :-
-   preTrans.BlockComparesSig(block, hash, selector),
+   (preTrans.BlockComparesSig(block, hash, selector);
+   preTrans.FallBackFunctionInfo(block, start, hash, selector)),
    preTrans.PublicFunction(start, hash, selector),
    ValidSelector(selector),
    preTrans.Statement_Block(jumpDestStmt, start),
@@ -1096,6 +1101,7 @@ postTrans.PublicFunctionJump(block, hash, selector) :-
    postTrans.Statement_Block(stmt, block),
    ValidSelector(selector),
    (preTrans.BlockComparesSig(_, hash, selector);
+   preTrans.FallBackFunctionInfo(_, _, hash, selector);
    preTrans.BlockComparesSigVyper(_, hash, selector);
    preTrans.BlockComparesSigFallthroughSolidity(_, hash, selector);
    (preTrans.BlockHasReceiveAsFallThrough(_, _, _, _), hash = RECEIVE_FUNCTION_SIGHASH, selector = $NoSelector())
@@ -1131,7 +1137,8 @@ postTrans.PublicFunction(block, hash, $NoSelector()) :-
    postTrans.Statement_Block(stmt, block).
 
 postTrans.PublicFunction(block , hash, selector):- 
-  preTrans.BlockComparesSig(_, hash, selector),
+  (preTrans.BlockComparesSig(_, hash, selector);
+  preTrans.FallBackFunctionInfo(_, _, hash, selector)),
   preTrans.PublicFunction(block, hash, selector),
   ValidSelector(selector).
 

--- a/logic/local.dl
+++ b/logic/local.dl
@@ -888,6 +888,8 @@ PreTransStatement_OriginalStatement(rvtClStmt, ogStmt) :-
 .init revertCloner = RevertBlockCloner
 COPY_CODE(revertCloner, factReader)
 
+.decl ValidSelector(optionalSelector: OptionalSelector)
+
 #ifdef BLOCK_CLONING
 // Enable the early cloning of blocks to increase precision (sacrificing performance)
 .init blockCloner = BLOCK_CLONING
@@ -903,9 +905,15 @@ PreTransStatement_OriginalStatement(heurClStmt, ogStmt) :-
   blockCloner.StatementToClonedStatement(_, _, ogStmt, heurClStmt),
   !revertCloner.StatementToClonedStatement(_, _, _, ogStmt).
 
+ValidSelector(optionalSelector):-
+  blockCloner.analysis.ValidSelector(optionalSelector).
+
 #else
 
 COPY_OUTPUT(preTrans, revertCloner)
+
+ValidSelector(optionalSelector):-
+  preTrans.IsOptionalSelector(optionalSelector).
 
 #endif
 
@@ -930,6 +938,7 @@ insertor.insertOps(jumpDestStmt,
 ) :-
    preTrans.PublicFunctionJump(block, hash, selector),
    preTrans.PublicFunction(start, hash, selector),
+   ValidSelector(selector),
    preTrans.Statement_Block(jumpDestStmt, start),
    preTrans.JUMPDEST(jumpDestStmt),
    preTrans.PushValue(pushStmt, as(jumpDestStmt, symbol)),
@@ -946,7 +955,8 @@ insertor.insertOps(functionStartStmt,
     STMT(JUMPDEST, MAKE_LABEL_REFERENCE(hash))
   )
 ) :-
-   preTrans.BlockComparesSigVyper(block, hash, _),
+   preTrans.BlockComparesSigVyper(block, hash, selector),
+   ValidSelector(selector),
    preTrans.BasicBlock_Tail(block, tail),
    preTrans.Statement_Next(tail, functionStartStmt),
    !preTrans.BlockComparesSig(_, _, _).
@@ -959,7 +969,8 @@ insertor.insertOps(functionStartStmt,
     STMT(JUMPDEST, MAKE_LABEL_REFERENCE(hash))
   )
 ) :-
-   preTrans.BlockComparesSigFallthroughSolidity(block, hash, _),
+   preTrans.BlockComparesSigFallthroughSolidity(block, hash, selector),
+   ValidSelector(selector),
    preTrans.BasicBlock_Tail(block, tail),
    preTrans.Statement_Next(tail, functionStartStmt),
    !preTrans.BlockComparesSig(_, hash, _).
@@ -1063,6 +1074,7 @@ postTrans.PublicFunctionJump(block, hash, selector) :-
    insertor.MetaData(stmt, meta),
    insertor.PublicFunctionJumpMetadata(meta, hash),
    postTrans.Statement_Block(stmt, block),
+   ValidSelector(selector),
    (preTrans.PublicFunctionJump(_, hash, selector);
    preTrans.BlockComparesSigVyper(_, hash, selector);
    preTrans.BlockComparesSigFallthroughSolidity(_, hash, selector);
@@ -1076,6 +1088,7 @@ postTrans.PublicFunction(block, hash, selector):-
    postTrans.JUMPDEST(stmt),
    postTrans.Statement_Block(stmt, block),
    preTrans.BlockComparesSigVyper(_, hash, selector),
+   ValidSelector(selector),
    !preTrans.BlockComparesSig(_, _, _),
    ISLABEL(meta), hash = GET_LABEL_REFERENCE(meta).
 
@@ -1084,6 +1097,7 @@ postTrans.PublicFunction(block, hash, selector) :-
    postTrans.JUMPDEST(stmt),
    postTrans.Statement_Block(stmt, block),
    preTrans.BlockComparesSigFallthroughSolidity(_, hash, selector),
+   ValidSelector(selector),
    !preTrans.BlockComparesSig(_, hash, _),
    ISLABEL(meta), hash = GET_LABEL_REFERENCE(meta).
 
@@ -1096,7 +1110,8 @@ postTrans.PublicFunction(block, hash, $NoSelector()) :-
    postTrans.JUMPDEST(stmt),
    postTrans.Statement_Block(stmt, block).
 
-postTrans.PublicFunction(b, h, s) :- preTrans.PublicFunction(b, h, s).
+postTrans.PublicFunction(b, h, s) :- preTrans.PublicFunction(b, h, s), ValidSelector(s).
+
 .output postTrans.PublicFunction, preTrans.PublicFunction, preTrans.BlockComparesSigFallthroughSolidity, preTrans.BlockComparesSigVyper, insertor.MetaData
 .output postTrans.PublicFunctionJump
 // Code chunking logic reserved for future EIP

--- a/logic/local.dl
+++ b/logic/local.dl
@@ -288,7 +288,6 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
 
   // Covers JUMPIs and other fallthrough cases
   .decl FallthroughStmt(stmt: Statement, next: Statement)
-
   FallthroughStmt(stmt, next) :-
     BasicBlock_Tail(_, stmt),
     !JUMP(stmt),
@@ -296,9 +295,13 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
     !OpcodePossiblyHalts(opcode),
     Statement_Next(stmt, next).
 
+  .decl FallthroughEdge(caller: Block, fallthroughBlock: Block)
+  FallthroughEdge(caller, as(fallthrough, Block)):-
+    Statement_Block(stmt, caller),
+    FallthroughStmt(stmt, fallthrough),
+    IsBasicBlockHead(fallthrough).
 
-  .decl ThrowJump(stmt: Statement)
-  
+  .decl ThrowJump(stmt: Statement)  
   ThrowJump(jmp) :-
      ImmediateBlockJumpTarget(block, variable),
      Variable_Value(variable, targetValue),
@@ -722,7 +725,7 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
 
   BlockComparesSigVyperBase(block, sigHash, selectorVarOrIndex) :-
     Statement_Block(pushStmt, block),
-    (PUSH4(pushStmt, sigHash) ; PUSH3(pushStmt, sigHash)),
+    SmallValuePush(pushStmt, sigHash),
     Statement_Defines(pushStmt, sigHashVar),
     Statement_Uses_Local(eqStmt, sigHashVar, n),
     Statement_Uses_Local(eqStmt, selectorVarOrIndex, 1 - n),
@@ -737,7 +740,7 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
   // New vyper pattern
   BlockComparesSigVyperBase(block, sigHash, selectorVarOrIndex):-
     Statement_Block(pushStmt, block),
-    (PUSH4(pushStmt, sigHash) ; PUSH3(pushStmt, sigHash)),
+    SmallValuePush(pushStmt, sigHash),
     Statement_Defines(pushStmt, sigHashVar),
     Statement_Uses_Local(xorStmt, sigHashVar, n),
     Statement_Uses_Local(xorStmt, selectorVarOrIndex, 1 - n),
@@ -759,7 +762,7 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
   BlockComparesSigFallthroughSolidity(block, sigHash, selector) :-
     Statement_Block(pushStmt, block),
     ImmediateBlockJumpTarget(block, _),
-    (PUSH4(pushStmt, sigHash) ; PUSH3(pushStmt, sigHash)),
+    SmallValuePush(pushStmt, sigHash),
     Statement_Defines(pushStmt, sigHashVar),
     SUB(subStmt),
     Statement_Uses_Local(subStmt, sigHashVar, n),

--- a/logic/local.dl
+++ b/logic/local.dl
@@ -466,26 +466,14 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
      Statement_Opcode(stmt, opcode),
      OpcodeGas(opcode, gas).
 
-  .decl PublicFunctionJump(block:Block, funHex: Value, optionalSelector: OptionalSelector)
-  .decl PublicFunction(block:Block, funHex: Value, optionalSelector: OptionalSelector)
+  .decl PublicFunctionJump(block: Block, funHex: Value, optionalSelector: OptionalSelector)
+  .decl PublicFunction(block: Block, funHex: Value, optionalSelector: OptionalSelector)
 
-  // Code inserted by compiler to compare function signature
-  .decl BlockComparesSig(block: Block, sigHash: Value, selectorVarOrIndex: OptionalSelector)
+  .decl IsOptionalSelector(optionalSelector: OptionalSelector)
 
-  // Compares label from stack to a constant: common public function dispatch pattern
-  BlockComparesSig(block, sigHash, selector) :-
-    Statement_Block(pushStmt, block),
-    ImmediateBlockJumpTarget(block, _),
-    (PUSH4(pushStmt, sigHash) ; PUSH3(pushStmt, sigHash)),
-    Statement_Defines(pushStmt, sigHashVar),
-    EQ(eqStmt),
-    Statement_Uses_Local(eqStmt, sigHashVar, n),
-    Statement_Uses_Local(eqStmt, selectorVarOrIndex, 1 - n),
-    ((CheckIsStackIndex(selectorVarOrIndex), selector = $SelectorStackIndex(block, selectorVarOrIndex));
-     (CheckIsVariable(selectorVarOrIndex), selector = $SelectorVariable(selectorVarOrIndex))),
-    Statement_Defines(eqStmt, pred),
-    JUMPI(jumpiStmt),
-    Statement_Uses_Local(jumpiStmt, pred, 1).
+  IsOptionalSelector(optionalSelector):-
+    PublicFunctionJump(_, _, optionalSelector);
+    PublicFunction(_, _, optionalSelector).
 
   .decl SWAPDUPPOPJUMPJUMPDESTOP(op: Opcode)
   SWAPDUPPOPJUMPJUMPDESTOP(opcode):-
@@ -695,6 +683,30 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
     codeOffsetNum = @hex_to_number(codeOffsetNumHex),
     ByteCodeHex(bytecodeStr),
     const = cat("0x", substr(bytecodeStr, 2*codeOffsetNum, 2*smallNum)).
+
+  IsOptionalSelector(selectorVarOrIndex):-
+    BlockComparesSig(_, _, selectorVarOrIndex);
+    BlockComparesSigFallthroughSolidity(_, _, selectorVarOrIndex);
+    BlockComparesSigVyper(_, _, selectorVarOrIndex).
+
+    // Code inserted by compiler to compare function signature
+  .decl BlockComparesSig(block: Block, sigHash: Value, selectorVarOrIndex: OptionalSelector)
+
+  // Compares label from stack to a constant: common public function dispatch pattern
+  BlockComparesSig(block, sigHash, selector) :-
+    Statement_Block(pushStmt, block),
+    ImmediateBlockJumpTarget(block, _),
+    (PUSH4(pushStmt, sigHash) ; PUSH3(pushStmt, sigHash)),
+    Statement_Defines(pushStmt, sigHashVar),
+    EQ(eqStmt),
+    Statement_Uses_Local(eqStmt, sigHashVar, n),
+    Statement_Uses_Local(eqStmt, selectorVarOrIndex, 1 - n),
+    ((CheckIsStackIndex(selectorVarOrIndex), selector = $SelectorStackIndex(block, selectorVarOrIndex));
+     (CheckIsVariable(selectorVarOrIndex), selector = $SelectorVariable(selectorVarOrIndex))),
+    Statement_Defines(eqStmt, pred),
+    JUMPI(jumpiStmt),
+    Statement_Uses_Local(jumpiStmt, pred, 1).
+
 
   .decl BlockComparesSigVyper(block: Block, sigHash: Value, selectorVarOrIndex: OptionalSelector)
 
@@ -928,9 +940,9 @@ insertor.insertOps(functionStartStmt,
 // Receive transformation
 insertor.insertOps(functionStartStmt,
   LIST(
-    STMT(PUSH4, MAKE_LABEL_REFERENCE("0x00000000")),
-    STMT(JUMP, cat("PublicFunctionJump:", "0x00000000")),
-    STMT(JUMPDEST, MAKE_LABEL_REFERENCE("0x00000000"))
+    STMT(PUSH4, MAKE_LABEL_REFERENCE(RECEIVE_FUNCTION_SIGHASH)),
+    STMT(JUMP, cat("PublicFunctionJump:", RECEIVE_FUNCTION_SIGHASH)),
+    STMT(JUMPDEST, MAKE_LABEL_REFERENCE(RECEIVE_FUNCTION_SIGHASH))
   )
 ) :-
   preTrans.BlockHasReceiveAsFallThrough(_, _, functionStartStmt, _).
@@ -1024,7 +1036,7 @@ postTrans.PublicFunctionJump(block, hash, selector) :-
    (preTrans.PublicFunctionJump(_, hash, selector);
    preTrans.BlockComparesSigVyper(_, hash, selector);
    preTrans.BlockComparesSigFallthroughSolidity(_, hash, selector);
-   (preTrans.BlockHasReceiveAsFallThrough(_, _, _, _), hash = "0x00000000", selector = $NoSelector())
+   (preTrans.BlockHasReceiveAsFallThrough(_, _, _, _), hash = RECEIVE_FUNCTION_SIGHASH, selector = $NoSelector())
    ).
    // we may lose some precision here when two blocks have the same hex
 
@@ -1048,7 +1060,7 @@ postTrans.PublicFunction(block, hash, selector) :-
 // For receive functions
 postTrans.PublicFunction(block, hash, $NoSelector()) :-
    preTrans.BlockHasReceiveAsFallThrough(_, _, _, _),
-   hash = "0x00000000",
+   hash = RECEIVE_FUNCTION_SIGHASH,
    hash = GET_LABEL_REFERENCE(meta), ISLABEL(meta),
    insertor.MetaData(stmt, meta),
    postTrans.JUMPDEST(stmt),

--- a/logic/local.dl
+++ b/logic/local.dl
@@ -554,10 +554,8 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
     StaticBlockJumpTarget(caller2, target),
     caller != caller2.
 
-  .decl ExtBlockPushesLabel(block: Block, val: Value)
-
   // pushes a label for later use. A return addr?
-  .decl BlockPushesLabel(block: Block, val: Value)
+  .decl BlockPushesLabel(block: Block, val: Value) overridable
   BlockPushesLabel(block, val) :-
     JUMPDEST(as(val, symbol)),
     Variable_Value(var, val),
@@ -565,11 +563,7 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
     Statement_Block(stmt, block),
     BasicBlock_Tail(block, call),
     LocalStackContents(call, _, var),
-    !BlockUsesLocal(block, var),
-    !ExtBlockPushesLabel(_, _).
-
-  BlockPushesLabel(block, val):-
-    ExtBlockPushesLabel(block, val).
+    !BlockUsesLocal(block, var).
 
   // Same reasoning, with more detail. In very rare cases, the continuation will not be found,
   // even though BlockPushesLabel is true.
@@ -625,6 +619,20 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
  .output MultiplePrivateFunctionCall
  .output PrivateFunctionCall
 // .output CallBlockEarliestContinuation
+
+  .decl CODECOPYStatement(stmt: Statement, offset: Value, size: Value)
+
+  CODECOPYStatement(codeCopy, codeOffsetNumHex, smallNumHex) :-
+    Statement_Opcode(codeCopy, "CODECOPY"),
+    BeforeLocalStackContents(codeCopy, 2, lenVar),
+    CheckIsVariable(lenVar),
+    Statement_Defines(pushLen, lenVar),
+    PushValue(pushLen, smallNumHex),
+    BeforeLocalStackContents(codeCopy, 1, codeOffsetVar),
+    CheckIsVariable(codeOffsetVar),
+    Statement_Defines(pushCodeOffset, codeOffsetVar),
+    PushValue(pushCodeOffset, codeOffsetNumHex).
+
 }
 
 .comp PreTransLocalAnalysis : LocalAnalysis {
@@ -655,20 +663,6 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
     codeOffsetNum = @hex_to_number(codeOffsetNumHex),
     ByteCodeHex(bytecodeStr),
     const = cat("0x", substr(bytecodeStr, 2*codeOffsetNum, 2*smallNum)).
-
-  .decl CODECOPYStatement(stmt: Statement, offset: Value, size: Value)
-
-  CODECOPYStatement(codeCopy, codeOffsetNumHex, smallNumHex) :-
-    Statement_Opcode(codeCopy, "CODECOPY"),
-    BeforeLocalStackContents(codeCopy, 2, lenVar),
-    CheckIsVariable(lenVar),
-    Statement_Defines(pushLen, lenVar),
-    PushValue(pushLen, smallNumHex),
-    BeforeLocalStackContents(codeCopy, 1, codeOffsetVar),
-    CheckIsVariable(codeOffsetVar),
-    Statement_Defines(pushCodeOffset, codeOffsetVar),
-    PushValue(pushCodeOffset, codeOffsetNumHex).
-
 
   .decl BlockComparesSigVyper(block: Block, sigHash: Value)
 
@@ -762,6 +756,14 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
                                              
 }
 
+.comp PostIncompleteGlobalLocalAnalysis : LocalAnalysis {
+  .decl ExtBlockPushesLabel(block: Block, val: Value)
+
+  .override BlockPushesLabel
+
+  BlockPushesLabel(block, val):-
+    ExtBlockPushesLabel(block, val).
+}
 
 /**
    Preprocessing of decompiler input, to yield convenient relations

--- a/logic/local.dl
+++ b/logic/local.dl
@@ -555,7 +555,7 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
     caller != caller2.
 
   // pushes a label for later use. A return addr?
-  .decl BlockPushesLabel(block: Block, val: Value)
+  .decl BlockPushesLabel(block: Block, val: Value) overridable
   BlockPushesLabel(block, val) :-
     JUMPDEST(as(val, symbol)),
     Variable_Value(var, val),

--- a/logic/local.dl
+++ b/logic/local.dl
@@ -771,43 +771,70 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
     PushValue(push, targetValue),
     JUMPDEST(as(targetValue, symbol)).
 
-  .decl BlockComparesCallDataSizeToFour(block: Block, jumpi: Statement, target: Block)
-  .decl BlockJumpsOnCallDataSize(block: Block, jumpi: Statement, target: Block)
-  .decl BlockHasReceiveAsFallThrough(block: Block, jumpi: Statement, fallthrough:Statement, target: Block)
+  .decl BlockComparesCallDataSizeToFour(block: Block, jumpi: Statement, lessThanFourTarget: Block)
+  .decl BlockJumpsOnCallDataSize(block: Block, jumpi: Statement, noCallDataBranch: Block, callDataBranch: Block)
+  .decl BlockHasReceiveAsFallThrough(block: Block, jumpi: Statement, fallthrough: Block, target: Block)
 
-  BlockComparesCallDataSizeToFour(block, stmt5, as(fallthrough, Block)):-
+  BlockComparesCallDataSizeToFour(block, stmt5, as(target, Block)):-
     PushValue(stmt, "0x4"),
     Statement_Next(stmt, stmt2),
     CALLDATASIZE(stmt2),
     Statement_Next(stmt2, stmt3),
     LT(stmt3),
     Statement_Next(stmt3, stmt4),
-    PushValue(stmt4, fallthrough),
+    PushValue(stmt4, target),
     Statement_Next(stmt4, stmt5),
     JUMPI(stmt5),
     Statement_Block(stmt5, block),
-    JUMPDEST(as(fallthrough, Statement)).
+    JUMPDEST(as(target, Statement)).
 
-  BlockJumpsOnCallDataSize(block, jumpi, as(fallthrough, Block)):-
+  BlockComparesCallDataSizeToFour(block, stmt6, as(fallthrough, Block)):-
+    PushValue(stmt, "0x4"),
+    Statement_Next(stmt, stmt2),
+    CALLDATASIZE(stmt2),
+    Statement_Next(stmt2, stmt3),
+    LT(stmt3),
+    Statement_Next(stmt3, stmt4),
+    ISZERO(stmt4),
+    Statement_Next(stmt4, stmt5),
+    PushValue(stmt5, _),
+    Statement_Next(stmt5, stmt6),
+    JUMPI(stmt6),
+    Statement_Block(stmt6, block),
+    Statement_Next(stmt6, fallthrough).
+
+  BlockJumpsOnCallDataSize(block, jumpi, as(fallthrough, Block), as(callDataSizeBranch, Block)):-
     CALLDATASIZE(cds),
     Statement_Next(cds, push),
-    PushValue(push, fallthrough),
+    PushValue(push, callDataSizeBranch),
     Statement_Next(push, jumpi),
     JUMPI(jumpi),
     Statement_Block(jumpi, block),
-    JUMPDEST(as(fallthrough, Statement)).
+    Statement_Next(jumpi, fallthrough),
+    JUMPDEST(as(callDataSizeBranch, Statement)).
+
+  BlockJumpsOnCallDataSize(block, jumpi, as(noCallDataSizeBranch, Block), as(fallthrough, Block)):-
+    CALLDATASIZE(cds),
+    Statement_Next(cds, isZero),
+    ISZERO(isZero),
+    Statement_Next(isZero, push),
+    PushValue(push, noCallDataSizeBranch),
+    Statement_Next(push, jumpi),
+    JUMPI(jumpi),
+    Statement_Block(jumpi, block),
+    Statement_Next(jumpi, fallthrough),
+    JUMPDEST(as(noCallDataSizeBranch, Statement)).
 
   // Fallback functions
   PublicFunctionJump(block, FALLBACK_FUNCTION_SIGHASH, $NoSelector()),
   PublicFunction(fallbackStart, FALLBACK_FUNCTION_SIGHASH, $NoSelector()):-
     BlockComparesCallDataSizeToFour(block, _, fallbackStart),
     1 = count : BlockComparesCallDataSizeToFour(_, _, _),
-    !BlockJumpsOnCallDataSize(fallbackStart, _, _).
+    !BlockJumpsOnCallDataSize(fallbackStart, _, _, _).
 
-  BlockHasReceiveAsFallThrough(block, jumpi, fallthrough, target):-
+  BlockHasReceiveAsFallThrough(block, jumpi, noCallDataSizeBranch, callDataSizeBranch):-
     BlockComparesCallDataSizeToFour(_, _, block),
-    BlockJumpsOnCallDataSize(block, jumpi, target),
-    FallthroughStmt(jumpi, fallthrough).
+    BlockJumpsOnCallDataSize(block, jumpi, noCallDataSizeBranch, callDataSizeBranch).
 
 }
 
@@ -938,14 +965,18 @@ insertor.insertOps(functionStartStmt,
    !preTrans.BlockComparesSig(_, hash, _).
 
 // Receive transformation
-insertor.insertOps(functionStartStmt,
+insertor.insertOps(insertStmt,
   LIST(
     STMT(PUSH4, MAKE_LABEL_REFERENCE(RECEIVE_FUNCTION_SIGHASH)),
     STMT(JUMP, cat("PublicFunctionJump:", RECEIVE_FUNCTION_SIGHASH)),
     STMT(JUMPDEST, MAKE_LABEL_REFERENCE(RECEIVE_FUNCTION_SIGHASH))
   )
 ) :-
-  preTrans.BlockHasReceiveAsFallThrough(_, _, functionStartStmt, _).
+  preTrans.BlockHasReceiveAsFallThrough(_, _, functionStart, _),
+  preTrans.BasicBlock_Head(functionStart, functionStartStmt),
+  preTrans.Statement_Opcode(functionStartStmt, op),
+  ((op != "JUMPDEST", insertStmt = functionStartStmt);
+  (op = "JUMPDEST", preTrans.Statement_Next(functionStartStmt, insertStmt))).
 
 // This one removes "throw jumps"
 insertor.removeOp(jmp),
@@ -1030,9 +1061,8 @@ insertor.insertOps(codeCopy,
 // For Solidity, Vyper
 postTrans.PublicFunctionJump(block, hash, selector) :-
    insertor.MetaData(stmt, meta),
-   STARTSWITH(meta, "PublicFunctionJump:"),
+   insertor.PublicFunctionJumpMetadata(meta, hash),
    postTrans.Statement_Block(stmt, block),
-   hash = substr(meta, 19, 30),
    (preTrans.PublicFunctionJump(_, hash, selector);
    preTrans.BlockComparesSigVyper(_, hash, selector);
    preTrans.BlockComparesSigFallthroughSolidity(_, hash, selector);

--- a/logic/local.dl
+++ b/logic/local.dl
@@ -466,20 +466,23 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
      Statement_Opcode(stmt, opcode),
      OpcodeGas(opcode, gas).
 
-  .decl PublicFunctionJump(block:Block, funHex: Value)
-  .decl PublicFunction(block:Block, funHex: Value)
+  .decl PublicFunctionJump(block:Block, funHex: Value, optionalSelector: OptionalSelector)
+  .decl PublicFunction(block:Block, funHex: Value, optionalSelector: OptionalSelector)
 
   // Code inserted by compiler to compare function signature
-  .decl BlockComparesSig(block: Block, sigHash: Value)
+  .decl BlockComparesSig(block: Block, sigHash: Value, selectorVarOrIndex: OptionalSelector)
 
   // Compares label from stack to a constant: common public function dispatch pattern
-  BlockComparesSig(block, sigHash) :-
+  BlockComparesSig(block, sigHash, selector) :-
     Statement_Block(pushStmt, block),
     ImmediateBlockJumpTarget(block, _),
     (PUSH4(pushStmt, sigHash) ; PUSH3(pushStmt, sigHash)),
     Statement_Defines(pushStmt, sigHashVar),
     EQ(eqStmt),
-    Statement_Uses_Local(eqStmt, sigHashVar, _),
+    Statement_Uses_Local(eqStmt, sigHashVar, n),
+    Statement_Uses_Local(eqStmt, selectorVarOrIndex, 1 - n),
+    ((CheckIsStackIndex(selectorVarOrIndex), selector = $SelectorStackIndex(block, selectorVarOrIndex));
+     (CheckIsVariable(selectorVarOrIndex), selector = $SelectorVariable(selectorVarOrIndex))),
     Statement_Defines(eqStmt, pred),
     JUMPI(jumpiStmt),
     Statement_Uses_Local(jumpiStmt, pred, 1).
@@ -633,6 +636,24 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
     Statement_Defines(pushCodeOffset, codeOffsetVar),
     PushValue(pushCodeOffset, codeOffsetNumHex).
 
+  .decl FunctionSelectorVariable(variable: Variable)
+  FunctionSelectorVariable(selector):-
+    CALLDATALOAD(stmt),
+    Statement_Uses_Local(stmt, zeroVar, 0),
+    Variable_Value(zeroVar, "0x0"),
+    Statement_Defines(stmt, selector).
+
+  FunctionSelectorVariable(selector):-
+    CALLDATALOAD(stmt),
+    Statement_Uses_Local(stmt, zeroVar, 0),
+    Variable_Value(zeroVar, "0x0"),
+    Statement_Defines(stmt, variable),
+    Statement_Uses_Local(shift, variable, 1),
+    Statement_Uses_Local(shift, shiftConst, 0),
+    Variable_Value(shiftConst, "0xe0"),
+    SHR(shift),
+    Statement_Defines(shift, selector).
+
 }
 
 .comp PreTransLocalAnalysis : LocalAnalysis {
@@ -664,13 +685,16 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
     ByteCodeHex(bytecodeStr),
     const = cat("0x", substr(bytecodeStr, 2*codeOffsetNum, 2*smallNum)).
 
-  .decl BlockComparesSigVyper(block: Block, sigHash: Value)
+  .decl BlockComparesSigVyper(block: Block, sigHash: Value, selectorVarOrIndex: OptionalSelector)
 
-  BlockComparesSigVyper(block, sigHash) :-
+  .decl BlockComparesSigVyperBase(block: Block, sigHash: Value, selectorVarOrIndex: VariableOrStackIndex)
+
+  BlockComparesSigVyperBase(block, sigHash, selectorVarOrIndex) :-
     Statement_Block(pushStmt, block),
     (PUSH4(pushStmt, sigHash) ; PUSH3(pushStmt, sigHash)),
     Statement_Defines(pushStmt, sigHashVar),
-    Statement_Uses_Local(eqStmt, sigHashVar, _),
+    Statement_Uses_Local(eqStmt, sigHashVar, n),
+    Statement_Uses_Local(eqStmt, selectorVarOrIndex, 1 - n),
     EQ(eqStmt),
     Statement_Defines(eqStmt, pred),
     Statement_Uses_Local(isZeroStmt, pred, 0),
@@ -680,33 +704,45 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
     JUMPI(jumpiStmt).
 
   // New vyper pattern
-  BlockComparesSigVyper(block, sigHash) :-
+  BlockComparesSigVyperBase(block, sigHash, selectorVarOrIndex):-
     Statement_Block(pushStmt, block),
     (PUSH4(pushStmt, sigHash) ; PUSH3(pushStmt, sigHash)),
     Statement_Defines(pushStmt, sigHashVar),
-    Statement_Uses_Local(xorStmt, sigHashVar, _),
+    Statement_Uses_Local(xorStmt, sigHashVar, n),
+    Statement_Uses_Local(xorStmt, selectorVarOrIndex, 1 - n),
     XOR(xorStmt),
     Statement_Defines(xorStmt, pred),
     Statement_Uses_Local(jumpiStmt, pred, 1),
     JUMPI(jumpiStmt).
 
+  BlockComparesSigVyper(block, sigHash, $SelectorVariable(selectorVar)):-
+    BlockComparesSigVyperBase(block, sigHash, selectorVar),
+    CheckIsVariable(selectorVar).
+
+  BlockComparesSigVyper(block, sigHash, $SelectorStackIndex(block, selectorIndex)):-
+    BlockComparesSigVyperBase(block, sigHash, selectorIndex),
+    CheckIsStackIndex(selectorIndex).
+
   // pattern in via-ir contracts, public function start is the block's fallthrough
-  .decl BlockComparesSigFallthroughSolidity(block: Block, sigHash: Value)
-  BlockComparesSigFallthroughSolidity(block, sigHash) :-
+  .decl BlockComparesSigFallthroughSolidity(block: Block, sigHash: Value, selectorVarOrIndex: OptionalSelector)
+  BlockComparesSigFallthroughSolidity(block, sigHash, selector) :-
     Statement_Block(pushStmt, block),
     ImmediateBlockJumpTarget(block, _),
     (PUSH4(pushStmt, sigHash) ; PUSH3(pushStmt, sigHash)),
     Statement_Defines(pushStmt, sigHashVar),
     SUB(subStmt),
-    Statement_Uses_Local(subStmt, sigHashVar, _),
+    Statement_Uses_Local(subStmt, sigHashVar, n),
+    Statement_Uses_Local(subStmt, selectorVarOrIndex, 1 - n),
+    ((CheckIsStackIndex(selectorVarOrIndex), selector = $SelectorStackIndex(block, selectorVarOrIndex));
+     (CheckIsVariable(selectorVarOrIndex), selector = $SelectorVariable(selectorVarOrIndex))),
     Statement_Defines(subStmt, pred),
     JUMPI(jumpiStmt),
     Statement_Uses_Local(jumpiStmt, pred, 1).
 
-  PublicFunctionJump(block, sigHash) :-   BlockComparesSig(block, sigHash).
+  PublicFunctionJump(block, sigHash, selectorVarOrIndex) :-   BlockComparesSig(block, sigHash, selectorVarOrIndex).
 
-  PublicFunction(as(targetValue, Block), sigHash) :-
-    BlockComparesSig(block, sigHash),
+  PublicFunction(as(targetValue, Block), sigHash, selectorVarOrIndex) :-
+    BlockComparesSig(block, sigHash, selectorVarOrIndex),
     ImmediateBlockJumpTarget(block, var),
     Statement_Defines(push, var),
     PushValue(push, targetValue),
@@ -739,8 +775,8 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
     JUMPDEST(as(fallthrough, Statement)).
 
   // Fallback functions
-  PublicFunctionJump(block, FALLBACK_FUNCTION_SIGHASH),
-  PublicFunction(fallbackStart, FALLBACK_FUNCTION_SIGHASH):-
+  PublicFunctionJump(block, FALLBACK_FUNCTION_SIGHASH, $NoSelector()),
+  PublicFunction(fallbackStart, FALLBACK_FUNCTION_SIGHASH, $NoSelector()):-
     BlockComparesCallDataSizeToFour(block, _, fallbackStart),
     1 = count : BlockComparesCallDataSizeToFour(_, _, _),
     !BlockJumpsOnCallDataSize(fallbackStart, _, _).
@@ -842,8 +878,8 @@ insertor.insertOps(jumpDestStmt,
     STMT(JUMP, cat("PublicFunctionJump:", hash))
   )
 ) :-
-   preTrans.PublicFunctionJump(block, hash),
-   preTrans.PublicFunction(start, hash),
+   preTrans.PublicFunctionJump(block, hash, selector),
+   preTrans.PublicFunction(start, hash, selector),
    preTrans.Statement_Block(jumpDestStmt, start),
    preTrans.JUMPDEST(jumpDestStmt),
    preTrans.PushValue(pushStmt, as(jumpDestStmt, symbol)),
@@ -860,10 +896,10 @@ insertor.insertOps(functionStartStmt,
     STMT(JUMPDEST, MAKE_LABEL_REFERENCE(hash))
   )
 ) :-
-   preTrans.BlockComparesSigVyper(block, hash),
+   preTrans.BlockComparesSigVyper(block, hash, _),
    preTrans.BasicBlock_Tail(block, tail),
    preTrans.Statement_Next(tail, functionStartStmt),
-   !preTrans.BlockComparesSig(_, _).
+   !preTrans.BlockComparesSig(_, _, _).
 
 // transformation for pattern in via-ir contracts
 insertor.insertOps(functionStartStmt,
@@ -873,10 +909,10 @@ insertor.insertOps(functionStartStmt,
     STMT(JUMPDEST, MAKE_LABEL_REFERENCE(hash))
   )
 ) :-
-   preTrans.BlockComparesSigFallthroughSolidity(block, hash),
+   preTrans.BlockComparesSigFallthroughSolidity(block, hash, _),
    preTrans.BasicBlock_Tail(block, tail),
    preTrans.Statement_Next(tail, functionStartStmt),
-   !preTrans.BlockComparesSig(_, hash).
+   !preTrans.BlockComparesSig(_, hash, _).
 
 // Receive transformation
 insertor.insertOps(functionStartStmt,
@@ -969,30 +1005,37 @@ insertor.insertOps(codeCopy,
 .init postTrans = PostTransLocalAnalysis
 
 // For Solidity, Vyper
-postTrans.PublicFunctionJump(block, substr(meta, 19, 30)) :-
+postTrans.PublicFunctionJump(block, hash, selector) :-
    insertor.MetaData(stmt, meta),
    STARTSWITH(meta, "PublicFunctionJump:"),
-   postTrans.Statement_Block(stmt, block).
+   postTrans.Statement_Block(stmt, block),
+   hash = substr(meta, 19, 30),
+   (preTrans.PublicFunctionJump(_, hash, selector);
+   preTrans.BlockComparesSigVyper(_, hash, selector);
+   preTrans.BlockComparesSigFallthroughSolidity(_, hash, selector);
+   (preTrans.BlockHasReceiveAsFallThrough(_, _, _, _), hash = "0x00000000", selector = $NoSelector())
+   ).
+   // we may lose some precision here when two blocks have the same hex
 
 // For Vyper
-postTrans.PublicFunction(block, hash) :-
+postTrans.PublicFunction(block, hash, selector):-
    insertor.MetaData(stmt, meta),
    postTrans.JUMPDEST(stmt),
    postTrans.Statement_Block(stmt, block),
-   preTrans.BlockComparesSigVyper(_, hash),
-   !preTrans.BlockComparesSig(_, _),
+   preTrans.BlockComparesSigVyper(_, hash, selector),
+   !preTrans.BlockComparesSig(_, _, _),
    ISLABEL(meta), hash = GET_LABEL_REFERENCE(meta).
 
-postTrans.PublicFunction(block, hash) :-
+postTrans.PublicFunction(block, hash, selector) :-
    insertor.MetaData(stmt, meta),
    postTrans.JUMPDEST(stmt),
    postTrans.Statement_Block(stmt, block),
-   preTrans.BlockComparesSigFallthroughSolidity(_, hash),
-   !preTrans.BlockComparesSig(_, hash),
+   preTrans.BlockComparesSigFallthroughSolidity(_, hash, selector),
+   !preTrans.BlockComparesSig(_, hash, _),
    ISLABEL(meta), hash = GET_LABEL_REFERENCE(meta).
 
 // For receive functions
-postTrans.PublicFunction(block, hash) :-
+postTrans.PublicFunction(block, hash, $NoSelector()) :-
    preTrans.BlockHasReceiveAsFallThrough(_, _, _, _),
    hash = "0x00000000",
    hash = GET_LABEL_REFERENCE(meta), ISLABEL(meta),
@@ -1000,8 +1043,9 @@ postTrans.PublicFunction(block, hash) :-
    postTrans.JUMPDEST(stmt),
    postTrans.Statement_Block(stmt, block).
 
-postTrans.PublicFunction(b, h) :- preTrans.PublicFunction(b, h).
-
+postTrans.PublicFunction(b, h, s) :- preTrans.PublicFunction(b, h, s).
+.output postTrans.PublicFunction, preTrans.PublicFunction, preTrans.BlockComparesSigFallthroughSolidity, preTrans.BlockComparesSigVyper, insertor.MetaData
+.output postTrans.PublicFunctionJump
 // Code chunking logic reserved for future EIP
 
 #define CHUNK_SIZE 31

--- a/logic/local.dl
+++ b/logic/local.dl
@@ -689,6 +689,14 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
     BlockComparesSigFallthroughSolidity(_, _, selectorVarOrIndex);
     BlockComparesSigVyper(_, _, selectorVarOrIndex).
 
+  // All pushes of values up to 4 bytes, can be used as selectors
+  .decl SmallValuePush(pushStmt: Statement, value: Value)
+  SmallValuePush(pushStmt, value):-
+    PUSH4(pushStmt, value);
+    PUSH3(pushStmt, value);
+    PUSH2(pushStmt, value);
+    PUSH1(pushStmt, value).
+
     // Code inserted by compiler to compare function signature
   .decl BlockComparesSig(block: Block, sigHash: Value, selectorVarOrIndex: OptionalSelector)
 
@@ -696,7 +704,7 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
   BlockComparesSig(block, sigHash, selector) :-
     Statement_Block(pushStmt, block),
     ImmediateBlockJumpTarget(block, _),
-    (PUSH4(pushStmt, sigHash) ; PUSH3(pushStmt, sigHash)),
+    SmallValuePush(pushStmt, sigHash),
     Statement_Defines(pushStmt, sigHashVar),
     EQ(eqStmt),
     Statement_Uses_Local(eqStmt, sigHashVar, n),

--- a/logic/local.dl
+++ b/logic/local.dl
@@ -693,7 +693,7 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
     BlockComparesSigVyper(_, _, selectorVarOrIndex).
 
   // All pushes of values up to 4 bytes, can be used as selectors
-  .decl SmallValuePush(pushStmt: Statement, value: Value)
+  .decl SmallValuePush(pushStmt: Statement, value: Value) overridable
   SmallValuePush(pushStmt, value):-
     PUSH4(pushStmt, value);
     PUSH3(pushStmt, value);
@@ -862,6 +862,17 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
 
 }
 
+/**
+  Same as PreTransLocalAnalysis but less complete public function identification.
+  Used when we don't verify/filter public functions based via the `OptionalSelector` mechanism
+*/
+.comp PreTransLocalAnalysisAlt: PreTransLocalAnalysis{
+  .override SmallValuePush
+  SmallValuePush(pushStmt, value):-
+    PUSH4(pushStmt, value);
+    PUSH3(pushStmt, value).
+}
+
 .comp PostTransLocalAnalysis : LocalAnalysis {
                                              
 }
@@ -907,7 +918,6 @@ PreTransStatement_OriginalStatement(ogStmt, ogStmt) :-
 PreTransStatement_OriginalStatement(rvtClStmt, ogStmt) :-
   revertCloner.StatementToClonedStatement(_, _, ogStmt, rvtClStmt).
 
-.init preTrans = PreTransLocalAnalysis
 
 .init revertCloner = RevertBlockCloner
 COPY_CODE(revertCloner, factReader)
@@ -919,6 +929,8 @@ COPY_CODE(revertCloner, factReader)
 .init blockCloner = BLOCK_CLONING
 COPY_OUTPUT(blockCloner, revertCloner)
 blockCloner.Prev_Block_OriginalBlock(block, originalBlock):- revertCloner.Block_OriginalBlock(block, originalBlock).
+
+.init preTrans = PreTransLocalAnalysis
 COPY_OUTPUT(preTrans, blockCloner)
 
 PreTransStatement_OriginalStatement(heurClStmt, ogStmt) :-
@@ -934,6 +946,7 @@ ValidSelector(optionalSelector):-
 
 #else
 
+.init preTrans = PreTransLocalAnalysisAlt
 COPY_OUTPUT(preTrans, revertCloner)
 
 ValidSelector(optionalSelector):-

--- a/logic/main.dl
+++ b/logic/main.dl
@@ -1,5 +1,5 @@
 #define FALLBACK_FUNCTION_SIGHASH "0x00000000"
-
+#define RECEIVE_FUNCTION_SIGHASH "0xeeeeeeee"
 
 
 /*

--- a/logic/statement_insertor.dl
+++ b/logic/statement_insertor.dl
@@ -60,7 +60,9 @@ to.PublicFunction(block, funHex, selector):- from.PublicFunction(block, funHex, 
   removeOp(stmt) :- removeOp(stmt). // suppress warning
 
   .decl MetaData(newStmt: Statement, value: Value)
-  
+
+  .decl PublicFunctionJumpMetadata(metadataValue: Value, publicFunctionHex: Value)
+
   // Simple translation
   .decl insertOp(stmt: Statement, op: Opcode, value: Value, order: number)
 
@@ -133,6 +135,9 @@ to.PublicFunction(block, funHex, selector):- from.PublicFunction(block, funHex, 
     insertOp(stmt, op, value, order),
     !OpcodeIsPush(op).
 
+  PublicFunctionJumpMetadata(meta, substr(meta, 19, 30)):-
+    MetaData(_, meta),
+    STARTSWITH(meta, "PublicFunctionJump:").
 
   Out_PushValue(newStmt, value) :-
     InsertedOpNewStatement(stmt, order, newStmt),

--- a/logic/statement_insertor.dl
+++ b/logic/statement_insertor.dl
@@ -449,12 +449,7 @@ INITIALIZE_STATEMENT_INSERTOR(_insertor, to)
   BlockCloner using an underlying global analysis to ensure that the
   program's semantics will not break. To be used in most cases.
 */
-.comp SafeBlockCloner : AbstractBlockCloner <DefaultOptimizedGlobalAnalysis> {
-
-  // We want this enabled all the time. This ifndef is just to avoid double limitsize definition
-  #ifndef ENABLE_LIMITSIZE
-  .limitsize analysis.BlockOutputContents(n=LIMITSIZE_BLOCK_OUTPUT_CONTENTS)
-  #endif
+.comp SafeBlockCloner : AbstractBlockCloner <DefaultIncompleteOptimizedGlobalAnalysis> {
 
   BlockPushedToStack(pushStmt, pushedVar, as(pushedBlock, Block)):-
     analysis.Variable_Value(pushedVar, pushedBlock),

--- a/logic/statement_insertor.dl
+++ b/logic/statement_insertor.dl
@@ -21,6 +21,12 @@ to.PushValue(stmt, value) :- _insertor.Out_PushValue(stmt, value).
 COPY_CODE(_insertor, from)\
 INITIALIZE_STATEMENT_INSERTOR(_insertor, to)
 
+#define COPY_CODE_FULL(to, from)\
+COPY_CODE(to, from)\
+to.PublicFunctionJump(block, funHex):- from.PublicFunctionJump(block, funHex).\
+to.PublicFunction(block, funHex):- from.PublicFunction(block, funHex).
+
+
 #define ISLABEL(value) (substr(value, 0, 9) = "JUMPDEST:")
 #define MAKE_LABEL_REFERENCE(value) cat("JUMPDEST:", value)
 #define GET_LABEL_REFERENCE(value) substr(value, 9, 30)

--- a/logic/statement_insertor.dl
+++ b/logic/statement_insertor.dl
@@ -23,8 +23,8 @@ INITIALIZE_STATEMENT_INSERTOR(_insertor, to)
 
 #define COPY_CODE_FULL(to, from)\
 COPY_CODE(to, from)\
-to.PublicFunctionJump(block, funHex):- from.PublicFunctionJump(block, funHex).\
-to.PublicFunction(block, funHex):- from.PublicFunction(block, funHex).
+to.PublicFunctionJump(block, funHex, selector):- from.PublicFunctionJump(block, funHex, selector).\
+to.PublicFunction(block, funHex, selector):- from.PublicFunction(block, funHex, selector).
 
 
 #define ISLABEL(value) (substr(value, 0, 9) = "JUMPDEST:")

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -131,6 +131,9 @@ class InstructionTsvExporter(TsvExporter):
         def process_immutable_refs(immutable_refs: Dict[str, List[Dict[str, int]]]) -> List[Tuple[str, int]]:
             res = []
             for id, accesses in immutable_refs.items():
+                # TODO: skipping this for now
+                if id == "library_deploy_address":
+                    continue
                 for access in accesses:
                     res.append((hex(access['start']), int(id)))
             return res

--- a/tests/context-sensitivity/finite-precise.json
+++ b/tests/context-sensitivity/finite-precise.json
@@ -1,6 +1,6 @@
 {
     "client_path": null,
     "gigahorse_args": ["-i", "--disable_scalable_fallback", "--disable_precise_fallback", "--disable_inline", "-M", "CONTEXT_SENSITIVITY=FinitePreciseContext"],
-    "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 5, 0],
+    "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 4, 0],
     ["Analytics_BlockHasNoTACBlock", 0, 0]]
 }


### PR DESCRIPTION
The main change of this PR is the introduction of an `incompleteGlobal` analysis round, before the instantiation of the typical main `global` analysis. This allows us to verify which of the variables that are pushed to the stack and have the values of valid `JUMPDESTs` are actually used as jump targets, overriding the `BlockPushesLabel()` facts used by `PrivateFunctionCall()` which is essential our context sensitivity algorithms. The result of this is a reduction of the number of contexts of our `global` CFG analysis, lightening the load of the function inference logic as well.

Other changes:
* Refactor, making results of `PublicFunction`, `PublicFunctionJump` relations consistent in both `preTrans` and `postTrans` local analysis instantiations.
* Now introduce `PublicFunction` context element on public function "call-site" instead of starting block, giving us a minor precision improvement.
* Use the `HeuristicBlockCloner`'s global analysis to filter `PublicFunction` instances found by `preTrans`, by ensuring the function selector is used in the comparisons. Allows us to support selectors of 1 and 2 bytes without imprecision. Closes #91.
* Increase completeness of `receive()` support, use special selector value of `0xeeeeeeee`

Will run some final benchmarks and post the results before merging.

___
## RESULTS
___
All runs have a timeout of 200s and are performed using `--disable_scalable_fallback`

#### Transactional-Shrinking


viaIR contracts see the biggest benefit with a reduction in timeouts and no increase in execution time. In the other two datasets we notice an increase in the average execution time but no new timeouts.

results over 3k ir contracts (`via-ir-dec23`):
```
2866 contracts decompiled/analyzed by dec23-ir-master-200 (0 exclusively)
2880 contracts decompiled/analyzed by dec23-ir-unsound-200 (14 exclusively)

ANALYTIC: decomp_time                       
dec23-ir-master-200 (common): 20948.068742275238 (+0.123%)          
dec23-ir-unsound-200 (common): 20922.326548814774
                                                                    
ANALYTIC: Analytics_JumpToMany            
dec23-ir-master-200 (common): 5425                                  
dec23-ir-unsound-200 (common): 5456 (+0.5714%)
                                                                    
ANALYTIC: Analytics_PublicFunction          
dec23-ir-master-200 (common): 61316                                 
dec23-ir-unsound-200 (common): 61263 (-0.08644%)
                                                                    
ANALYTIC: Analytics_ReachableBlocks               
dec23-ir-master-200 (common): 1265532                               
dec23-ir-unsound-200 (common): 1265532
                                                                    
ANALYTIC: Analytics_UnreachableBlock                
dec23-ir-master-200 (common): 29734                                 
dec23-ir-unsound-200 (common): 29734        
                                                                    
ANALYTIC: Analytics_ReachableBlocksInTAC           
dec23-ir-master-200 (common): 1264073 (-0.005616%)                  
dec23-ir-unsound-200 (common): 1264144
                                                                    
ANALYTIC: Analytics_BlockHasNoTACBlock      
dec23-ir-master-200 (common): 1459 (+5.115%)                        
dec23-ir-unsound-200 (common): 1388   
                                                                    
ANALYTIC: Analytics_DeadBlocks          
dec23-ir-master-200 (common): 12216 (+0.7339%)                      
dec23-ir-unsound-200 (common): 12127              
                                                                    
ANALYTIC: Analytics_PolymorphicTargetSameCtx
dec23-ir-master-200 (common): 761                                   
dec23-ir-unsound-200 (common): 761                             
                                                                    
ANALYTIC: Analytics_LocalBlockEdge              
dec23-ir-master-200 (common): 1796030                               
dec23-ir-unsound-200 (common): 1795110 (-0.05122%)                                                                                       
                                                                    
ANALYTIC: Analytics_StmtMissingOperand        
dec23-ir-master-200 (common): 587 (+0.6861%)                        
dec23-ir-unsound-200 (common): 583
                                                                                                                                         
ANALYTIC: Analytics_PrivateFunctionMatchesMetadata
dec23-ir-master-200 (common): 82382 (-0.002428%)                                                                                                                                                                                                                                  
dec23-ir-unsound-200 (common): 82384
                                                                    
ANALYTIC: Analytics_PrivateFunctionMatchesMetadataIncorrectArgs                                                                          
dec23-ir-master-200 (common): 2203 (+0.04541%)                                                                                           
dec23-ir-unsound-200 (common): 2202                                                                                                                                                                                                                                               
                                                                    
ANALYTIC: Analytics_PrivateFunctionMatchesMetadataIncorrectReturnArgs
dec23-ir-master-200 (common): 1600 (+0.1879%)
dec23-ir-unsound-200 (common): 1597

ANALYTIC: Analytics_Contexts                                                                                                                                                                                                                                                      
dec23-ir-master-200 (common): 3881200 (+53.9%)                                                                                                                                                                                                                                    
dec23-ir-unsound-200 (common): 2521911
```

2k solc0.8 contracts over 10kb (`solc08-over10k`):
```
1980 contracts decompiled/analyzed by dec23-large-master-200 (0 exclusively)
1981 contracts decompiled/analyzed by dec23-large-unsound-200 (1 exclusively)

ANALYTIC: decomp_time
dec23-large-master-200 (common): 13397.00133228302
dec23-large-unsound-200 (common): 15676.011434793472 (+17.01%)

ANALYTIC: Analytics_JumpToMany
dec23-large-master-200 (common): 436
dec23-large-unsound-200 (common): 436

ANALYTIC: Analytics_PublicFunction
dec23-large-master-200 (common): 80120
dec23-large-unsound-200 (common): 80090 (-0.03744%)

ANALYTIC: Analytics_ReachableBlocks
dec23-large-master-200 (common): 1631364
dec23-large-unsound-200 (common): 1631364

ANALYTIC: Analytics_UnreachableBlock
dec23-large-master-200 (common): 28720
dec23-large-unsound-200 (common): 28720

ANALYTIC: Analytics_ReachableBlocksInTAC
dec23-large-master-200 (common): 1631182
dec23-large-unsound-200 (common): 1631182

ANALYTIC: Analytics_BlockHasNoTACBlock
dec23-large-master-200 (common): 182
dec23-large-unsound-200 (common): 182

ANALYTIC: Analytics_DeadBlocks
dec23-large-master-200 (common): 2267
dec23-large-unsound-200 (common): 2267

ANALYTIC: Analytics_PolymorphicTargetSameCtx
dec23-large-master-200 (common): 1262 (+0.1587%)
dec23-large-unsound-200 (common): 1260

ANALYTIC: Analytics_LocalBlockEdge
dec23-large-master-200 (common): 1776089 (-0.001126%)
dec23-large-unsound-200 (common): 1776109

ANALYTIC: Analytics_StmtMissingOperand
dec23-large-master-200 (common): 83
dec23-large-unsound-200 (common): 83

ANALYTIC: Analytics_Contexts
dec23-large-master-200 (common): 2538793 (+17.44%)
dec23-large-unsound-200 (common): 2161745
```

2k contracts with metadata (`metadata-dataset1`):
```
1990 contracts decompiled/analyzed by some config
1990 contracts decompiled/analyzed by all configs (common)

ANALYTIC: decomp_time
dec23-metadata-master-200 (common): 11313.415241718292
dec23-metadata-unsound-200 (common): 12820.136463880539 (+13.32%)

ANALYTIC: Analytics_JumpToMany
dec23-metadata-master-200 (common): 358
dec23-metadata-unsound-200 (common): 358

ANALYTIC: Analytics_PublicFunction
dec23-metadata-master-200 (common): 77907
dec23-metadata-unsound-200 (common): 77901 (-0.007701%)

ANALYTIC: Analytics_ReachableBlocks
dec23-metadata-master-200 (common): 1229995
dec23-metadata-unsound-200 (common): 1229995

ANALYTIC: Analytics_UnreachableBlock
dec23-metadata-master-200 (common): 11664
dec23-metadata-unsound-200 (common): 11664

ANALYTIC: Analytics_ReachableBlocksInTAC
dec23-metadata-master-200 (common): 1229901
dec23-metadata-unsound-200 (common): 1229901

ANALYTIC: Analytics_BlockHasNoTACBlock
dec23-metadata-master-200 (common): 94
dec23-metadata-unsound-200 (common): 94

ANALYTIC: Analytics_DeadBlocks
dec23-metadata-master-200 (common): 1272
dec23-metadata-unsound-200 (common): 1272

ANALYTIC: Analytics_PolymorphicTargetSameCtx
dec23-metadata-master-200 (common): 736 (+0.2725%)
dec23-metadata-unsound-200 (common): 734

ANALYTIC: Analytics_LocalBlockEdge
dec23-metadata-master-200 (common): 1427369
dec23-metadata-unsound-200 (common): 1427310 (-0.004133%)

ANALYTIC: Analytics_StmtMissingOperand
dec23-metadata-master-200 (common): 86
dec23-metadata-unsound-200 (common): 86

ANALYTIC: Analytics_PrivateFunctionMatchesMetadata
dec23-metadata-master-200 (common): 104265
dec23-metadata-unsound-200 (common): 104265

ANALYTIC: Analytics_PrivateFunctionMatchesMetadataIncorrectArgs
dec23-metadata-master-200 (common): 505
dec23-metadata-unsound-200 (common): 505

ANALYTIC: Analytics_PrivateFunctionMatchesMetadataIncorrectReturnArgs
dec23-metadata-master-200 (common): 730
dec23-metadata-unsound-200 (common): 730

ANALYTIC: Analytics_Contexts
dec23-metadata-master-200 (common): 1826948 (+21.72%)
dec23-metadata-unsound-200 (common): 1500998
```

#### Plain Transactional

Again, a minor reduction in the number of contexts and increase in the average execution time. Doesn't really give great benefit anywhere.

`via-ir-dec23`:
```
2602 contracts decompiled/analyzed by dec23-ir-master-trans-200 (0 exclusively)
2602 contracts decompiled/analyzed by dec23-ir-unsound-trans-200 (0 exclusively)

ANALYTIC: decomp_time
dec23-ir-master-trans-200 (common): 16918.658376932144
dec23-ir-unsound-trans-200 (common): 18542.089124679565 (+9.596%)

ANALYTIC: Analytics_JumpToMany
dec23-ir-master-trans-200 (common): 7553
dec23-ir-unsound-trans-200 (common): 7553

ANALYTIC: Analytics_PublicFunction
dec23-ir-master-trans-200 (common): 52208
dec23-ir-unsound-trans-200 (common): 52194 (-0.02682%)

ANALYTIC: Analytics_ReachableBlocks
dec23-ir-master-trans-200 (common): 1022113
dec23-ir-unsound-trans-200 (common): 1022113

ANALYTIC: Analytics_UnreachableBlock
dec23-ir-master-trans-200 (common): 25090
dec23-ir-unsound-trans-200 (common): 25090

ANALYTIC: Analytics_ReachableBlocksInTAC
dec23-ir-master-trans-200 (common): 1019992
dec23-ir-unsound-trans-200 (common): 1019992

ANALYTIC: Analytics_BlockHasNoTACBlock
dec23-ir-master-trans-200 (common): 2121
dec23-ir-unsound-trans-200 (common): 2121

ANALYTIC: Analytics_DeadBlocks
dec23-ir-master-trans-200 (common): 15010
dec23-ir-unsound-trans-200 (common): 15280 (+1.799%)

ANALYTIC: Analytics_PolymorphicTargetSameCtx
dec23-ir-master-trans-200 (common): 1967
dec23-ir-unsound-trans-200 (common): 1973 (+0.305%)

ANALYTIC: Analytics_LocalBlockEdge
dec23-ir-master-trans-200 (common): 1426408 (-0.06348%)
dec23-ir-unsound-trans-200 (common): 1427314

ANALYTIC: Analytics_StmtMissingOperand
dec23-ir-master-trans-200 (common): 699
dec23-ir-unsound-trans-200 (common): 699

ANALYTIC: Analytics_PrivateFunctionMatchesMetadata
dec23-ir-master-trans-200 (common): 61974
dec23-ir-unsound-trans-200 (common): 61974

ANALYTIC: Analytics_PrivateFunctionMatchesMetadataIncorrectArgs
dec23-ir-master-trans-200 (common): 1550
dec23-ir-unsound-trans-200 (common): 1550

ANALYTIC: Analytics_PrivateFunctionMatchesMetadataIncorrectReturnArgs
dec23-ir-master-trans-200 (common): 951
dec23-ir-unsound-trans-200 (common): 951

ANALYTIC: Analytics_Contexts
dec23-ir-master-trans-200 (common): 5820182 (+7.586%)
dec23-ir-unsound-trans-200 (common): 5409804
```

`metadata-dataset1`:
```
1842 contracts decompiled/analyzed by dec23-metadata-master-trans-200 (0 exclusively)
1842 contracts decompiled/analyzed by dec23-metadata-unsound-trans-200 (0 exclusively)

ANALYTIC: decomp_time
dec23-metadata-master-trans-200 (common): 10633.035330295563
dec23-metadata-unsound-trans-200 (common): 12469.912697076797 (+17.28%)

ANALYTIC: Analytics_JumpToMany
dec23-metadata-master-trans-200 (common): 187
dec23-metadata-unsound-trans-200 (common): 187

ANALYTIC: Analytics_PublicFunction
dec23-metadata-master-trans-200 (common): 71587
dec23-metadata-unsound-trans-200 (common): 71582 (-0.006985%)

ANALYTIC: Analytics_ReachableBlocks
dec23-metadata-master-trans-200 (common): 1119714
dec23-metadata-unsound-trans-200 (common): 1119714

ANALYTIC: Analytics_UnreachableBlock
dec23-metadata-master-trans-200 (common): 10962
dec23-metadata-unsound-trans-200 (common): 10962

ANALYTIC: Analytics_ReachableBlocksInTAC
dec23-metadata-master-trans-200 (common): 1119591
dec23-metadata-unsound-trans-200 (common): 1119591

ANALYTIC: Analytics_BlockHasNoTACBlock
dec23-metadata-master-trans-200 (common): 123
dec23-metadata-unsound-trans-200 (common): 123

ANALYTIC: Analytics_DeadBlocks
dec23-metadata-master-trans-200 (common): 3805
dec23-metadata-unsound-trans-200 (common): 3805

ANALYTIC: Analytics_PolymorphicTargetSameCtx
dec23-metadata-master-trans-200 (common): 2678 (+0.1496%)
dec23-metadata-unsound-trans-200 (common): 2674

ANALYTIC: Analytics_LocalBlockEdge
dec23-metadata-master-trans-200 (common): 1291262
dec23-metadata-unsound-trans-200 (common): 1291224 (-0.002943%)

ANALYTIC: Analytics_StmtMissingOperand
dec23-metadata-master-trans-200 (common): 76
dec23-metadata-unsound-trans-200 (common): 76

ANALYTIC: Analytics_PrivateFunctionMatchesMetadata
dec23-metadata-master-trans-200 (common): 95228
dec23-metadata-unsound-trans-200 (common): 95228

ANALYTIC: Analytics_PrivateFunctionMatchesMetadataIncorrectArgs
dec23-metadata-master-trans-200 (common): 232
dec23-metadata-unsound-trans-200 (common): 232

ANALYTIC: Analytics_PrivateFunctionMatchesMetadataIncorrectReturnArgs
dec23-metadata-master-trans-200 (common): 547
dec23-metadata-unsound-trans-200 (common): 547

ANALYTIC: Analytics_Contexts
dec23-metadata-master-trans-200 (common): 4668384 (+11.65%)
dec23-metadata-unsound-trans-200 (common): 4181344
```