### PR TITLE
Incomplete global v2

### DIFF
--- a/gigahorse.py
+++ b/gigahorse.py
@@ -568,7 +568,7 @@ if __name__ == "__main__":
                         type=int,
                         nargs="?",
                         metavar="NUM",
-                        help="Override the maximum context depth for decompilation (default is 8).")
+                        help="Override the maximum context depth for decompilation (default is 20).")
 
     parser.add_argument("--early_cloning",
                         action="store_true",

--- a/logic/context-sensitivity/abstract_context.dl
+++ b/logic/context-sensitivity/abstract_context.dl
@@ -16,6 +16,7 @@
   .decl IsContext(ctx: Context)
   .decl InitialContext(ctx: Context)
 
+  .decl SpecialBlock(block: Block)
   /**
     Context is reachable under PublicFunction identified by its sighash.
     Only useful for contexts with a public function component

--- a/logic/context-sensitivity/abstract_context.dl
+++ b/logic/context-sensitivity/abstract_context.dl
@@ -17,6 +17,7 @@
   .decl InitialContext(ctx: Context)
 
   .decl SpecialBlockEdge(block: Block, next: Block)
+  .decl OtherSpecialBlockEdge(block: Block, next: Block)
   /**
     Context is reachable under PublicFunction identified by its sighash.
     Only useful for contexts with a public function component

--- a/logic/context-sensitivity/abstract_context.dl
+++ b/logic/context-sensitivity/abstract_context.dl
@@ -16,7 +16,7 @@
   .decl IsContext(ctx: Context)
   .decl InitialContext(ctx: Context)
 
-  .decl SpecialBlock(block: Block)
+  .decl SpecialBlockEdge(block: Block, next: Block)
   /**
     Context is reachable under PublicFunction identified by its sighash.
     Only useful for contexts with a public function component

--- a/logic/context-sensitivity/abstract_context.dl
+++ b/logic/context-sensitivity/abstract_context.dl
@@ -16,8 +16,8 @@
   .decl IsContext(ctx: Context)
   .decl InitialContext(ctx: Context)
 
-  .decl SpecialBlockEdge(block: Block, next: Block)
-  .decl OtherSpecialBlockEdge(block: Block, next: Block)
+  .decl ImportantBlockEdge(block: Block, next: Block)
+
   /**
     Context is reachable under PublicFunction identified by its sighash.
     Only useful for contexts with a public function component
@@ -57,7 +57,7 @@
     InputMaxContextDepth(d).
 
 
-  MaxContextDepth(sigHash, 10) :-
+  MaxContextDepth(sigHash, 20) :-
     (local.PublicFunction(_, sigHash, _);
      sigHash = FALLBACK_FUNCTION_SIGHASH),
     !InputMaxContextDepth(_).

--- a/logic/context-sensitivity/transactional_shrinking_context.dl
+++ b/logic/context-sensitivity/transactional_shrinking_context.dl
@@ -5,6 +5,7 @@
   // Split into two rules to add plan.
   MergeContext(ctx, caller, ctx):-
     ReachableContext(ctx, caller),
+    !SpecialBlock(caller),
     !local.PublicFunctionJump(caller, _, _),
     !local.PrivateFunctionCallOrReturn(caller).
 
@@ -30,6 +31,15 @@
     local.PrivateFunctionCall(caller, _, _, _),
     DecomposeAndTruncateIfNeeded(ctx, pub, cutDownAtEndPri),
     !local.PublicFunctionJump(caller, _, _),
+    newPrivateContext = [caller, cutDownAtEndPri].
+    .plan 1:(3,1,2)
+
+  MergeContext(ctx, caller, [pub, newPrivateContext]):-
+    ReachableContext(ctx, caller),
+    SpecialBlock(caller),
+    DecomposeAndTruncateIfNeeded(ctx, pub, cutDownAtEndPri),
+    !local.PublicFunctionJump(caller, _, _),
+    !local.PrivateFunctionCallOrReturn(caller),
     newPrivateContext = [caller, cutDownAtEndPri].
     .plan 1:(3,1,2)
 

--- a/logic/context-sensitivity/transactional_shrinking_context.dl
+++ b/logic/context-sensitivity/transactional_shrinking_context.dl
@@ -5,7 +5,7 @@
   // Split into two rules to add plan.
   MergeContext(ctx, caller, ctx):-
     ReachableContext(ctx, caller),
-    !SpecialBlockEdge(caller, _),
+    !ImportantBlockEdge(caller, _),
     !local.PublicFunctionJump(caller, _, _),
     !local.PrivateFunctionCallOrReturn(caller).
 
@@ -92,31 +92,9 @@
     PrivateFunctionReturn(block),
     DecomposeContext(ctx, pub, priCtx),
     !FallthroughEdge(block, cont), // temp: handle conditional returns
-    // !OtherSpecialBlockEdge(block, cont),
     !local.PublicFunctionJump(block, _, _),
     CutToCaller(priCtx, cont, cutPri).
     .plan 1:(3,1,2,4), 2:(4,3,1,2)
-
-  // // OPTION A: Cut as little as possible
-  // MergeContextResponse(ctx, block, cont, [pub, cutPri]):-
-  //   MergeContextRequest(ctx, block, cont),
-  //   PrivateFunctionReturn(block),
-  //   DecomposeContext(ctx, pub, priCtx),
-  //   OtherSpecialBlockEdge(block, cont),
-  //   !FallthroughEdge(block, cont), // temp: handle conditional returns
-  //   !local.PublicFunctionJump(block, _, _),
-  //   CutToIncludeCaller(priCtx, cont, cutPri).
-  //   .plan 1:(3,1,2,5,4), 2:(5,3,1,2,4)
-
-  // OPTION B: Don't cut
-  // MergeContextResponse(ctx, block, cont, [pub, [block, cutDownAtEndPri]]):-
-  //   MergeContextRequest(ctx, block, cont),
-  //   PrivateFunctionReturn(block),
-  //   DecomposeAndTruncateIfNeeded(ctx, pub, cutDownAtEndPri),
-  //   OtherSpecialBlockEdge(block, cont),
-  //   !FallthroughEdge(block, cont), // temp: handle conditional returns
-  //   !local.PublicFunctionJump(block, _, _).
-  //   .plan 1:(3,1,2,4)
 
   // if return and matching call doesn't exist -> push return
   MergeContextResponse(ctx, block, cont, [pub, newPrivateContext]):-
@@ -140,7 +118,7 @@
 
   MergeContextResponse(ctx, caller, callee, [pub, newPrivateContext]):-
     MergeContextRequest(ctx, caller, callee),
-    SpecialBlockEdge(caller, callee),
+    ImportantBlockEdge(caller, callee),
     DecomposeAndTruncateIfNeeded(ctx, pub, cutDownAtEndPri),
     !local.PrivateFunctionCall(caller, _, _, _),
     !local.PublicFunctionJump(caller, _, _),
@@ -149,7 +127,7 @@
 
   MergeContextResponse(ctx, caller, next, ctx):-
     MergeContextRequest(ctx, caller, next),
-    SpecialBlockEdge(caller, callee),
+    ImportantBlockEdge(caller, callee),
     next != callee,
     !local.PrivateFunctionCall(caller, _, _, _),
     !local.PublicFunctionJump(caller, _, _).

--- a/logic/context-sensitivity/transactional_shrinking_context.dl
+++ b/logic/context-sensitivity/transactional_shrinking_context.dl
@@ -88,6 +88,7 @@
     MergeContextRequest(ctx, block, cont),
     PrivateFunctionReturn(block),
     DecomposeContext(ctx, pub, priCtx),
+    !FallthroughEdge(block, cont), // temp: handle conditional returns
     !local.PublicFunctionJump(block, _, _),
     CutToCaller(priCtx, cont, cutPri).
     .plan 1:(3,1,2,4), 2:(4,3,1,2)
@@ -99,9 +100,18 @@
     DecomposeContext(ctx, pub, priCtx),
     DecomposeAndTruncateIfNeeded(ctx, pub, cutDownAtEndPri),
     NoCutToCaller(priCtx, cont),
+    !FallthroughEdge(block, cont), // temp: handle conditional returns
     !local.PublicFunctionJump(block, _, _),
     newPrivateContext = [block, cutDownAtEndPri].
     .plan 1:(3,1,2,4,5), 2:(4,3,1,2,5), 3:(5,3,1,2,4)
+
+  // temp: handle conditional returns
+  MergeContextResponse(ctx, block, next, ctx):-
+    MergeContextRequest(ctx, block, next),
+    PrivateFunctionReturn(block),
+    FallthroughEdge(block, next),
+    !local.PrivateFunctionCall(block, _, _, _),
+    !local.PublicFunctionJump(block, _, _).
 
   MergeContextResponse(ctx, caller, callee, [pub, newPrivateContext]):-
     MergeContextRequest(ctx, caller, callee),

--- a/logic/context-sensitivity/transactional_shrinking_context.dl
+++ b/logic/context-sensitivity/transactional_shrinking_context.dl
@@ -34,15 +34,6 @@
     newPrivateContext = [caller, cutDownAtEndPri].
     .plan 1:(3,1,2)
 
-  // MergeContext(ctx, caller, [pub, newPrivateContext]):-
-  //   ReachableContext(ctx, caller),
-  //   SpecialBlockEdge(caller, _),
-  //   DecomposeAndTruncateIfNeeded(ctx, pub, cutDownAtEndPri),
-  //   !local.PublicFunctionJump(caller, _, _),
-  //   !local.PrivateFunctionCallOrReturn(caller),
-  //   newPrivateContext = [caller, cutDownAtEndPri].
-  //   .plan 1:(3,1,2)
-
 
   /// "NEW" variant
   // For a matching context element, the call needs to have pushed deepest in the stack
@@ -54,6 +45,18 @@
 
   CutToCaller(priCtx, cont, newPriCtx) :-
     CutToCaller(nextPriCtx, cont, newPriCtx),
+    DecomposePrivateContext(priCtx, head, nextPriCtx),
+    !local.PrivateFunctionCall(head, _, cont, _).
+    .plan 1:(2,1)
+
+  // Added to experiment with less cutting when we know a cut can lead to a loss of precision
+  .decl CutToIncludeCaller(priCtx: PrivateContext, continuation: Block, newPriCtx: PrivateContext) overridable
+  CutToIncludeCaller(priCtx, cont, priCtx) :-
+    DecomposePrivateContext(priCtx, head, _),
+    local.PrivateFunctionCall(head, _, cont, cont).
+
+  CutToIncludeCaller(priCtx, cont, newPriCtx) :-
+    CutToIncludeCaller(nextPriCtx, cont, newPriCtx),
     DecomposePrivateContext(priCtx, head, nextPriCtx),
     !local.PrivateFunctionCall(head, _, cont, _).
     .plan 1:(2,1)
@@ -89,9 +92,31 @@
     PrivateFunctionReturn(block),
     DecomposeContext(ctx, pub, priCtx),
     !FallthroughEdge(block, cont), // temp: handle conditional returns
+    // !OtherSpecialBlockEdge(block, cont),
     !local.PublicFunctionJump(block, _, _),
     CutToCaller(priCtx, cont, cutPri).
     .plan 1:(3,1,2,4), 2:(4,3,1,2)
+
+  // // OPTION A: Cut as little as possible
+  // MergeContextResponse(ctx, block, cont, [pub, cutPri]):-
+  //   MergeContextRequest(ctx, block, cont),
+  //   PrivateFunctionReturn(block),
+  //   DecomposeContext(ctx, pub, priCtx),
+  //   OtherSpecialBlockEdge(block, cont),
+  //   !FallthroughEdge(block, cont), // temp: handle conditional returns
+  //   !local.PublicFunctionJump(block, _, _),
+  //   CutToIncludeCaller(priCtx, cont, cutPri).
+  //   .plan 1:(3,1,2,5,4), 2:(5,3,1,2,4)
+
+  // OPTION B: Don't cut
+  // MergeContextResponse(ctx, block, cont, [pub, [block, cutDownAtEndPri]]):-
+  //   MergeContextRequest(ctx, block, cont),
+  //   PrivateFunctionReturn(block),
+  //   DecomposeAndTruncateIfNeeded(ctx, pub, cutDownAtEndPri),
+  //   OtherSpecialBlockEdge(block, cont),
+  //   !FallthroughEdge(block, cont), // temp: handle conditional returns
+  //   !local.PublicFunctionJump(block, _, _).
+  //   .plan 1:(3,1,2,4)
 
   // if return and matching call doesn't exist -> push return
   MergeContextResponse(ctx, block, cont, [pub, newPrivateContext]):-

--- a/logic/context-sensitivity/transactional_shrinking_context.dl
+++ b/logic/context-sensitivity/transactional_shrinking_context.dl
@@ -5,7 +5,7 @@
   // Split into two rules to add plan.
   MergeContext(ctx, caller, ctx):-
     ReachableContext(ctx, caller),
-    !SpecialBlock(caller),
+    !SpecialBlockEdge(caller, _),
     !local.PublicFunctionJump(caller, _, _),
     !local.PrivateFunctionCallOrReturn(caller).
 
@@ -34,14 +34,14 @@
     newPrivateContext = [caller, cutDownAtEndPri].
     .plan 1:(3,1,2)
 
-  MergeContext(ctx, caller, [pub, newPrivateContext]):-
-    ReachableContext(ctx, caller),
-    SpecialBlock(caller),
-    DecomposeAndTruncateIfNeeded(ctx, pub, cutDownAtEndPri),
-    !local.PublicFunctionJump(caller, _, _),
-    !local.PrivateFunctionCallOrReturn(caller),
-    newPrivateContext = [caller, cutDownAtEndPri].
-    .plan 1:(3,1,2)
+  // MergeContext(ctx, caller, [pub, newPrivateContext]):-
+  //   ReachableContext(ctx, caller),
+  //   SpecialBlockEdge(caller, _),
+  //   DecomposeAndTruncateIfNeeded(ctx, pub, cutDownAtEndPri),
+  //   !local.PublicFunctionJump(caller, _, _),
+  //   !local.PrivateFunctionCallOrReturn(caller),
+  //   newPrivateContext = [caller, cutDownAtEndPri].
+  //   .plan 1:(3,1,2)
 
 
   /// "NEW" variant
@@ -103,6 +103,21 @@
     newPrivateContext = [block, cutDownAtEndPri].
     .plan 1:(3,1,2,4,5), 2:(4,3,1,2,5), 3:(5,3,1,2,4)
 
+  MergeContextResponse(ctx, caller, callee, [pub, newPrivateContext]):-
+    MergeContextRequest(ctx, caller, callee),
+    SpecialBlockEdge(caller, callee),
+    DecomposeAndTruncateIfNeeded(ctx, pub, cutDownAtEndPri),
+    !local.PrivateFunctionCall(caller, _, _, _),
+    !local.PublicFunctionJump(caller, _, _),
+    newPrivateContext = [caller, cutDownAtEndPri].
+    .plan 1:(3,1,2)
+
+  MergeContextResponse(ctx, caller, next, ctx):-
+    MergeContextRequest(ctx, caller, next),
+    SpecialBlockEdge(caller, callee),
+    next != callee,
+    !local.PrivateFunctionCall(caller, _, _, _),
+    !local.PublicFunctionJump(caller, _, _).
 
 }
 

--- a/logic/debug.dl
+++ b/logic/debug.dl
@@ -16,7 +16,7 @@
 .output FunctionalBlockInputContents, FunctionalBlockOutputContents, FunctionalStatement_Uses_Local
 .output NumberOfFunctionArguments
 .output NumberOfFunctionReturnArguments
-
+.output Block_IRBlock
 .output Variable_String
 
 // The following relations print a number instead of a context in record form to help debugging

--- a/logic/decompiler_analytics.dl
+++ b/logic/decompiler_analytics.dl
@@ -502,10 +502,3 @@ Analytics_BlocksLocalOrNot(block1, block2) :-
 
 Analytics_NeedToAddCtxAtEdge(from, to):-
   global.NeedToAddCtxAtEdge(from, to).
-
-.decl Analytics_NeedToNotCut(from: Block, to: Block)
-.output Analytics_NeedToNotCut
-
-Analytics_NeedToNotCut(from, to):-
-  global.NeedToNotCut(from, to).
-

--- a/logic/decompiler_analytics.dl
+++ b/logic/decompiler_analytics.dl
@@ -495,3 +495,17 @@ Analytics_BlocksLocalOrNot(block1, block2) :-
    IRInFunction(block1, fun1),
    IRInFunction(block2, fun2),
    fun1 != fun2.
+
+
+.decl Analytics_NeedToAddCtxAtEdge(from: Block, to: Block)
+.output Analytics_NeedToAddCtxAtEdge
+
+Analytics_NeedToAddCtxAtEdge(from, to):-
+  global.NeedToAddCtxAtEdge(from, to).
+
+.decl Analytics_NeedToNotCut(from: Block, to: Block)
+.output Analytics_NeedToNotCut
+
+Analytics_NeedToNotCut(from, to):-
+  global.NeedToNotCut(from, to).
+

--- a/logic/global.dl
+++ b/logic/global.dl
@@ -56,6 +56,7 @@ global.StatementPushesUsedLabel(stmt):-
   postTrans.Statement_Defines(stmt, pushedVar).
 
 global.sens.SpecialBlockEdge(block, next):- incompleteGlobal.NeedToAddCtxAtEdge(block, next).
+global.sens.OtherSpecialBlockEdge(block, next):- incompleteGlobal.NeedToNotCut(block, next).
 
 COPY_CODE_FULL(global, postTrans)
 
@@ -323,7 +324,7 @@ PreMask_Length(cat(mask, "ff"), bytes+1) :-
   NeedToAddCtxAtEdge(fromBlock, toBlock):-
     ImprecisionIntroducedAtEdge(ctx, fromBlock, ctx, toBlock, _).
 
-    .decl NeedToNotCut(fromBlock: Block, toBlock: Block)
+  .decl NeedToNotCut(fromBlock: Block, toBlock: Block)
   DEBUG_OUTPUT(NeedToNotCut)
   NeedToNotCut(fromBlock, toBlock):-
     ImprecisionIntroducedAtEdge(ctx, fromBlock, otherCtx, toBlock, _),

--- a/logic/global.dl
+++ b/logic/global.dl
@@ -55,8 +55,7 @@ global.StatementPushesUsedLabel(stmt):-
   incompleteGlobal.VariableUsedInAsJumpdest(pushedVar),
   postTrans.Statement_Defines(stmt, pushedVar).
 
-global.sens.SpecialBlockEdge(block, next):- incompleteGlobal.NeedToAddCtxAtEdge(block, next).
-global.sens.OtherSpecialBlockEdge(block, next):- incompleteGlobal.NeedToNotCut(block, next).
+global.sens.ImportantBlockEdge(block, next):- incompleteGlobal.NeedToAddCtxAtEdge(block, next).
 
 COPY_CODE_FULL(global, postTrans)
 
@@ -328,14 +327,6 @@ PreMask_Length(cat(mask, "ff"), bytes+1) :-
   DEBUG_OUTPUT(NeedToAddCtxAtEdge)
   NeedToAddCtxAtEdge(fromBlock, toBlock):-
     ImprecisionIntroducedAtEdge(ctx, fromBlock, ctx, toBlock, _).
-
-  .decl NeedToNotCut(fromBlock: Block, toBlock: Block)
-  DEBUG_OUTPUT(NeedToNotCut)
-  NeedToNotCut(fromBlock, toBlock):-
-    ImprecisionIntroducedAtEdge(ctx, fromBlock, otherCtx, toBlock, _),
-    PrivateFunctionCallOrReturn(fromBlock),
-    ctx != otherCtx.
-
 }
 
 /**

--- a/logic/global.dl
+++ b/logic/global.dl
@@ -294,30 +294,35 @@ PreMask_Length(cat(mask, "ff"), bytes+1) :-
   .decl ImprecisionIntroducedAtEdge(fromCtx: sens.Context, fromBlock: Block, toCtx: sens.Context, to: Block, index: StackIndex)
   DEBUG_OUTPUT(ImprecisionIntroducedAtEdge)
 
+
+  /**
+    __Note__: Plans are commented out, they were needed at some point so I added them.
+    Right now adding them breaks souffle 2.4 so I removed them. Didn't make a difference
+  */
   ImpreciseBlockInputContentsIndex(ctx, block, index):-
     BlockInputContents(ctx, block, index, var1),
     BlockInputContents(ctx, block, index, var2),
     var1 != var2.
-   .plan 1:(2,1)
+  //  .plan 1:(2,1)
 
   ImpreciseBlockOutputContentsIndex(ctx, block, index):-
     BlockOutputContents(ctx, block, index, var1),
     BlockOutputContents(ctx, block, index, var2),
     var1 != var2.
-   .plan 1:(2,1)
+  //  .plan 1:(2,1)
 
   ImpreciseBlockInputContentsIndexFromPrev(ctx, block, index):-
     ImpreciseBlockInputContentsIndex(ctx, block, index),
     BlockEdge(prevCtx, prevBlock, ctx, block),
     ImpreciseBlockOutputContentsIndex(prevCtx, prevBlock, index).
-    .plan 1:(2,1,3), 2:(3,2,1)
+    // .plan 1:(2,1,3), 2:(3,2,1)
 
   ImprecisionIntroducedAtEdge(fromCtx, fromBlock, toCtx, to, index):-
     BlockEdge(fromCtx, fromBlock, toCtx, to),
     ImpreciseBlockInputContentsIndex(toCtx, to, index),
     !ImpreciseBlockInputContentsIndexFromPrev(toCtx, to, index),
     !ImpreciseBlockOutputContentsIndex(fromCtx, fromBlock, index).
-   .plan 1:(2,1)
+  //  .plan 1:(2,1)
 
   .decl NeedToAddCtxAtEdge(fromBlock: Block, toBlock: Block)
   DEBUG_OUTPUT(NeedToAddCtxAtEdge)

--- a/logic/global.dl
+++ b/logic/global.dl
@@ -289,11 +289,6 @@ PreMask_Length(cat(mask, "ff"), bytes+1) :-
   DEBUG_OUTPUT(ImpreciseBlockInputContentsIndex)
   .decl ImpreciseBlockOutputContentsIndex(ctx: sens.Context, block: Block, index: StackIndex)
   DEBUG_OUTPUT(ImpreciseBlockOutputContentsIndex)
-  .decl ImpreciseBlockInputContentsIndexDetailed(ctx: sens.Context, block: Block, index: StackIndex, numOfVars: number)
-  DEBUG_OUTPUT(ImpreciseBlockInputContentsIndexDetailed)
-  .decl ImpreciseBlockOutputContentsIndexDetailed(ctx: sens.Context, block: Block, index: StackIndex, numOfVars: number)
-  DEBUG_OUTPUT(ImpreciseBlockOutputContentsIndexDetailed)
-
   .decl ImpreciseBlockInputContentsIndexFromPrev(ctx: sens.Context, block: Block, index: StackIndex)
   DEBUG_OUTPUT(ImpreciseBlockInputContentsIndexFromPrev)
   .decl ImprecisionIntroducedAtEdge(fromCtx: sens.Context, fromBlock: Block, toCtx: sens.Context, to: Block, index: StackIndex)
@@ -311,18 +306,10 @@ PreMask_Length(cat(mask, "ff"), bytes+1) :-
     var1 != var2.
    .plan 1:(2,1)
 
-  ImpreciseBlockInputContentsIndexDetailed(ctx, block, index, numOfVars):-
-    ImpreciseBlockInputContentsIndex(ctx, block, index),
-    numOfVars = count : BlockInputContents(ctx, block, index, _).
-
-  ImpreciseBlockOutputContentsIndexDetailed(ctx, block, index, numOfVars):-
-    ImpreciseBlockOutputContentsIndex(ctx, block, index),
-    numOfVars = count : BlockOutputContents(ctx, block, index, _).
-
   ImpreciseBlockInputContentsIndexFromPrev(ctx, block, index):-
-    ImpreciseBlockInputContentsIndexDetailed(ctx, block, index, num),
+    ImpreciseBlockInputContentsIndex(ctx, block, index),
     BlockEdge(prevCtx, prevBlock, ctx, block),
-    ImpreciseBlockOutputContentsIndexDetailed(prevCtx, prevBlock, index, num).
+    ImpreciseBlockOutputContentsIndex(prevCtx, prevBlock, index).
     .plan 1:(2,1,3), 2:(3,2,1)
 
   ImprecisionIntroducedAtEdge(fromCtx, fromBlock, toCtx, to, index):-

--- a/logic/global.dl
+++ b/logic/global.dl
@@ -55,6 +55,8 @@ global.StatementPushesUsedLabel(stmt):-
   incompleteGlobal.VariableUsedInAsJumpdest(pushedVar),
   postTrans.Statement_Defines(stmt, pushedVar).
 
+global.sens.SpecialBlock(block):- incompleteGlobal.NeedToAddCtxAtEdge(block, _).
+
 COPY_CODE_FULL(global, postTrans)
 
 // Masks with all 1s
@@ -280,6 +282,46 @@ PreMask_Length(cat(mask, "ff"), bytes+1) :-
     IsOptionalSelector($SelectorStackIndex(block, selectorStackIndex)),
     BlockInputContents(_, block, selectorStackIndex, selectorVariable),
     FunctionSelectorVariable(selectorVariable).
+
+
+  .decl ImpreciseBlockInputContentsIndex(ctx: sens.Context, block: Block, index: StackIndex)
+  DEBUG_OUTPUT(ImpreciseBlockInputContentsIndex)
+  .decl ImpreciseBlockOutputContentsIndex(ctx: sens.Context, block: Block, index: StackIndex)
+  DEBUG_OUTPUT(ImpreciseBlockOutputContentsIndex)
+  .decl ImpreciseBlockInputContentsIndexFromPrev(ctx: sens.Context, block: Block, index: StackIndex)
+  DEBUG_OUTPUT(ImpreciseBlockInputContentsIndexFromPrev)
+  .decl ImprecisionIntroducedAtEdge(fromCtx: sens.Context, fromBlock: Block, toCtx: sens.Context, to: Block, index: StackIndex)
+  DEBUG_OUTPUT(ImprecisionIntroducedAtEdge)
+
+  ImpreciseBlockInputContentsIndex(ctx, block, index):-
+    BlockInputContents(ctx, block, index, var1),
+    BlockInputContents(ctx, block, index, var2),
+    var1 != var2.
+   .plan 1:(2,1)
+
+  ImpreciseBlockOutputContentsIndex(ctx, block, index):-
+    BlockOutputContents(ctx, block, index, var1),
+    BlockOutputContents(ctx, block, index, var2),
+    var1 != var2.
+   .plan 1:(2,1)
+
+  ImpreciseBlockInputContentsIndexFromPrev(ctx, block, index):-
+    ImpreciseBlockInputContentsIndex(ctx, block, index),
+    BlockEdge(prevCtx, prevBlock, ctx, block),
+    ImpreciseBlockOutputContentsIndex(prevCtx, prevBlock, index).
+    .plan 1:(2,1,3), 2:(3,2,1)
+
+  ImprecisionIntroducedAtEdge(fromCtx, fromBlock, toCtx, to, index):-
+    BlockEdge(fromCtx, fromBlock, toCtx, to),
+    ImpreciseBlockInputContentsIndex(toCtx, to, index),
+    !ImpreciseBlockInputContentsIndexFromPrev(toCtx, to, index),
+    !ImpreciseBlockOutputContentsIndex(fromCtx, fromBlock, index).
+   .plan 1:(2,1)
+
+  .decl NeedToAddCtxAtEdge(fromBlock: Block, toBlock: Block)
+  DEBUG_OUTPUT(NeedToAddCtxAtEdge)
+  NeedToAddCtxAtEdge(fromBlock, toBlock):-
+    ImprecisionIntroducedAtEdge(ctx, fromBlock, ctx, toBlock, _).
 
 }
 

--- a/logic/global.dl
+++ b/logic/global.dl
@@ -55,7 +55,7 @@ global.StatementPushesUsedLabel(stmt):-
   incompleteGlobal.VariableUsedInAsJumpdest(pushedVar),
   postTrans.Statement_Defines(stmt, pushedVar).
 
-global.sens.SpecialBlock(block):- incompleteGlobal.NeedToAddCtxAtEdge(block, _).
+global.sens.SpecialBlockEdge(block, next):- incompleteGlobal.NeedToAddCtxAtEdge(block, next).
 
 COPY_CODE_FULL(global, postTrans)
 

--- a/logic/global.dl
+++ b/logic/global.dl
@@ -289,6 +289,11 @@ PreMask_Length(cat(mask, "ff"), bytes+1) :-
   DEBUG_OUTPUT(ImpreciseBlockInputContentsIndex)
   .decl ImpreciseBlockOutputContentsIndex(ctx: sens.Context, block: Block, index: StackIndex)
   DEBUG_OUTPUT(ImpreciseBlockOutputContentsIndex)
+  .decl ImpreciseBlockInputContentsIndexDetailed(ctx: sens.Context, block: Block, index: StackIndex, numOfVars: number)
+  DEBUG_OUTPUT(ImpreciseBlockInputContentsIndexDetailed)
+  .decl ImpreciseBlockOutputContentsIndexDetailed(ctx: sens.Context, block: Block, index: StackIndex, numOfVars: number)
+  DEBUG_OUTPUT(ImpreciseBlockOutputContentsIndexDetailed)
+
   .decl ImpreciseBlockInputContentsIndexFromPrev(ctx: sens.Context, block: Block, index: StackIndex)
   DEBUG_OUTPUT(ImpreciseBlockInputContentsIndexFromPrev)
   .decl ImprecisionIntroducedAtEdge(fromCtx: sens.Context, fromBlock: Block, toCtx: sens.Context, to: Block, index: StackIndex)
@@ -306,10 +311,18 @@ PreMask_Length(cat(mask, "ff"), bytes+1) :-
     var1 != var2.
    .plan 1:(2,1)
 
-  ImpreciseBlockInputContentsIndexFromPrev(ctx, block, index):-
+  ImpreciseBlockInputContentsIndexDetailed(ctx, block, index, numOfVars):-
     ImpreciseBlockInputContentsIndex(ctx, block, index),
+    numOfVars = count : BlockInputContents(ctx, block, index, _).
+
+  ImpreciseBlockOutputContentsIndexDetailed(ctx, block, index, numOfVars):-
+    ImpreciseBlockOutputContentsIndex(ctx, block, index),
+    numOfVars = count : BlockOutputContents(ctx, block, index, _).
+
+  ImpreciseBlockInputContentsIndexFromPrev(ctx, block, index):-
+    ImpreciseBlockInputContentsIndexDetailed(ctx, block, index, num),
     BlockEdge(prevCtx, prevBlock, ctx, block),
-    ImpreciseBlockOutputContentsIndex(prevCtx, prevBlock, index).
+    ImpreciseBlockOutputContentsIndexDetailed(prevCtx, prevBlock, index, num).
     .plan 1:(2,1,3), 2:(3,2,1)
 
   ImprecisionIntroducedAtEdge(fromCtx, fromBlock, toCtx, to, index):-

--- a/logic/global.dl
+++ b/logic/global.dl
@@ -323,6 +323,13 @@ PreMask_Length(cat(mask, "ff"), bytes+1) :-
   NeedToAddCtxAtEdge(fromBlock, toBlock):-
     ImprecisionIntroducedAtEdge(ctx, fromBlock, ctx, toBlock, _).
 
+    .decl NeedToNotCut(fromBlock: Block, toBlock: Block)
+  DEBUG_OUTPUT(NeedToNotCut)
+  NeedToNotCut(fromBlock, toBlock):-
+    ImprecisionIntroducedAtEdge(ctx, fromBlock, otherCtx, toBlock, _),
+    PrivateFunctionCallOrReturn(fromBlock),
+    ctx != otherCtx.
+
 }
 
 /**

--- a/logic/local.dl
+++ b/logic/local.dl
@@ -619,8 +619,18 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
     PrivateFunctionCall(block, _, _, _);
     PrivateFunctionReturn(block).
 
-  .decl CODECOPYStatement(stmt: Statement, offset: Value, size: Value)
+    .decl FallthroughBlockPushesContinuation(block: Block, fallthrough: Statement)
+  DEBUG_OUTPUT(FallthroughBlockPushesContinuation)
+  FallthroughBlockPushesContinuation(block, fallthrough):-
+    BlockPushesLabel(block, _),
+    BasicBlock_Tail(block, stmt),
+    Statement_Next(stmt, fallthrough),
+    !JUMP(stmt),
+    !JUMPI(stmt),
+    Statement_Opcode(stmt, opcode),
+    !OpcodePossiblyHalts(opcode).
 
+  .decl CODECOPYStatement(stmt: Statement, offset: Value, size: Value)
   CODECOPYStatement(codeCopy, codeOffsetNumHex, smallNumHex) :-
     Statement_Opcode(codeCopy, "CODECOPY"),
     BeforeLocalStackContents(codeCopy, 2, lenVar),
@@ -1031,6 +1041,17 @@ insertor.insertOps(insertStmt,
   preTrans.Statement_Opcode(functionStartStmt, op),
   ((op != "JUMPDEST", insertStmt = functionStartStmt);
   (op = "JUMPDEST", preTrans.Statement_Next(functionStartStmt, insertStmt))).
+
+// Add a jump to fallthrough blocks (excluding JUMPI blocks) that look like function calls
+// In other places (functions.dl, function_inliner.dl) we require the JUMP to exist
+insertor.insertOps(fallthrough,
+  LIST(
+    STMT(PUSH4, as(fallthrough, symbol)),
+    STMT(JUMP, "")
+  )
+):-
+  preTrans.FallthroughBlockPushesContinuation(_, fallthrough),
+  preTrans.JUMPDEST(fallthrough).
 
 // This one removes "throw jumps"
 insertor.removeOp(jmp),

--- a/logic/local.dl
+++ b/logic/local.dl
@@ -547,7 +547,9 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
     BasicBlock_Tail(block, stmt),
     Statement_Next(stmt, fallthrough),
     !JUMP(stmt),
-    !JUMPI(stmt).
+    !JUMPI(stmt),
+    Statement_Opcode(stmt, opcode),
+    !OpcodePossiblyHalts(opcode).
 
   .decl StaticBlockJumpTargetNonUnique(caller: Block, target: Value)
   StaticBlockJumpTargetNonUnique(caller, target) :-

--- a/logic/local.dl
+++ b/logic/local.dl
@@ -542,6 +542,13 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
     Variable_Value(targetVar, target),
     JUMPDEST(as(target, symbol)).
 
+  // SL: Added so that fallthrough blocks can populate PrivateFunctionCall
+  StaticBlockJumpTarget(block, as(fallthrough, Value)) :-
+    BasicBlock_Tail(block, stmt),
+    Statement_Next(stmt, fallthrough),
+    !JUMP(stmt),
+    !JUMPI(stmt).
+
   .decl StaticBlockJumpTargetNonUnique(caller: Block, target: Value)
   StaticBlockJumpTargetNonUnique(caller, target) :-
     StaticBlockJumpTarget(caller, target),

--- a/logic/local.dl
+++ b/logic/local.dl
@@ -602,7 +602,7 @@ ByteCodeHex(substr(bytecode, 2, strlen(bytecode))):-
   .decl PrivateFunctionReturn(returnBlock: Block)
   PrivateFunctionReturn(returnBlock) :-
     Statement_Block(stmt, returnBlock),
-    JUMP(stmt),
+    (JUMP(stmt); JUMPI(stmt)), // temp: handle conditional returns
     !ImmediateBlockJumpTarget(returnBlock, _).
 
   .decl PrivateFunctionCallOrReturn(block: Block)

--- a/logic/statement_insertor.dl
+++ b/logic/statement_insertor.dl
@@ -550,10 +550,10 @@ to.PublicFunction(block, funHex, selector):- from.PublicFunction(block, funHex, 
     PossibleCallerWithReturn(from2, _, candidate),
     from != from2.
 
-  // BlockCloningCandidate(candidate):-
-  //   PossibleCallerWithReturn(_, var, candidate),
-  //   PossibleCallerWithReturn(_, var2, candidate),
-  //   var != var2.
+  BlockCloningCandidate(candidate):-
+    PossibleCallerWithReturn(_, var, candidate),
+    PossibleCallerWithReturn(_, var2, candidate),
+    var != var2.
 
 }
 

--- a/logic/statement_insertor.dl
+++ b/logic/statement_insertor.dl
@@ -509,12 +509,31 @@ to.PublicFunction(block, funHex, selector):- from.PublicFunction(block, funHex, 
 
   .override BlockCloningCandidate
 
-  .decl PossibleCallerWithReturn(caller: Block, return: Block)
-  PossibleCallerWithReturn(caller, as(return, Block)):-
+  // Just like LocalAnalysis.BlockPushesLabel but outputs the variable
+  .decl BlockPushesLabelVar(block: Block, var: Variable)
+  BlockPushesLabelVar(block, var) :-
+    analysis.JUMPDEST(as(val, symbol)),
+    analysis.Variable_Value(var, val),
+    analysis.Statement_Defines(stmt, var),
+    analysis.Statement_Block(stmt, block),
+    analysis.BasicBlock_Tail(block, call),
+    analysis.LocalStackContents(call, _, var),
+    !analysis.BlockUsesLocal(block, var).
+
+  .decl PossibleCallerWithReturn(caller: Block, targetVar: Variable, return: Block)
+  PossibleCallerWithReturn(caller, var, as(return, Block)):-
     analysis.ImmediateBlockJumpTarget(caller, targetVar),
     analysis.Variable_Value(targetVar, target),
     analysis.JUMPDEST(as(target, symbol)),
-    analysis.BlockPushesLabel(caller, return).
+    BlockPushesLabelVar(caller, var),
+    analysis.Variable_Value(var, return).
+
+  // viaIR fallthrough call pattern
+  PossibleCallerWithReturn(caller, var, as(return, Block)):-
+    analysis.FallthroughBlockPushesContinuation(caller, fallthrough),
+    analysis.JUMPDEST(fallthrough),
+    BlockPushesLabelVar(caller, var),
+    analysis.Variable_Value(var, return).
 
   // SL: Too general, causes slowdown
   BlockCloningCandidate(candidate):-
@@ -527,15 +546,15 @@ to.PublicFunction(block, funHex, selector):- from.PublicFunction(block, funHex, 
   // caller-side return blocks that are shared between call-sites
   // SL: Best heuristic so far, targets functions.dl level precision loss
   BlockCloningCandidate(candidate):-
-    PossibleCallerWithReturn(from, candidate),
-    PossibleCallerWithReturn(from2, candidate),
+    PossibleCallerWithReturn(from, _, candidate),
+    PossibleCallerWithReturn(from2, _, candidate),
     from != from2.
-    // BlockPushesBlockToStack(from, candidate),
-    // BlockPushesBlockToStack(from2, candidate),
-    // from != from2,
-    // 1 != 1,
-    // !DirectBlockEdge(from, candidate),
-    // !DirectBlockEdge(from2, candidate).
+
+  // BlockCloningCandidate(candidate):-
+  //   PossibleCallerWithReturn(_, var, candidate),
+  //   PossibleCallerWithReturn(_, var2, candidate),
+  //   var != var2.
+
 }
 
 /**

--- a/tests/memory-modeling/arrays/0117c9ec55e2ac580fa9c9b1c2d1fff9.json
+++ b/tests/memory-modeling/arrays/0117c9ec55e2ac580fa9c9b1c2d1fff9.json
@@ -1,7 +1,7 @@
 {
     "client_path": null,
     "gigahorse_args": ["-i", "--disable_scalable_fallback", "-C", "clients/analytics_client.dl"],
-    "expected_analytics": [["Analytics_JumpToMany", 1, 0], ["Analytics_UnreachableBlock", 0, 0],
+    "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 0, 0],
     ["Analytics_BlockHasNoTACBlock", 0, 0], ["Analytics_StmtMissingOperand", 0, 0],
     ["Analytics_NonModeledMLOAD", 0, 0],["Analytics_NonModeledMSTORE", 2, 0],
     ["Analytics_ConstArrayContents", 8, 0]]

--- a/tooling/compare-runs.py
+++ b/tooling/compare-runs.py
@@ -26,6 +26,7 @@ analytics = {
 }
 
 decomp_analytics = {
+  'Analytics_PublicFunction': 'completeness',
   'Analytics_ReachableBlocks': 'completeness',
   'Analytics_UnreachableBlock': 'incompleteness',
   'Analytics_ReachableBlocksInTAC': 'completeness',
@@ -48,6 +49,8 @@ decomp_analytics = {
 mem_analytics = {
   'Analytics_NonModeledMSTORE': 'incompleteness',
   'Analytics_NonModeledMLOAD': 'incompleteness',
+  'Analytics_CallToSignature': 'completeness',
+  'Analytics_EventSignature': 'completeness',
   'Analytics_PublicFunctionArg': 'completeness',
   'Analytics_PublicFunctionArrayArg': 'completeness'
 }


### PR DESCRIPTION
This PR includes a few changes:
* Detect edges that introduce imprecision at the `incompleteGlobal` level and have the same context for `from` and `to`. Add `from` to the context during the main global analysis round.
* Support for new pattern present in `viaIR` produced bytecode. Call blocks that do not include a `JUMP` (or `JUMPI`). Call start is the fallthrough.
* Slightly better more general block cloning

-----------------------------------------
All results shown will be using `-T 200 --disable_inline -- disable_scalable_fallback`
## viair-dec23
```
2881 contracts decompiled/analyzed by jan24-ir-master-200 (25 exclusively)
2905 contracts decompiled/analyzed by jan24-ir-branch-200 (49 exclusively)

ANALYTIC: decomp_time
jan24-ir-master-200 (common): 12580.137337684631
jan24-ir-branch-200 (common): 16028.838307857513 (+27.41%)

ANALYTIC: Analytics_JumpToMany
jan24-ir-master-200 (common): 5334 (+14.64%)
jan24-ir-branch-200 (common): 4653

ANALYTIC: Analytics_ReachableBlocks
jan24-ir-master-200 (common): 1256925
jan24-ir-branch-200 (common): 1256925

ANALYTIC: Analytics_BlockHasNoTACBlock
jan24-ir-master-200 (common): 1380 (+1.322%)
jan24-ir-branch-200 (common): 1362

ANALYTIC: Analytics_DeadBlocks
jan24-ir-master-200 (common): 12122 (+13.89%)
jan24-ir-branch-200 (common): 10644

ANALYTIC: Analytics_PolymorphicTargetSameCtx
jan24-ir-master-200 (common): 744 (+736%)
jan24-ir-branch-200 (common): 89

ANALYTIC: Analytics_StmtMissingOperand
jan24-ir-master-200 (common): 623 (+25.6%)
jan24-ir-branch-200 (common): 496

ANALYTIC: Analytics_Contexts
jan24-ir-master-200 (common): 2386797 (+2.208%)
jan24-ir-branch-200 (common): 2335239
```

## metadata-dataset1
```
1990 contracts decompiled/analyzed by jan24-metadata-master-200 (0 exclusively)
1996 contracts decompiled/analyzed by jan24-metadata-branch-200 (6 exclusively)

ANALYTIC: decomp_time
jan24-metadata-master-200 (common): 7452.368603944778 (+15.88%)
jan24-metadata-branch-200 (common): 6430.882352113724

ANALYTIC: Analytics_JumpToMany
jan24-metadata-master-200 (common): 358 (+2.874%)
jan24-metadata-branch-200 (common): 348

ANALYTIC: Analytics_ReachableBlocks
jan24-metadata-master-200 (common): 1229995
jan24-metadata-branch-200 (common): 1229995

ANALYTIC: Analytics_BlockHasNoTACBlock
jan24-metadata-master-200 (common): 94 (+1243%)
jan24-metadata-branch-200 (common): 7

ANALYTIC: Analytics_PolymorphicTargetSameCtx
jan24-metadata-master-200 (common): 734 (+3236%)
jan24-metadata-branch-200 (common): 22

ANALYTIC: Analytics_StmtMissingOperand
jan24-metadata-master-200 (common): 86 (+1.176%)
jan24-metadata-branch-200 (common): 85

ANALYTIC: Analytics_Contexts
jan24-metadata-master-200 (common): 1500998 (+28.23%)
jan24-metadata-branch-200 (common): 1170534
```

## solc08-over10k
```
1981 contracts decompiled/analyzed by jan24-large-master-200 (2 exclusively)
1993 contracts decompiled/analyzed by jan24-large-branch-200 (14 exclusively)

ANALYTIC: decomp_time
jan24-large-master-200 (common): 10076.616517066956 (+8.747%)
jan24-large-branch-200 (common): 9266.106414556503

ANALYTIC: Analytics_JumpToMany
jan24-large-master-200 (common): 441 (+5.251%)
jan24-large-branch-200 (common): 419

ANALYTIC: Analytics_ReachableBlocks
jan24-large-master-200 (common): 1630449
jan24-large-branch-200 (common): 1630449


ANALYTIC: Analytics_BlockHasNoTACBlock
jan24-large-master-200 (common): 180 (+8900%)
jan24-large-branch-200 (common): 2

ANALYTIC: Analytics_PolymorphicTargetSameCtx
jan24-large-master-200 (common): 1248 (+4060%)
jan24-large-branch-200 (common): 30

ANALYTIC: Analytics_StmtMissingOperand
jan24-large-master-200 (common): 83
jan24-large-branch-200 (common): 84 (+1.205%)

ANALYTIC: Analytics_Contexts
jan24-large-master-200 (common): 2146643 (+21.27%)
jan24-large-branch-200 (common): 1770172
```