### PR TITLE
 Smaller function inference changes #2

### DIFF
--- a/logic/functions.dl
+++ b/logic/functions.dl
@@ -274,13 +274,27 @@ PossibleReturnAddressWithRank(newCallCtx, caller, retCtx, retBlock, retTarget, n
   PossibleReturnAddressWithPositiveRank(prevCallCtx, targetSetter, retCtx, retBlock, retTarget, n),
   MaybeFunctionCallReturnNewContext(prevCallCtx, targetSetter, newCallCtx, caller),
   OptBlockImmediateJump(newCallCtx, caller),
-  PossibleCallReturn(newCallCtx, caller, minIndex, actualReturnTarget), // minIndex != inIndex,
+  PossibleCallReturn(newCallCtx, caller, _, actualReturnTarget), // minIndex != inIndex,
   actualReturnTarget != retTarget,
   !PossibleReturnAddressWithPos(caller, _, _, _, _).
  .plan 1:(2,3,1,4)
 
 
-PossibleReturnAddressWithRank(newCallCtx, caller, retCtx, retBlock, retTarget, n-2) :-
+PossibleReturnAddressWithRank(newCallCtx, caller, retCtx, retBlock, actualReturnTarget, 0) :-
+  PossibleReturnAddressWithRank(prevCallCtx, targetSetter, _, _, intermCaller, 0),
+  PossibleReturnAddressWithRank(prevCallCtx, targetSetter, _, _, caller, 1),
+  PossibleReturnAddressWithPositiveRank(prevCallCtx, targetSetter, retCtx, retBlock, actualReturnTarget, n),
+  MaybeFunctionCallReturnNewContext(prevCallCtx, targetSetter, intermCallCtx, intermCaller),
+  postTrans.PrivateFunctionReturn(intermCaller),
+  global.BlockEdge(intermCallCtx, intermCaller, newCallCtx, caller), n > 1,
+  postTrans.BasicBlock_Tail(caller, jump),
+  postTrans.Statement_Opcode(jump, "JUMP"),
+  PossibleCallReturn(newCallCtx, caller, _, actualReturnTarget),
+  !PossibleReturnAddressWithPos(caller, _, _, _, _),
+  !PossibleReturnAddressWithPos(intermCaller, _, _, _, _).
+  .plan 1:(2,1,5,4,3,6,7,8,9), 2:(3,2,1,4,5,6,7,8,9), 3:(4,3,2,1,5,6,7,8,9)
+
+PossibleReturnAddressWithRank(newCallCtx, caller, retCtx, retBlock, retTarget, n) :-
   PossibleReturnAddressWithRank(prevCallCtx, targetSetter, _, _, intermCaller, 0),
   PossibleReturnAddressWithRank(prevCallCtx, targetSetter, _, _, caller, 1),
   PossibleReturnAddressWithPositiveRank(prevCallCtx, targetSetter, retCtx, retBlock, retTarget, n),
@@ -289,9 +303,10 @@ PossibleReturnAddressWithRank(newCallCtx, caller, retCtx, retBlock, retTarget, n
   global.BlockEdge(intermCallCtx, intermCaller, newCallCtx, caller), n > 1,
   postTrans.BasicBlock_Tail(caller, jump),
   postTrans.Statement_Opcode(jump, "JUMP"),
+  PossibleCallReturn(newCallCtx, caller, _, actualReturnTarget), actualReturnTarget != retTarget,
   !PossibleReturnAddressWithPos(caller, _, _, _, _),
   !PossibleReturnAddressWithPos(intermCaller, _, _, _, _).
-  .plan 1:(2,1,5,4,3,6,7,8), 2:(3,2,1,4,5,6,7,8), 3:(4,3,2,1,5,6,7,8)
+  .plan 1:(2,1,5,4,3,6,7,8,9), 2:(3,2,1,4,5,6,7,8,9), 3:(4,3,2,1,5,6,7,8,9)
 
 // PossibleReturnAddressWithRank(newCallCtx, caller, retCtx, retBlock, retTarget, n - 1 + maxrank) :-
 //   PossibleReturnAddressWithRank(prevCallCtx, targetSetter, _, _, intermCaller, 0),


### PR DESCRIPTION
Improve propagation of `PossibleReturnAddressWithRank` when continuation is a nonImmediateJump. It uses `PossibleCallReturn` now.

Result difference was minor but seemed more right.
ir:
```
ANALYTIC: decomp_time
jul24-ir-propag2 (common): 25581.549938201904
jul24-ir-propag3 (common): 25701.03565144539 (+0.4671%)

ANALYTIC: Analytics_JumpToMany
jul24-ir-propag2 (common): 4258 (+0.4245%)
jul24-ir-propag3 (common): 4240

ANALYTIC: Analytics_BlockHasNoTACBlock
jul24-ir-propag2 (common): 237 (+22.16%)
jul24-ir-propag3 (common): 194

ANALYTIC: Analytics_DeadBlocks
jul24-ir-propag2 (common): 710 (+11.29%)
jul24-ir-propag3 (common): 638

ANALYTIC: Analytics_StmtMissingOperand
jul24-ir-propag2 (common): 338
jul24-ir-propag3 (common): 340 (+0.5917%)

ANALYTIC: Analytics_PrivateFunctionMatchesMetadata
jul24-ir-propag2 (common): 85527 (-0.02104%)
jul24-ir-propag3 (common): 85545

ANALYTIC: Analytics_PrivateFunctionMatchesMetadataIncorrectArgs
jul24-ir-propag2 (common): 1814 (+0.2764%)
jul24-ir-propag3 (common): 1809

ANALYTIC: Analytics_PrivateFunctionMatchesMetadataIncorrectReturnArgs
jul24-ir-propag2 (common): 1298 (+0.9331%)
jul24-ir-propag3 (common): 1286
```
metadata:
```
ANALYTIC: decomp_time
jul24-meta-propag2 (common): 13263.557058095932
jul24-meta-propag3 (common): 13275.906133890152 (+0.09311%)

ANALYTIC: Analytics_PrivateFunctionMatchesMetadata
jul24-meta-propag2 (common): 105085
jul24-meta-propag3 (common): 105083 (-0.001903%)

ANALYTIC: Analytics_PrivateFunctionMatchesMetadataIncorrectArgs
jul24-meta-propag2 (common): 221
jul24-meta-propag3 (common): 222 (+0.4525%)

ANALYTIC: Analytics_PrivateFunctionMatchesMetadataIncorrectReturnArgs
jul24-meta-propag2 (common): 560
jul24-meta-propag3 (common): 561
```

Noting a smaller regression `0f711f0c92017007bcfee13575b8a263`, although looking at it didn't give any insights.