### PR TITLE
Function inliner refactor

### DIFF
--- a/clientlib/flows.dl
+++ b/clientlib/flows.dl
@@ -224,6 +224,17 @@ localFlowAnalysis.TransferBoundary(block) :- IsBlock(block).
 
 #define LocalFlows localFlowAnalysis.Flows
 
+/**
+  Local flows excluding PHIs
+  To be used when more precise, local inferrences are needed
+*/
+.init altLocalFlowAnalysis = LocalFlowAnalysis
+
+altLocalFlowAnalysis.TransferStmt(stmt) :- FlowOp(op), Statement_Opcode(stmt, op), op != "PHI".
+altLocalFlowAnalysis.TransferBoundary(block) :- IsBlock(block).
+
+#define LocalFlowsExclPHI altLocalFlowAnalysis.Flows
+
 // x controls whether y is executed.
 .decl Controls(x:Statement, y:Block)
 

--- a/clientlib/function_inliner.dl
+++ b/clientlib/function_inliner.dl
@@ -101,9 +101,13 @@ IsUtilFunc(fun):-
     numOfBlocks = count : In_InFunction(_, fun),
     numOfBlocks <= 3.
 
+  // a function is only called once by a caller that makes a single call
   InlineCandidate(fun):-
     In_IsFunction(fun),
     1 = count : In_CallGraphEdge(_, fun),
+    In_CallGraphEdge(caller, fun),
+    In_InFunction(caller, callerFun),
+    1 = count: {In_InFunction(inCaller, callerFun), In_CallGraphEdge(inCaller, _)},
     !IsPublicFunction(fun).
 
   InlineCandidate(fun):-

--- a/clientlib/function_inliner.dl
+++ b/clientlib/function_inliner.dl
@@ -18,7 +18,31 @@
 .comp AnalysisHelpInliner : FunctionInliner {
 
   .override InlineCandidate
-  .output InlineCandidate, FunctionToInline, IsPublicFunction, FunctionIsInner, SafelyInlinableFunction
+  // .output InlineCandidate, FunctionToInline, IsPublicFunction, FunctionIsInner, SafelyInlinableFunction
+
+  .decl HighLevelStatement(stmt: Statement)
+  HighLevelStatement(stmt):-
+    Statement_Opcode(stmt, op),
+    (
+      op = "CALLPRIVATE";
+      op = "CALL";
+      op = "STATICCALL";
+      op = "DELEGATECALL";
+      op = "REVERT";
+      op = "THROW";
+      op = "SSTORE"
+    ).
+
+  HighLevelStatement(stmt):-
+    Analytics_NonModeledMSTORE(stmt);
+    StructStore(stmt, _, _, _);
+    StructAllocation(stmt, _, _);
+    ArrayStore(stmt, _, _);
+    ArrayAllocationInternal(stmt, _, _, _).
+
+  InlineCandidate(fun):-
+    In_CallGraphEdge(_, fun),
+    0 = count : { Statement_Function(stmt, fun), HighLevelStatement(stmt) }.
 
   /* Inline guards to help our analysis */
   InlineCandidate(fun):-

--- a/clientlib/function_inliner.dl
+++ b/clientlib/function_inliner.dl
@@ -18,7 +18,7 @@
 .comp AnalysisHelpInliner : FunctionInliner {
 
   .override InlineCandidate
-  // .output InlineCandidate, FunctionToInline, IsPublicFunction, FunctionIsInner, SafelyInlinableFunction
+  .output InlineCandidate, FunctionToInline, IsPublicFunction, FunctionIsInner, SafelyInlinableFunction
 
   .decl HighLevelStatement(stmt: Statement)
   HighLevelStatement(stmt):-
@@ -43,18 +43,28 @@
     ArrayStore(stmt, _, _);
     ArrayAllocationInternal(stmt, _, _, _).
 
-  InlineCandidate(fun):-
+  HighLevelStatement(ret):-
+    In_Statement_Opcode(ret, "RETURNPRIVATE"),
+    In_Statement_Uses(ret, _, pos),
+    pos >= 1.
+
+  .decl Function_HighLevelStmts(fun: Function, numOfStmts: number)
+  Function_HighLevelStmts(fun, numOfStmts):-
     In_CallGraphEdge(_, fun),
-    0 = count : { Statement_Function(stmt, fun), HighLevelStatement(stmt) }.
+    numOfStmts = count : { Statement_Function(stmt, fun), HighLevelStatement(stmt) }.
+
+  InlineCandidate(fun, "VerySmall"):-
+    In_CallGraphEdge(_, fun),
+    Function_HighLevelStmts(fun, 1).
 
   // Functions that have a single high-level stmt and no actual returns
-  InlineCandidate(fun):-
-    In_CallGraphEdge(_, fun),
-    1 = count : { Statement_Function(stmt, fun), HighLevelStatement(stmt) },
-    !In_FormalReturnArgs(fun, _, 0).
+  // InlineCandidate(fun):-
+  //   In_CallGraphEdge(_, fun),
+  //   1 = count : { Statement_Function(stmt, fun), HighLevelStatement(stmt) },
+  //   !In_FormalReturnArgs(fun, _, 0).
 
   /* Inline guards to help our analysis */
-  InlineCandidate(fun):-
+  InlineCandidate(fun, "WrapperMethod"):-
     (In_Statement_Opcode(callerOp, "CALLER"); In_Statement_Opcode(callerOp, "ORIGIN")),
     In_Statement_Defines(callerOp, sender, 0),
     LocalFlows(sender, formalRet),
@@ -82,12 +92,13 @@ IsUtilFunc(fun):-
     HighLevelFunctionName(fun, funName),
     prefix=substr(funName, 0, strlen(prefix)).
 
-  InlineCandidate(fun):-
+  InlineCandidate(fun, "Util"):-
+    In_CallGraphEdge(_, fun),
     IsUtilFunc(fun).
 
 
   /* To detect some storage constructs breaking through functions */
-  InlineCandidate(fun):-
+  InlineCandidate(fun, "Storage1"):-
     (SHA3(_, _, _, var) ; Variable_Value(var, _)),
     LocalFlows(var, actualArg),
     In_ActualArgs(caller, actualArg, pos),
@@ -96,7 +107,7 @@ IsUtilFunc(fun):-
     LocalFlows(formalArg, storeIndex),
     (SLOAD(_, storeIndex, _) ; SSTORE(_, storeIndex, _)).
 
-  InlineCandidate(fun):-
+  InlineCandidate(fun, "Storage2"):-
     (SHA3(_, _, _, var) ; Variable_Value(var, _)),
     LocalFlows(var, actualArg),
     In_ActualArgs(caller, actualArg, pos),
@@ -107,7 +118,7 @@ IsUtilFunc(fun):-
     LocalFlows(def, storeIndex),
     (SLOAD(_, storeIndex, _) ; SSTORE(_, storeIndex, _)).
 
-  InlineCandidate(fun):-
+  InlineCandidate(fun, "Storage3"):-
     // (SHA3_2ARG(_, _, _, def); SHA3_1ARG(_, _, def)),
     // LocalFlows(def, intermIndex),
     // using internal storage modeling predicate here
@@ -119,29 +130,29 @@ IsUtilFunc(fun):-
     LocalFlows(intermIndexCaller, storeIndex),
     (SLOAD(_, storeIndex, _) ; SSTORE(_, storeIndex, _)).
 
-  InlineCandidate(fun):-
+  InlineCandidate(fun, "CallData1"):-
     //In_Variable_Value(actualArg, _),
     //In_ActualArgs(caller, actualArg, pos),
     //In_CallGraphEdge(caller, fun),
     In_FormalArgs(fun, formalArg, _),
-    LocalFlows(formalArg, calldataIndex),
+    LocalFlowsExclPHI(formalArg, calldataIndex),
     CALLDATALOAD(_, calldataIndex, _).
 
-  InlineCandidate(fun):-
+  InlineCandidate(fun, "CallData2"):-
     CALLDATALOAD(cdl, calldataIndex, _),
     In_Variable_Value(calldataIndex, _),
     In_Statement_Function(cdl, fun),
     !IsPublicFunction(fun).
 
   // Less than 3 blocks
-  InlineCandidate(fun):-
+  InlineCandidate(fun, "Small"):-
     In_CallGraphEdge(_, fun),
     In_FormalArgs(fun, _, _),
     numOfBlocks = count : In_InFunction(_, fun),
     numOfBlocks < 3.
 
   // a function is only called once by a caller that makes a single call
-  InlineCandidate(fun):-
+  InlineCandidate(fun, "SingleCall"):-
     In_IsFunction(fun),
     1 = count : In_CallGraphEdge(_, fun),
     In_CallGraphEdge(caller, fun),
@@ -149,22 +160,35 @@ IsUtilFunc(fun):-
     1 = count: {In_InFunction(inCaller, callerFun), In_CallGraphEdge(inCaller, _)},
     !IsPublicFunction(fun).
 
-  InlineCandidate(fun):-
+  InlineCandidate(fun, "ConsumeMemNoArgs"):-
     StatementConsumesMemoryNoArgs(memConsStmt),
-    In_Statement_Function(memConsStmt, fun).
+    In_Statement_Function(memConsStmt, fun),
+    Function_HighLevelStmts(fun, numOfStmts),
+    numOfStmts < 15.
 
-  InlineCandidate(fun):-
+  InlineCandidate(fun, "Memory1"):-
     In_FormalArgs(fun, formalArg, _),
-    LocalFlows(formalArg, loadAddr),
+    LocalFlowsExclPHI(formalArg, loadAddr),
     MLOAD(_, loadAddr, loaded),
-    ( LocalFlows(loaded, formalRet);
-      LocalFlows(formalArg, formalRet)),
+    ( LocalFlowsExclPHI(loaded, formalRet);
+      LocalFlowsExclPHI(formalArg, formalRet)),
     In_FormalReturnArgs(fun, formalRet, _),
     !Struct_WordWidth(formalArg, _),
     // !Struct_WordWidth(formalRet, _),
     !VarIsArray(formalArg, _).
 
-  InlineCandidate(fun):-
+  // aimed to catch patterns that compute memory allocation bytes inside a function
+  InlineCandidate(fun, "Memory2"):-
+    In_FormalArgs(fun, formalArg, _),
+    In_FormalReturnArgs(fun, formalRet, index),
+    LocalFlowsExclPHI(formalArg, formalRet),
+    In_CallGraphEdge(caller, fun),
+    In_ActualReturnArgs(caller, actualRet, index),
+    LocalFlowsExclPHI(actualRet, bumpVar),
+    MSTORE(mstore, _, bumpVar),
+    MSTOREFreePtr(mstore).
+
+  InlineCandidate(fun, "Memory3"):-
     MLOADFreePtr_To(_, loadedAddr),
     In_FormalReturnArgs(fun, loadedAddr, _),
     !Struct_WordWidth(loadedAddr, _),
@@ -174,7 +198,7 @@ IsUtilFunc(fun):-
     If an arg passed to a function is always the free mem pointer and never a high-level
     memory structure, we inline it as it's likely an allocation split in half.
   */
-  InlineCandidate(fun):-
+  InlineCandidate(fun, "Memory4"):-
     CallArgIsNonModeledMemObject(_, fun, argNum),
     count: CallArgIsNonModeledMemObject(_, fun, argNum) = count: In_CallGraphEdge(_, fun).
 
@@ -186,9 +210,9 @@ IsUtilFunc(fun):-
     !Struct_WordWidth(loadedAddr, _),
     !VarIsArray(loadedAddr, _).
 
-  InlineCandidate(fun):-
+  InlineCandidate(fun, "Memory5"):-
     In_FormalArgs(fun, formalArg, _),
-    LocalFlows(formalArg, storeAddr),
+    LocalFlowsExclPHI(formalArg, storeAddr),
     MSTORE(_, storeAddr, _),
     !Struct_WordWidth(formalArg, _),
     !VarIsArray(formalArg, _).
@@ -199,7 +223,7 @@ IsUtilFunc(fun):-
     (In_Statement_Opcode(callStmt, "CALL"); In_Statement_Opcode(callStmt, "STATICCALL"); In_Statement_Opcode(callStmt, "DELEGATECALL")),
     In_Statement_Function(callStmt, fun).
 
-  InlineCandidate(fun):-
+  InlineCandidate(fun, "ReturnDataNoCall"):-
     (In_Statement_Opcode(returnDataStmt, "RETURNDATASIZE"); In_Statement_Opcode(returnDataStmt, "RETURNDATACOPY")),
     In_Statement_Function(returnDataStmt, fun),
     !FunctionContainsExternalCall(fun).
@@ -210,7 +234,7 @@ IsUtilFunc(fun):-
     StatementUsesMemory(stmt,_),
     In_Statement_Function(stmt, fun).
 
-  InlineCandidate(fun):-
+  InlineCandidate(fun, "MemoryLoop"):-
     MemoryCopyLoop(memLoop, _, _),
     In_InFunction(memLoop, fun),
     !FunctionContainsMemConsStmt(fun).
@@ -222,7 +246,7 @@ IsUtilFunc(fun):-
 .output NeedsMoreInlining
 
 NeedsMoreInlining(fun):-
-  inliner.InlineCandidate(fun),
+  inliner.InlineCandidate(fun, _),
   inliner.SafelyInlinableFunction(fun),
   !inliner.FunctionToInline(fun),
   !IsPublicFunction(fun).

--- a/clientlib/function_inliner.dl
+++ b/clientlib/function_inliner.dl
@@ -30,11 +30,14 @@
       op = "DELEGATECALL";
       op = "REVERT";
       op = "THROW";
-      op = "SSTORE"
+      op = "SSTORE";
+      op = "CREATE";
+      op = "CREATE2"
     ).
 
   HighLevelStatement(stmt):-
     Analytics_NonModeledMSTORE(stmt);
+    LOGStatement(stmt, _);
     StructStore(stmt, _, _, _);
     StructAllocation(stmt, _, _);
     ArrayStore(stmt, _, _);

--- a/clientlib/function_inliner.dl
+++ b/clientlib/function_inliner.dl
@@ -21,6 +21,7 @@
   .output InlineCandidate, FunctionToInline, IsPublicFunction, FunctionIsInner, SafelyInlinableFunction
 
   .decl HighLevelStatement(stmt: Statement)
+  DEBUG_OUTPUT(HighLevelStatement)
   HighLevelStatement(stmt):-
     Statement_Opcode(stmt, op),
     (
@@ -40,8 +41,11 @@
     LOGStatement(stmt, _);
     StructStore(stmt, _, _, _);
     StructAllocation(stmt, _, _);
-    ArrayStore(stmt, _, _);
     ArrayAllocationInternal(stmt, _, _, _).
+
+  HighLevelStatement(stmt):-
+    ArrayStore(stmt, arrRep, _),
+    !ConstArray_Contents(arrRep, _).
 
   HighLevelStatement(ret):-
     In_Statement_Opcode(ret, "RETURNPRIVATE"),

--- a/clientlib/function_inliner.dl
+++ b/clientlib/function_inliner.dl
@@ -128,9 +128,18 @@ IsUtilFunc(fun):-
     !Struct_WordWidth(loadedAddr, _),
     !VarIsArray(loadedAddr, _).
 
+  /**
+    If an arg passed to a function is always the free mem pointer and never a high-level
+    memory structure, we inline it as it's likely an allocation split in half.
+  */
   InlineCandidate(fun):-
+    CallArgIsNonModeledMemObject(_, fun, argNum),
+    count: CallArgIsNonModeledMemObject(_, fun, argNum) = count: In_CallGraphEdge(_, fun).
+
+  .decl CallArgIsNonModeledMemObject(caller: Block, callee: Function, argNum: number)
+  CallArgIsNonModeledMemObject(caller, fun, argNum):-
     MLOADFreePtr_To(_, loadedAddr),
-    In_ActualArgs(caller, loadedAddr, _),
+    In_ActualArgs(caller, loadedAddr, argNum),
     In_CallGraphEdge(caller, fun),
     !Struct_WordWidth(loadedAddr, _),
     !VarIsArray(loadedAddr, _).

--- a/clientlib/function_inliner.dl
+++ b/clientlib/function_inliner.dl
@@ -1,6 +1,6 @@
 #include "tac-transformers/abstract_function_inliner.dl"
 #include "memory_modeling/memory_modeling.dl"
-
+#include "storage_modeling/storage_modeling.dl"
 
 /**
   Inliner was designed as a component in order to be able to have
@@ -75,8 +75,11 @@ IsUtilFunc(fun):-
     (SLOAD(_, storeIndex, _) ; SSTORE(_, storeIndex, _)).
 
   InlineCandidate(fun):-
-    (SHA3_2ARG(_, _, _, def); SHA3_1ARG(_, _, def)),
-    LocalFlows(def, intermIndex),
+    // (SHA3_2ARG(_, _, _, def); SHA3_1ARG(_, _, def)),
+    // LocalFlows(def, intermIndex),
+    // using internal storage modeling predicate here
+    // to get higher coverage
+    Variable_StorageIndex(intermIndex, _),
     In_FormalReturnArgs(fun, intermIndex, pos),
     In_CallGraphEdge(caller, fun),
     In_ActualReturnArgs(caller, intermIndexCaller, pos),

--- a/clientlib/function_inliner.dl
+++ b/clientlib/function_inliner.dl
@@ -31,7 +31,8 @@
 IsUtilFunc(fun):-
     (prefix = "abi_encode_";
     prefix = "calldata_";
-    prefix = "checked_";
+    // prefix = "checked_";
+    // don't want to inline checked arithmetic functions
     prefix = "extract_";
     prefix = "getter_";
     prefix = "mapping_index_";
@@ -99,7 +100,7 @@ IsUtilFunc(fun):-
     In_CallGraphEdge(_, fun),
     In_FormalArgs(fun, _, _),
     numOfBlocks = count : In_InFunction(_, fun),
-    numOfBlocks <= 3.
+    numOfBlocks < 3.
 
   // a function is only called once by a caller that makes a single call
   InlineCandidate(fun):-

--- a/clientlib/function_inliner.dl
+++ b/clientlib/function_inliner.dl
@@ -47,6 +47,12 @@
     In_CallGraphEdge(_, fun),
     0 = count : { Statement_Function(stmt, fun), HighLevelStatement(stmt) }.
 
+  // Functions that have a single high-level stmt and no actual returns
+  InlineCandidate(fun):-
+    In_CallGraphEdge(_, fun),
+    1 = count : { Statement_Function(stmt, fun), HighLevelStatement(stmt) },
+    !In_FormalReturnArgs(fun, _, 0).
+
   /* Inline guards to help our analysis */
   InlineCandidate(fun):-
     (In_Statement_Opcode(callerOp, "CALLER"); In_Statement_Opcode(callerOp, "ORIGIN")),
@@ -126,13 +132,6 @@ IsUtilFunc(fun):-
     In_Variable_Value(calldataIndex, _),
     In_Statement_Function(cdl, fun),
     !IsPublicFunction(fun).
-
-  // Functions that only have a return jump and no actual returns
-  InlineCandidate(fun):-
-    In_CallGraphEdge(_, fun),
-    numOfStatements = count : In_Statement_Function(_, fun),
-    numOfStatements = 1,
-    !In_FormalReturnArgs(fun, _, 0).
 
   // Less than 3 blocks
   InlineCandidate(fun):-

--- a/clientlib/function_inliner.dl
+++ b/clientlib/function_inliner.dl
@@ -69,8 +69,7 @@ IsUtilFunc(fun):-
     In_CallGraphEdge(caller, fun),
     In_FormalArgs(fun, formalArg, pos),
     LocalFlows(formalArg, intermIndex),
-    MemoryStatement_ActualArg(stmt, intermIndex, _),
-    SHA3(stmt, _, _, def),
+    (SHA3_2ARG(_, _, intermIndex, def); SHA3_1ARG(_, intermIndex, def)),
     LocalFlows(def, storeIndex),
     (SLOAD(_, storeIndex, _) ; SSTORE(_, storeIndex, _)).
 

--- a/clientlib/function_inliner.dl
+++ b/clientlib/function_inliner.dl
@@ -75,6 +75,15 @@ IsUtilFunc(fun):-
     (SLOAD(_, storeIndex, _) ; SSTORE(_, storeIndex, _)).
 
   InlineCandidate(fun):-
+    (SHA3_2ARG(_, _, _, def); SHA3_1ARG(_, _, def)),
+    LocalFlows(def, intermIndex),
+    In_FormalReturnArgs(fun, intermIndex, pos),
+    In_CallGraphEdge(caller, fun),
+    In_ActualReturnArgs(caller, intermIndexCaller, pos),
+    LocalFlows(intermIndexCaller, storeIndex),
+    (SLOAD(_, storeIndex, _) ; SSTORE(_, storeIndex, _)).
+
+  InlineCandidate(fun):-
     //In_Variable_Value(actualArg, _),
     //In_ActualArgs(caller, actualArg, pos),
     //In_CallGraphEdge(caller, fun),

--- a/clientlib/function_inliner.dl
+++ b/clientlib/function_inliner.dl
@@ -18,7 +18,7 @@
 .comp AnalysisHelpInliner : FunctionInliner {
 
   .override InlineCandidate
-  //.output InlineCandidate
+  .output InlineCandidate, FunctionToInline, IsPublicFunction, FunctionIsInner, SafelyInlinableFunction
 
   /* Inline guards to help our analysis */
   InlineCandidate(fun):-
@@ -60,6 +60,18 @@ IsUtilFunc(fun):-
     In_CallGraphEdge(caller, fun),
     In_FormalArgs(fun, formalArg, pos),
     LocalFlows(formalArg, storeIndex),
+    (SLOAD(_, storeIndex, _) ; SSTORE(_, storeIndex, _)).
+
+  InlineCandidate(fun):-
+    (SHA3(_, _, _, var) ; Variable_Value(var, _)),
+    LocalFlows(var, actualArg),
+    In_ActualArgs(caller, actualArg, pos),
+    In_CallGraphEdge(caller, fun),
+    In_FormalArgs(fun, formalArg, pos),
+    LocalFlows(formalArg, intermIndex),
+    MemoryStatement_ActualArg(stmt, intermIndex, _),
+    SHA3(stmt, _, _, def),
+    LocalFlows(def, storeIndex),
     (SLOAD(_, storeIndex, _) ; SSTORE(_, storeIndex, _)).
 
   InlineCandidate(fun):-
@@ -113,6 +125,13 @@ IsUtilFunc(fun):-
   InlineCandidate(fun):-
     MLOADFreePtr_To(_, loadedAddr),
     In_FormalReturnArgs(fun, loadedAddr, _),
+    !Struct_WordWidth(loadedAddr, _),
+    !VarIsArray(loadedAddr, _).
+
+  InlineCandidate(fun):-
+    MLOADFreePtr_To(_, loadedAddr),
+    In_ActualArgs(caller, loadedAddr, _),
+    In_CallGraphEdge(caller, fun),
     !Struct_WordWidth(loadedAddr, _),
     !VarIsArray(loadedAddr, _).
 

--- a/clientlib/function_inliner.dl
+++ b/clientlib/function_inliner.dl
@@ -18,7 +18,7 @@
 .comp AnalysisHelpInliner : FunctionInliner {
 
   .override InlineCandidate
-  .output InlineCandidate, FunctionToInline, IsPublicFunction, FunctionIsInner, SafelyInlinableFunction
+  // .output InlineCandidate, FunctionToInline, IsPublicFunction, FunctionIsInner, SafelyInlinableFunction
 
   .decl HighLevelStatement(stmt: Statement)
   DEBUG_OUTPUT(HighLevelStatement)

--- a/clientlib/function_inliner.dl
+++ b/clientlib/function_inliner.dl
@@ -49,6 +49,7 @@
     pos >= 1.
 
   .decl Function_HighLevelStmts(fun: Function, numOfStmts: number)
+  DEBUG_OUTPUT(Function_HighLevelStmts)
   Function_HighLevelStmts(fun, numOfStmts):-
     In_CallGraphEdge(_, fun),
     numOfStmts = count : { Statement_Function(stmt, fun), HighLevelStatement(stmt) }.
@@ -164,7 +165,7 @@ IsUtilFunc(fun):-
     StatementConsumesMemoryNoArgs(memConsStmt),
     In_Statement_Function(memConsStmt, fun),
     Function_HighLevelStmts(fun, numOfStmts),
-    numOfStmts < 15.
+    numOfStmts < 20.
 
   InlineCandidate(fun, "Memory1"):-
     In_FormalArgs(fun, formalArg, _),

--- a/clientlib/memory_modeling/structs.dl
+++ b/clientlib/memory_modeling/structs.dl
@@ -6,6 +6,18 @@ StatementDominates(stmt1, stmt2):-
   Statement_Block(stmt2, block2),
   (Dominates(block1, block2) ; LocalStatementPathInBlock(stmt1, stmt2)).
 
+.decl StatementDoesntDominate(stmt1: Statement, stmt2: Statement) inline
+StatementDoesntDominate(stmt1, stmt2):-
+  Statement_Block(stmt1, block),
+  Statement_Block(stmt2, block),
+  LocalStatementPathInBlock(stmt2, stmt1).
+
+StatementDoesntDominate(stmt1, stmt2):-
+  Statement_Block(stmt1, block1),
+  Statement_Block(stmt2, block2),
+  block1 != block2,
+  !Dominates(block1, block2).
+
 
 /**
   Base case for struct allocations
@@ -111,6 +123,14 @@ StructAllocationCheck(structBase):-
   ControlsWith(jmpi, throwBlock, condVar),
   ThrowBlock(throwBlock).
 
+// Maybe not the best way to define it, may revisit
+.decl StructStoresInDifferentPaths(structBase: Variable)
+StructStoresInDifferentPaths(structBaseVar):-
+  StoreToPossibleStruct(mstore1, structBaseVar, _, _),
+  StoreToPossibleStruct(mstore2, structBaseVar, _, _),
+  StatementDoesntDominate(mstore1, mstore2),
+  StatementDoesntDominate(mstore2, mstore1).
+
 // REVIEW: it requires at least as many InitialStoreToPossibleStruct as the struct's words
 // it may possibly not be the case in optimized code
 // REVIEW: only infers the structs in cases where it escapes the current method
@@ -127,6 +147,11 @@ StructAllocation(freePtrUpdStore, structBaseVar, wordWidth):-
   StructAllocationCheck(structBaseVar),
   // LocalFlows(structBaseVar, argOrRet),
   // (ActualArgs(_, argOrRet, _) ; FormalReturnArgs(_, argOrRet, _)),
+  !ProbablyConstantArray(structBaseVar).
+
+StructAllocation(freePtrUpdStore, structBaseVar, wordWidth):-
+  PossibleStructAllocation(_, freePtrUpdStore, structBaseVar, wordWidth),
+  StructStoresInDifferentPaths(structBaseVar),
   !ProbablyConstantArray(structBaseVar).
 
 /**

--- a/clientlib/tac-transformers/abstract_function_inliner.dl
+++ b/clientlib/tac-transformers/abstract_function_inliner.dl
@@ -90,6 +90,12 @@
     1 < count: Function_Exit(fun, _),
     !In_FormalReturnArgs(fun, _, 0).
 
+   .decl FunctionMultiReturnRestriction(fun:Function)
+  FunctionMultiReturnRestriction(fun):-
+    In_IsFunction(fun),
+    1 < count: Function_Exit(fun, _),
+    In_FormalReturnArgs(fun, _, 0).
+
   /* We can safely inline functions with only one return
      and matching args and returns at every call-site(as described above) */
   SafelyInlinableFunction(fun):-
@@ -98,7 +104,7 @@
     InFunction(fun_entry_block, fun),
     In_FunctionEntry(fun_entry_block),
     !GlobalEntryBlock(fun_entry_block),
-    FunctionReturnRestriction(fun),
+    (FunctionReturnRestriction(fun); FunctionMultiReturnRestriction(fun)),
     !FunHasArgMismatch(fun),
     !FunHasRetMismatch(fun),
     !FunCalledWithImpreciseControlFlow(fun).
@@ -359,7 +365,33 @@
     FunctionToInline_RetStmt(callee, retStmt),
     In_Statement_Uses(retStmt, formalRet, i + 1).
 
+  .decl InlinedCallNeedsPHIIntroduced(callerBlock: Block, callStmt: Statement, callee: Function, retStmt: Statement, index: number, actualRet: Variable, formalRet: Variable)
+  DEBUG_OUTPUT(InlinedCallNeedsPHIIntroduced)
+  InlinedCallNeedsPHIIntroduced(callerBlock, callStmt, callee, retStmt, i, actualRet, formalRet):-
+    CallToClonedFunction(callerBlock, callStmt, callee),
+    FunctionMultiReturnRestriction(callee),
+    In_Statement_Defines(callStmt, actualRet, i),
+    FunctionToInline_RetStmt(callee, retStmt),
+    In_Statement_Uses(retStmt, formalRet, i + 1).
 
+  .decl NewPHIInfo(callerBlock: Block, callStmt: Statement, actualRet: Variable, phiBlock: Block, stmtId: Statement, defVar: Variable, useVar: Variable)
+  DEBUG_OUTPUT(NewPHIInfo)
+
+  NewPHIInfo(callerBlock, callStmt, actualRet, phiBlock, stmtId, defVar, formalRett):-
+    InlinedCallNeedsPHIIntroduced(callerBlock, callStmt, _, _, i, actualRet, formalRet),
+    In_LocalBlockEdge(callerBlock, phiBlock),
+    InVar_OutVar(formalRet, callerBlock, formalRett),
+    !ClonedCallArgs(_, _, _, _, formalRet),
+    stmtId = cat(cat(cat(cat(callerBlock, "S"), phiBlock), "_"), to_string(i)),
+    defVar = cat(cat(cat(cat(actualRet, "V"), phiBlock), "_"), to_string(i)).
+
+  NewPHIInfo(callerBlock, callStmt, actualRet, phiBlock, stmtId, defVar, actualArgg):-
+    InlinedCallNeedsPHIIntroduced(callerBlock, callStmt, _, _, i, actualRet, formalRet),
+    In_LocalBlockEdge(callerBlock, phiBlock),
+    ClonedCallArgs(callerBlock, _, _, actualArg, formalRet), //Formal ret is formal arg
+    InVar_OutVar(actualArg, "", actualArgg),
+    stmtId = cat(cat(cat(cat(callerBlock, "S"), phiBlock), "_"), to_string(i)),
+    defVar = cat(cat(cat(cat(actualRet, "V"), phiBlock), "_"), to_string(i)).
 
   Out_Statement_Defines(outStmt, outVar, i),
   InVar_OutVar(inVar, callerBlock, outVar),
@@ -387,12 +419,14 @@
   InVar_OutVar(actualRet , "", formalRett):-
     ClonedCallRets(callerBlock, _, _, _, actualRet, formalRet),
     InVar_OutVar(formalRet, callerBlock, formalRett),
+    !InlinedCallNeedsPHIIntroduced(callerBlock, _, _, _, _, actualRet, formalRet),
     !ClonedCallArgs(_, _, _, _, formalRet).
 
   InVar_OutVar(actualRet , "", actualArgg):-
     ClonedCallRets(caller, _, _, _, actualRet, formalRet),
     ClonedCallArgs(caller, _, _, actualArg, formalRet), //Formal ret is formal arg
-    InVar_OutVar(actualArg, "", actualArgg).
+    InVar_OutVar(actualArg, "", actualArgg),
+    !InlinedCallNeedsPHIIntroduced(caller, _, _, _, _, actualRet, formalRet).
 
   Out_Statement_Uses(outStmt, outVar, i):-
     In_Statement_Uses(inStmt, inVar, i),
@@ -414,8 +448,16 @@
     InStatement_OutStatement(inStmt, "", outStmt),
     ClonedCallRets(callerBlock, _, _, _, actualRet, formalRet),
     InVar_OutVar(formalRet, callerBlock, outVar),
+    !InlinedCallNeedsPHIIntroduced(callerBlock, _, _, _, _, actualRet, formalRet),
     !ClonedCallRets(_, inStmt, _, _, _, _).
 
+  Out_Statement_Uses(outStmt, phiVar, i):-
+    In_Statement_Uses(inStmt, actualRet, i),
+    InStatement_OutStatement(inStmt, "", outStmt),
+    ClonedCallRets(callerBlock, _, _, _, actualRet, formalRet),
+    InlinedCallNeedsPHIIntroduced(callerBlock, _, _, _, _, actualRet, formalRet),
+    NewPHIInfo(callerBlock, _, actualRet, _, _, phiVar, _),
+    !ClonedCallRets(_, inStmt, _, _, _, _).
 
   /* Fixing the uses of cloned calls/returns to restore the JUMP stmts */
   Out_Statement_Uses(outCall, outJumpTargetVar, 0):-
@@ -429,6 +471,12 @@
     In_Statement_Uses(retJump, jumpTargetVar, 0),
     InStatement_OutStatement(retJump, callerBlock, outRetJump),
     InVar_OutVar(jumpTargetVar, callerBlock, outJumpTargetVar).
+
+  Out_Statement_Opcode(stmtId, "PHI"),
+  Out_Statement_Defines(stmtId, defVar, 0),
+  Out_Statement_Uses(stmtId, useVar, -1),
+  Out_Statement_Block(stmtId, phiBlock):-
+    NewPHIInfo(_, _, _, phiBlock, stmtId, defVar, useVar).
 
   .decl In_VariableHoldsJumpdest(inVar: Variable)
   In_VariableHoldsJumpdest(inVar):-

--- a/clientlib/tac-transformers/abstract_function_inliner.dl
+++ b/clientlib/tac-transformers/abstract_function_inliner.dl
@@ -85,16 +85,23 @@
     In_IsFunction(fun),
     1 = count: Function_Exit(fun, _).
 
+  // FunctionReturnRestriction(fun):-
+  //   In_IsFunction(fun),
+  //   1 < count: Function_Exit(fun, _),
+  //   !In_FormalReturnArgs(fun, _, 0).
+
   FunctionReturnRestriction(fun):-
     In_IsFunction(fun),
     1 < count: Function_Exit(fun, _),
-    !In_FormalReturnArgs(fun, _, 0).
+    !FunctionMultiReturnRestriction(fun).
 
-   .decl FunctionMultiReturnRestriction(fun:Function)
+  .decl FunctionMultiReturnRestriction(fun:Function)
   FunctionMultiReturnRestriction(fun):-
     In_IsFunction(fun),
     1 < count: Function_Exit(fun, _),
-    In_FormalReturnArgs(fun, _, 0).
+    In_FormalReturnArgs(fun, var1, i),
+    In_FormalReturnArgs(fun, var2, i),
+    var1 != var2.
 
   /* We can safely inline functions with only one return
      and matching args and returns at every call-site(as described above) */

--- a/clientlib/tac-transformers/abstract_function_inliner.dl
+++ b/clientlib/tac-transformers/abstract_function_inliner.dl
@@ -15,7 +15,7 @@
 
   /* Will be overriden to specify which functions the specific inliner will want to inline 
      FunctionToInline will contain a subset of this */
-  .decl InlineCandidate(fun:Function) overridable
+  .decl InlineCandidate(fun: Function, reason: symbol) overridable
   
   /* Functions that will be inlined in this instatiation of the component */
   .decl FunctionToInline(fun:Function)
@@ -45,7 +45,7 @@
   .decl VariableToClone(var:Variable, fromFun:Function, callerBlock:Block, callerFun:Function, newVar:Variable)
   
   /* By default tries to inline all private functions */
-  InlineCandidate(fun):-
+  InlineCandidate(fun, "NoReason"):-
     In_IsFunction(fun),
     !IsPublicFunction(fun).
 
@@ -128,7 +128,7 @@
     !In_LocalBlockEdge(block, _).
 
   CGEToInlineCandidate(caller, callee):-
-    InlineCandidate(callee),
+    InlineCandidate(callee, _),
     SafelyInlinableFunction(callee),
     In_CallGraphEdge(callerBlock, callee),
     In_InFunction(callerBlock, caller).
@@ -136,7 +136,7 @@
   /* The functions that end up being inlined are the safely inlinable candidates
      that do not contain calls to other inline candidates */
   FunctionToInline(func):-
-    InlineCandidate(func),
+    InlineCandidate(func, _),
     SafelyInlinableFunction(func),
     In_IsFunction(func),
     !IsPublicFunction(func),


### PR DESCRIPTION
Refactor inliner to:
* allow the inlining of functions with more than one returns, helping with some storage patterns
* better heuristics, attempt to avoid inlining larger methods when it wouldn't benefit the analysis
* make the inliner easier to debug

Results:
------------------------------------------------------

#### solc08-over10k:
```
ANALYTIC: Analytics_NonModeledMSTORE
may24-08-clientsmaster-800 (common): 22374 (+5.27%)
may24-08-clientsinliner2-800 (common): 21254

ANALYTIC: Analytics_NonModeledMLOAD
may24-08-clientsmaster-800 (common): 13460 (+0.9374%)
may24-08-clientsinliner2-800 (common): 13335

ANALYTIC: Analytics_CallToSignature
may24-08-clientsmaster-800 (common): 4288
may24-08-clientsinliner2-800 (common): 4287 (-0.02332%)

ANALYTIC: Analytics_EventSignature
may24-08-clientsmaster-800 (common): 5795
may24-08-clientsinliner2-800 (common): 5795

ANALYTIC: Analytics_PublicFunctionArg
may24-08-clientsmaster-800 (common): 36576
may24-08-clientsinliner2-800 (common): 36418 (-0.432%)

ANALYTIC: Analytics_PublicFunctionArrayArg
may24-08-clientsmaster-800 (common): 2822
may24-08-clientsinliner2-800 (common): 2821 (-0.03544%)

ANALYTIC: Analytics_NonModeledSSTORE
may24-08-clientsmaster-800 (common): 390 (+239.1%)
may24-08-clientsinliner2-800 (common): 115

ANALYTIC: Analytics_NonModeledSLOAD
may24-08-clientsmaster-800 (common): 1348 (+200.9%)
may24-08-clientsinliner2-800 (common): 448

ANALYTIC: Analytics_GlobalVariable
may24-08-clientsmaster-800 (common): 14929
may24-08-clientsinliner2-800 (common): 14925 (-0.02679%)

ANALYTIC: client_time
may24-08-clientsmaster-800 (common): 53744.260494470596 (+3.189%)
may24-08-clientsinliner2-800 (common): 52083.51030373573

ANALYTIC: inline_time
may24-08-clientsmaster-800 (common): 2538.471233844757
may24-08-clientsinliner2-800 (common): 3012.8361172676086 (+18.69%)
```

#### viair-dec23
```
ANALYTIC: Analytics_NonModeledMSTORE
may24-ir-clientsmaster-800 (common): 56269 (+28.99%)
may24-ir-clientsinliner2-800 (common): 43623

ANALYTIC: Analytics_NonModeledMLOAD
may24-ir-clientsmaster-800 (common): 44468 (+9.465%)
may24-ir-clientsinliner2-800 (common): 40623

ANALYTIC: Analytics_CallToSignature
may24-ir-clientsmaster-800 (common): 4518
may24-ir-clientsinliner2-800 (common): 4518

ANALYTIC: Analytics_EventSignature
may24-ir-clientsmaster-800 (common): 4760
may24-ir-clientsinliner2-800 (common): 4759 (-0.02101%)

ANALYTIC: Analytics_PublicFunctionArg
may24-ir-clientsmaster-800 (common): 42854 (-0.01866%)
may24-ir-clientsinliner2-800 (common): 42862

ANALYTIC: Analytics_PublicFunctionArrayArg
may24-ir-clientsmaster-800 (common): 4143
may24-ir-clientsinliner2-800 (common): 4124 (-0.4586%)

ANALYTIC: Analytics_NonModeledSSTORE
may24-ir-clientsmaster-800 (common): 2224 (+17.8%)
may24-ir-clientsinliner2-800 (common): 1888

ANALYTIC: Analytics_NonModeledSLOAD
may24-ir-clientsmaster-800 (common): 3046 (+24.53%)
may24-ir-clientsinliner2-800 (common): 2446

ANALYTIC: Analytics_GlobalVariable
may24-ir-clientsmaster-800 (common): 5200
may24-ir-clientsinliner2-800 (common): 5175 (-0.4808%)

ANALYTIC: client_time
may24-ir-clientsmaster-800 (common): 52351.94763755798
may24-ir-clientsinliner2-800 (common): 55225.69925236702 (+5.489%)

ANALYTIC: inline_time
may24-ir-clientsmaster-800 (common): 2918.6505179405212
may24-ir-clientsinliner2-800 (common): 3836.98495554924 (+31.46%)
```