### PR TITLE
Smaller function inference changes #1

### DIFF
--- a/logic/debug.dl
+++ b/logic/debug.dl
@@ -77,6 +77,11 @@ IsFunctionCallReturnOrd(ord(ctx), caller, func, ord(retCtx), retBlock, retTarget
 MaybeFunctionCallReturnOrd(ord(ctx), caller, func, ord(retCtx), retBlock, retTarget):-
   MaybeFunctionCallReturn(ctx, caller, func, retCtx, retBlock, retTarget).
 
+.decl PossibleCallReturnOrd(callCtx: number, caller: Block, index: number, target: Block)
+DEBUG_OUTPUT(PossibleCallReturnOrd)
+PossibleCallReturnOrd(ord(callCtx), caller, minIndex, retTarget):-
+  PossibleCallReturn(callCtx, caller, minIndex, retTarget).
+
 .decl PossibleReturnAddressWithRankOrd(callCtx:number, targetSetter:Block, retCtx:number, retBlock:Block, retTarget:Block, rank:number)
 .output PossibleReturnAddressWithRankOrd
 PossibleReturnAddressWithRankOrd(ord(callCtx), targetSetter, ord(retCtx), retBlock, retTarget, rank):-

--- a/logic/functions.dl
+++ b/logic/functions.dl
@@ -62,12 +62,13 @@ ContextCanReachFromCallerToReturn_Intermediate(callCtx, caller, ctxTo, toBlock, 
 ContextCanReachFromCallerToReturn_Intermediate(ctxFrom, caller, ctxTo, toBlock, retBlock, retTarget) :-
   ContextCanReachFromCallerToReturn_Intermediate(ctxFrom, caller, ctxOther, otherBlock, retBlock, retTarget),
   global.BlockEdge(ctxOther, otherBlock, ctxTo, toBlock),
+  // retBlock != otherBlock.
   retBlock != otherBlock, toBlock != retTarget.
 
-// ContextCanReachFromCallerToReturn_Intermediate(ctxFrom, caller, ctxTo, toBlock, retBlock, retTarget) :-
-//   ContextCanReachFromCallerToReturn_Intermediate(ctxFrom, caller, ctxOther, retBlock, retBlock, retTarget),
-//   global.BlockEdge(ctxOther, retBlock, ctxTo, toBlock),
-//   toBlock != retTarget.
+ContextCanReachFromCallerToReturn_Intermediate(ctxFrom, caller, ctxTo, toBlock, retBlock, retTarget) :-
+  ContextCanReachFromCallerToReturn_Intermediate(ctxFrom, caller, ctxOther, retBlock, retBlock, retTarget),
+  global.BlockEdge(ctxOther, retBlock, ctxTo, toBlock),
+  toBlock != retTarget.
 
 
 

--- a/logic/functions.dl
+++ b/logic/functions.dl
@@ -198,6 +198,7 @@ MaybeFunctionCallReturn(ctx, caller, func, retCtx, retBlock, retTarget) :-
   global.BlockJumpValidTarget(ctx, caller, targetVar, func),
   ContextCanReachFromCallerToReturn(ctx, caller, retCtx, retBlock, retTarget),
   global.BlockJumpValidTarget(retCtx, retBlock, _, retTarget).
+  // PossibleCallReturn(ctx, caller, _, retTarget).
  .plan 1:(6,1,2,3,4,5,7)
 
 /**
@@ -222,6 +223,7 @@ PossibleReturnAddressWithPositiveRank(callCtx, caller, retCtx, retBlock, retTarg
 .decl MaybeFunctionCallReturnNewContext(ctx:global.sens.Context, caller:Block, retTargetCtx:global.sens.Context, retTarget:Block)
 MaybeFunctionCallReturnNewContext(ctx, caller, retTargetCtx, retTarget) :-
   MaybeFunctionCallReturn(ctx, caller, _, retCtx, ret, retTarget),
+  !postTrans.NormalizedConditionalCallPattern(retTarget, _, _),
   global.BlockEdge(retCtx, ret, retTargetCtx, retTarget).
 
 /**
@@ -243,13 +245,88 @@ PossibleReturnAddressWithRank(newCallCtx, caller, retCtx, retBlock, retTarget, n
   n + maxrank < RETURN_ADDRESS_RANK_THRESHOLD.
  .plan 1:(2,3,1,4)
 
+.decl PossibleCallReturnOrd(callCtx: number, caller: Block, index: number, target: Block)
+DEBUG_OUTPUT(PossibleCallReturnOrd)
+PossibleCallReturnOrd(ord(callCtx), caller, minIndex, retTarget):-
+  PossibleCallReturn(callCtx, caller, minIndex, retTarget).
+.decl PossibleCallReturn(callCtx: global.sens.Context, caller: Block, index: number, target: Block)
+DEBUG_OUTPUT(PossibleCallReturn)
+
+PossibleCallReturn(callCtx, caller, minIndex, as(retTarget, Block)):-
+  (global.PrivateFunctionCall(_, _, caller, _); global.PrivateFunctionCall(caller, _, _, _)),
+  global.ReachableContext(callCtx, caller),
+  minIndex = min outIndex: global.AuxBlockOutputContentsJumpTarget(callCtx, caller, outIndex, _),
+  global.BlockOutputContents(callCtx, caller, minIndex, retBlockVar),
+  global.Variable_Value(retBlockVar, retTarget).
+
+// .decl Match(newCallCtx: number, caller: Block, retTarget: Block, prevRank: number, inIndex: number, outIndex: number)
+// .output Match
+
+// Match(ord(newCallCtx), caller, retTarget, n, inIndex, outIndex):-
+//   PossibleReturnAddressWithPositiveRank(prevCallCtx, targetSetter, retCtx, retBlock, retTarget, n),
+//   MaybeFunctionCallReturnNewContext(prevCallCtx, targetSetter, newCallCtx, caller),
+//   OptBlockImmediateJump(newCallCtx, caller),
+//   global.BlockInputContents(newCallCtx, caller, inIndex, retBlockVar),
+//   global.Variable_Value(retBlockVar, as(retTarget, Value)),
+//   global.BlockOutputContents(newCallCtx, caller, outIndex, retBlockVar),
+//   postTrans.BlockStackDelta(caller, stackDelta),
+//   inIndex + stackDelta != outIndex,
+//   !PossibleReturnAddressWithPos(caller, _, _, _, _).
+
+
 // Case where the caller doesn't push new return targets to the stack
-PossibleReturnAddressWithRank(newCallCtx, caller, retCtx, retBlock, retTarget, n-1) :-
+PossibleReturnAddressWithRank(newCallCtx, caller, retCtx, retBlock, retTarget, 0) :-
+  PossibleReturnAddressWithPositiveRank(prevCallCtx, targetSetter, retCtx, retBlock, retTarget, _),
+  MaybeFunctionCallReturnNewContext(prevCallCtx, targetSetter, newCallCtx, caller),
+  OptBlockImmediateJump(newCallCtx, caller),
+  // global.BlockInputContents(newCallCtx, caller, inIndex, retBlockVar),
+  // global.Variable_Value(retBlockVar, as(retTarget, Value)),
+  PossibleCallReturn(newCallCtx, caller, _, retTarget),
+  !PossibleReturnAddressWithPos(caller, _, _, _, _).
+ .plan 1:(2,3,1,4)
+
+// Case where the caller doesn't push new return targets to the stack
+PossibleReturnAddressWithRank(newCallCtx, caller, retCtx, retBlock, retTarget, n) :-
   PossibleReturnAddressWithPositiveRank(prevCallCtx, targetSetter, retCtx, retBlock, retTarget, n),
   MaybeFunctionCallReturnNewContext(prevCallCtx, targetSetter, newCallCtx, caller),
   OptBlockImmediateJump(newCallCtx, caller),
+  // global.BlockInputContents(newCallCtx, caller, inIndex, retBlockVar),
+  // global.Variable_Value(retBlockVar, as(retTarget, Value)),
+  PossibleCallReturn(newCallCtx, caller, minIndex, actualReturnTarget), // minIndex != inIndex,
+  actualReturnTarget != retTarget,
   !PossibleReturnAddressWithPos(caller, _, _, _, _).
- .plan 1:(2,3,1)
+ .plan 1:(2,3,1,4)
+
+// .decl DEBUGReturn(prevCaller: Block, intermCaller: Block, caller: Block, retTarget: Block)
+// .output DEBUGReturn
+// DEBUGReturn(targetSetter, intermCaller, caller, retTarget),
+// PossibleReturnAddressWithRank(newCallCtx, caller, retCtx, retBlock, retTarget, n-2) :-
+//   PossibleReturnAddressWithRank(prevCallCtx, targetSetter, _, _, intermCaller, 0),
+//   PossibleReturnAddressWithRank(prevCallCtx, targetSetter, _, _, caller, 1),
+//   PossibleReturnAddressWithPositiveRank(prevCallCtx, targetSetter, retCtx, retBlock, retTarget, n),
+//   MaybeFunctionCallReturnNewContext(prevCallCtx, targetSetter, intermCallCtx, intermCaller),
+//   postTrans.PrivateFunctionReturn(intermCaller),
+//   global.BlockEdge(intermCallCtx, intermCaller, newCallCtx, caller), n > 1,
+//   postTrans.BasicBlock_Tail(caller, jump),
+//   postTrans.Statement_Opcode(jump, "JUMP"),
+//   !PossibleReturnAddressWithPos(caller, _, _, _, _),
+//   !PossibleReturnAddressWithPos(intermCaller, _, _, _, _).
+//   .plan 1:(2,1,5,4,3,6,7,8), 2:(3,2,1,4,5,6,7,8), 3:(4,3,2,1,5,6,7,8)
+
+// PossibleReturnAddressWithRank(newCallCtx, caller, retCtx, retBlock, retTarget, n - 1 + maxrank) :-
+//   PossibleReturnAddressWithRank(prevCallCtx, targetSetter, _, _, intermCaller, 0),
+//   PossibleReturnAddressWithRank(prevCallCtx, targetSetter, _, _, caller, 1),
+//   PossibleReturnAddressWithPositiveRank(prevCallCtx, targetSetter, retCtx, retBlock, retTarget, n),
+//   MaybeFunctionCallReturnNewContext(prevCallCtx, targetSetter, intermCallCtx, intermCaller),
+//   postTrans.PrivateFunctionReturn(intermCaller),
+//   global.BlockEdge(intermCallCtx, intermCaller, newCallCtx, caller), n > 1,
+//   postTrans.BasicBlock_Tail(caller, jump),
+//   postTrans.Statement_Opcode(jump, "JUMP"),
+//   MaxRankForPossibleReturnAddressSetter(caller, maxrank),
+//   !PossibleReturnAddressWithPos(intermCaller, _, _, _, _).
+//   .plan 1:(2,1,5,4,3,6,7,8,9), 2:(3,2,1,4,5,6,7,8,9), 3:(4,3,2,1,5,6,7,8,9)
+
+//  .plan 1:(2,3,4,1)
 
 /**
   Seems pretty certain we found a return. In fact, at this point,

--- a/logic/functions.dl
+++ b/logic/functions.dl
@@ -223,7 +223,8 @@ PossibleReturnAddressWithPositiveRank(callCtx, caller, retCtx, retBlock, retTarg
 .decl MaybeFunctionCallReturnNewContext(ctx:global.sens.Context, caller:Block, retTargetCtx:global.sens.Context, retTarget:Block)
 MaybeFunctionCallReturnNewContext(ctx, caller, retTargetCtx, retTarget) :-
   MaybeFunctionCallReturn(ctx, caller, _, retCtx, ret, retTarget),
-  !postTrans.NormalizedConditionalCallPattern(retTarget, _, _),
+  // Commented out for now, from branch logic to reintroduce in branch
+  // !postTrans.NormalizedConditionalCallPattern(retTarget, _, _),
   global.BlockEdge(retCtx, ret, retTargetCtx, retTarget).
 
 /**

--- a/logic/functions.dl
+++ b/logic/functions.dl
@@ -62,12 +62,12 @@ ContextCanReachFromCallerToReturn_Intermediate(callCtx, caller, ctxTo, toBlock, 
 ContextCanReachFromCallerToReturn_Intermediate(ctxFrom, caller, ctxTo, toBlock, retBlock, retTarget) :-
   ContextCanReachFromCallerToReturn_Intermediate(ctxFrom, caller, ctxOther, otherBlock, retBlock, retTarget),
   global.BlockEdge(ctxOther, otherBlock, ctxTo, toBlock),
-  retBlock != otherBlock.
+  retBlock != otherBlock, toBlock != retTarget.
 
-ContextCanReachFromCallerToReturn_Intermediate(ctxFrom, caller, ctxTo, toBlock, retBlock, retTarget) :-
-  ContextCanReachFromCallerToReturn_Intermediate(ctxFrom, caller, ctxOther, retBlock, retBlock, retTarget),
-  global.BlockEdge(ctxOther, retBlock, ctxTo, toBlock),
-  toBlock != retTarget.
+// ContextCanReachFromCallerToReturn_Intermediate(ctxFrom, caller, ctxTo, toBlock, retBlock, retTarget) :-
+//   ContextCanReachFromCallerToReturn_Intermediate(ctxFrom, caller, ctxOther, retBlock, retBlock, retTarget),
+//   global.BlockEdge(ctxOther, retBlock, ctxTo, toBlock),
+//   toBlock != retTarget.
 
 
 
@@ -128,7 +128,7 @@ PossibleReturnAddressWithPos(targetSetter, retCtx, retBlock, retTarget, pos) :-
   We try to filter this out and will need to handle it separately.
 */
 PossibleReturnAddressWithPos(as(next, Block), retCtx, retBlock, retTarget, pos) :-
-  OptNotImmediateBlockJumpTarget(retCtx, retBlock, targetVariable, retTarget),
+  OptNotImmediateBlockJumpTarget(retCtx, retBlock, targetVariable, retTarget), // SL: Source of imprecision, can inlude blocks that do not pass through caller
   postTrans.Statement_Defines(targetSetStatement, targetVariable),
   postTrans.Statement_Block(targetSetStatement, targetSetter),
   postTrans.BasicBlock_Tail(targetSetter, jumpiStmt),

--- a/logic/functions.dl
+++ b/logic/functions.dl
@@ -301,18 +301,18 @@ PossibleReturnAddressWithRank(newCallCtx, caller, retCtx, retBlock, retTarget, n
 // .decl DEBUGReturn(prevCaller: Block, intermCaller: Block, caller: Block, retTarget: Block)
 // .output DEBUGReturn
 // DEBUGReturn(targetSetter, intermCaller, caller, retTarget),
-// PossibleReturnAddressWithRank(newCallCtx, caller, retCtx, retBlock, retTarget, n-2) :-
-//   PossibleReturnAddressWithRank(prevCallCtx, targetSetter, _, _, intermCaller, 0),
-//   PossibleReturnAddressWithRank(prevCallCtx, targetSetter, _, _, caller, 1),
-//   PossibleReturnAddressWithPositiveRank(prevCallCtx, targetSetter, retCtx, retBlock, retTarget, n),
-//   MaybeFunctionCallReturnNewContext(prevCallCtx, targetSetter, intermCallCtx, intermCaller),
-//   postTrans.PrivateFunctionReturn(intermCaller),
-//   global.BlockEdge(intermCallCtx, intermCaller, newCallCtx, caller), n > 1,
-//   postTrans.BasicBlock_Tail(caller, jump),
-//   postTrans.Statement_Opcode(jump, "JUMP"),
-//   !PossibleReturnAddressWithPos(caller, _, _, _, _),
-//   !PossibleReturnAddressWithPos(intermCaller, _, _, _, _).
-//   .plan 1:(2,1,5,4,3,6,7,8), 2:(3,2,1,4,5,6,7,8), 3:(4,3,2,1,5,6,7,8)
+PossibleReturnAddressWithRank(newCallCtx, caller, retCtx, retBlock, retTarget, n-2) :-
+  PossibleReturnAddressWithRank(prevCallCtx, targetSetter, _, _, intermCaller, 0),
+  PossibleReturnAddressWithRank(prevCallCtx, targetSetter, _, _, caller, 1),
+  PossibleReturnAddressWithPositiveRank(prevCallCtx, targetSetter, retCtx, retBlock, retTarget, n),
+  MaybeFunctionCallReturnNewContext(prevCallCtx, targetSetter, intermCallCtx, intermCaller),
+  postTrans.PrivateFunctionReturn(intermCaller),
+  global.BlockEdge(intermCallCtx, intermCaller, newCallCtx, caller), n > 1,
+  postTrans.BasicBlock_Tail(caller, jump),
+  postTrans.Statement_Opcode(jump, "JUMP"),
+  !PossibleReturnAddressWithPos(caller, _, _, _, _),
+  !PossibleReturnAddressWithPos(intermCaller, _, _, _, _).
+  .plan 1:(2,1,5,4,3,6,7,8), 2:(3,2,1,4,5,6,7,8), 3:(4,3,2,1,5,6,7,8)
 
 // PossibleReturnAddressWithRank(newCallCtx, caller, retCtx, retBlock, retTarget, n - 1 + maxrank) :-
 //   PossibleReturnAddressWithRank(prevCallCtx, targetSetter, _, _, intermCaller, 0),

--- a/logic/functions.dl
+++ b/logic/functions.dl
@@ -247,10 +247,9 @@ PossibleReturnAddressWithRank(newCallCtx, caller, retCtx, retBlock, retTarget, n
   n + maxrank < RETURN_ADDRESS_RANK_THRESHOLD.
  .plan 1:(2,3,1,4)
 
-.decl PossibleCallReturnOrd(callCtx: number, caller: Block, index: number, target: Block)
-DEBUG_OUTPUT(PossibleCallReturnOrd)
-PossibleCallReturnOrd(ord(callCtx), caller, minIndex, retTarget):-
-  PossibleCallReturn(callCtx, caller, minIndex, retTarget).
+/**
+  Possible call made by `caller` under a `callCtx` will probably return to the `target` block residing in stack`index`
+*/
 .decl PossibleCallReturn(callCtx: global.sens.Context, caller: Block, index: number, target: Block)
 DEBUG_OUTPUT(PossibleCallReturn)
 
@@ -261,28 +260,11 @@ PossibleCallReturn(callCtx, caller, minIndex, as(retTarget, Block)):-
   global.BlockOutputContents(callCtx, caller, minIndex, retBlockVar),
   global.Variable_Value(retBlockVar, retTarget).
 
-// .decl Match(newCallCtx: number, caller: Block, retTarget: Block, prevRank: number, inIndex: number, outIndex: number)
-// .output Match
-
-// Match(ord(newCallCtx), caller, retTarget, n, inIndex, outIndex):-
-//   PossibleReturnAddressWithPositiveRank(prevCallCtx, targetSetter, retCtx, retBlock, retTarget, n),
-//   MaybeFunctionCallReturnNewContext(prevCallCtx, targetSetter, newCallCtx, caller),
-//   OptBlockImmediateJump(newCallCtx, caller),
-//   global.BlockInputContents(newCallCtx, caller, inIndex, retBlockVar),
-//   global.Variable_Value(retBlockVar, as(retTarget, Value)),
-//   global.BlockOutputContents(newCallCtx, caller, outIndex, retBlockVar),
-//   postTrans.BlockStackDelta(caller, stackDelta),
-//   inIndex + stackDelta != outIndex,
-//   !PossibleReturnAddressWithPos(caller, _, _, _, _).
-
-
 // Case where the caller doesn't push new return targets to the stack
 PossibleReturnAddressWithRank(newCallCtx, caller, retCtx, retBlock, retTarget, 0) :-
   PossibleReturnAddressWithPositiveRank(prevCallCtx, targetSetter, retCtx, retBlock, retTarget, _),
   MaybeFunctionCallReturnNewContext(prevCallCtx, targetSetter, newCallCtx, caller),
   OptBlockImmediateJump(newCallCtx, caller),
-  // global.BlockInputContents(newCallCtx, caller, inIndex, retBlockVar),
-  // global.Variable_Value(retBlockVar, as(retTarget, Value)),
   PossibleCallReturn(newCallCtx, caller, _, retTarget),
   !PossibleReturnAddressWithPos(caller, _, _, _, _).
  .plan 1:(2,3,1,4)
@@ -292,16 +274,12 @@ PossibleReturnAddressWithRank(newCallCtx, caller, retCtx, retBlock, retTarget, n
   PossibleReturnAddressWithPositiveRank(prevCallCtx, targetSetter, retCtx, retBlock, retTarget, n),
   MaybeFunctionCallReturnNewContext(prevCallCtx, targetSetter, newCallCtx, caller),
   OptBlockImmediateJump(newCallCtx, caller),
-  // global.BlockInputContents(newCallCtx, caller, inIndex, retBlockVar),
-  // global.Variable_Value(retBlockVar, as(retTarget, Value)),
   PossibleCallReturn(newCallCtx, caller, minIndex, actualReturnTarget), // minIndex != inIndex,
   actualReturnTarget != retTarget,
   !PossibleReturnAddressWithPos(caller, _, _, _, _).
  .plan 1:(2,3,1,4)
 
-// .decl DEBUGReturn(prevCaller: Block, intermCaller: Block, caller: Block, retTarget: Block)
-// .output DEBUGReturn
-// DEBUGReturn(targetSetter, intermCaller, caller, retTarget),
+
 PossibleReturnAddressWithRank(newCallCtx, caller, retCtx, retBlock, retTarget, n-2) :-
   PossibleReturnAddressWithRank(prevCallCtx, targetSetter, _, _, intermCaller, 0),
   PossibleReturnAddressWithRank(prevCallCtx, targetSetter, _, _, caller, 1),

--- a/logic/functions.dl
+++ b/logic/functions.dl
@@ -255,7 +255,7 @@ DEBUG_OUTPUT(PossibleCallReturn)
 PossibleCallReturn(callCtx, caller, minIndex, as(retTarget, Block)):-
   (global.PrivateFunctionCall(_, _, caller, _); global.PrivateFunctionCall(caller, _, _, _)),
   global.ReachableContext(callCtx, caller),
-  minIndex = min outIndex: global.AuxBlockOutputContentsJumpTarget(callCtx, caller, outIndex, _),
+  minIndex = min outIndex: global.BlockOutputContentsJumpTarget(callCtx, caller, outIndex, _),
   global.BlockOutputContents(callCtx, caller, minIndex, retBlockVar),
   global.Variable_Value(retBlockVar, retTarget).
 

--- a/logic/global_components.dl
+++ b/logic/global_components.dl
@@ -339,6 +339,10 @@
   VariableToModel(var):-
     VariableContainsJumpTarget(var); FunctionSelectorVariable(var).
 
+  .decl BlockOutputContentsJumpTarget(context:sens.Context, block:Block, index:StackIndex, var:Variable)
+  BlockOutputContentsJumpTarget(context, block, index, var):-
+    AuxBlockOutputContentsJumpTarget(context, block, index, var),
+    VariableUsedInAsJumpdest(var).
 
   /**
     Cut down `BlockOutputContents`, only containing jump targets (and the function selector var).


### PR DESCRIPTION
Starting effort to dissect my `function_inference_improvement` branch, cherry picking and merging its different changes independently.

This first PR includes a couple of changes:
1. Change the way `PossibleReturnAddressWithRank` is propagated. Instead of taking the order as constant and decreasing their ranks at each function call, consider the target with the smallest index as the return target. This helps the precision of the function inference.
2. Change `ContextCanReachFromCallerToReturn_Intermediate` to never go over the `retTarget`. This helps scalability and tac-level precision.

Results
===========================

ir:
```
For has_output 19 not detected by config jul24-ir-master: {'0361a64b32ba953a7f045ccbbb6b8337', '7ff4dc044e6a41d1a68d212b46468f75', 'e51461a7a0767277d55f076cb5ebc335', '3ccd17c1d76974fb4d1c52f412f3a95b', '9d9c9c168e478f48c71ca3c3933b8e0b', 'def9577f5115e9d0f32d05c3e39312d9', '9c953e4b9140d7c4403809987bc49aab', '8b4e97264becf7811671895fa7041523', '3fcc5e1ab504ca21fa316118749b357f', 'd92c3acc0ac19b7fbebeecf2d0d2c3b6', '78bb72fb85c9788a916115e02e433a61', 'af969cce912cbb902f321ffe1459137f', '2568577d3c49c6ec16605d8d116b7a94', 'aec09b4ec157f668875e4588d697d3bf', '7a8d73256e70fd00596ff4683f0da36d', 'a5060a4ac14117b306ce60aa80c7dee7', '5430c0fe36e3995d839616ee506f8d38', '86f3a61ddbbf21f3345d576087b73f13', '25de9c7e9ef8639f4e863bd5d290f427'}
For has_output 1 not detected by config jul24-ir-propag2: {'ecfdc6baa3ffa39d143086a1a89afe30'}

ANALYTIC: decomp_time
jul24-ir-master (common): 26556.478464126587 (+9.301%)
jul24-ir-propag2 (common): 24296.625276088715

ANALYTIC: Analytics_JumpToMany
jul24-ir-master (common): 4724 (+16.01%)
jul24-ir-propag2 (common): 4072

ANALYTIC: Analytics_ReachableBlocksInTAC
jul24-ir-master (common): 1282064 (-0.09554%)
jul24-ir-propag2 (common): 1283290

ANALYTIC: Analytics_BlockHasNoTACBlock
jul24-ir-master (common): 1451 (+544.9%)
jul24-ir-propag2 (common): 225

ANALYTIC: Analytics_DeadBlocks
jul24-ir-master (common): 10956 (+1523%)
jul24-ir-propag2 (common): 675

ANALYTIC: Analytics_MissingEdgeInTAC
jul24-ir-master (common): 375
jul24-ir-propag2 (common): 25 (-93.33%)

ANALYTIC: Analytics_StmtMissingOperand
jul24-ir-master (common): 511 (+54.85%)
jul24-ir-propag2 (common): 330

ANALYTIC: Analytics_PrivateFunctionMatchesMetadata
jul24-ir-master (common): 83434 (-0.8909%)
jul24-ir-propag2 (common): 84184

ANALYTIC: Analytics_PrivateFunctionMatchesMetadataIncorrectArgs
jul24-ir-master (common): 2096 (+21.09%)
jul24-ir-propag2 (common): 1731

ANALYTIC: Analytics_PrivateFunctionMatchesMetadataIncorrectReturnArgs
jul24-ir-master (common): 1507 (+18.38%)
jul24-ir-propag2 (common): 1273
```

08:
```
For has_output 1 not detected by config jul24-08-master: {'0413ddf6c3cf0d353c656fb5daf3fb25'}
For has_output 0 not detected by config jul24-08-propag2: set()

ANALYTIC: decomp_time
jul24-08-master (common): 16643.774605989456 (+0.5245%)
jul24-08-propag2 (common): 16556.926507234573

ANALYTIC: Analytics_JumpToMany
jul24-08-master (common): 192 (+8.475%)
jul24-08-propag2 (common): 177

ANALYTIC: Analytics_BlockHasNoTACBlock
jul24-08-master (common): 5 (+150%)
jul24-08-propag2 (common): 2

ANALYTIC: Analytics_DeadBlocks
jul24-08-master (common): 198 (+40.43%)
jul24-08-propag2 (common): 141

ANALYTIC: Analytics_LocalBlockEdge
jul24-08-master (common): 1779406 (-0.02124%)
jul24-08-propag2 (common): 1779784

ANALYTIC: Analytics_MissingEdgeInTAC
jul24-08-master (common): 79
jul24-08-propag2 (common): 69 (-12.66%)

ANALYTIC: Analytics_StmtMissingOperand
jul24-08-master (common): 39 (+62.5%)
jul24-08-propag2 (common): 24
```