### PR TITLE
Test workflows now make use of the new dependency images

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,33 +23,17 @@ jobs:
       checks: write
       pull-requests: write
 
+    container:
+      image: ghcr.io/nevillegrech/gigahorse-toolchain-deps-souffle23:latest
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.8
-
-      - name: Install pytest
-        run: |
-          python -m pip install --upgrade pip
-          pip install pytest
-
-      - name: Install Souffle
-        run: |
-          sudo wget https://souffle-lang.github.io/ppa/souffle-key.public -O /usr/share/keyrings/souffle-archive-keyring.gpg
-          echo "deb [signed-by=/usr/share/keyrings/souffle-archive-keyring.gpg] https://souffle-lang.github.io/ppa/ubuntu/ stable main" | sudo tee /etc/apt/sources.list.d/souffle.list
-          sudo apt update && sudo apt install souffle=2.3
-
       - name: Test Souffle
         run: souffle --version
-
-      - name: Install Boost
-        run: sudo apt install libboost-all-dev
 
       - name: Build Souffle addon
         run: cd $GITHUB_WORKSPACE/souffle-addon && make && cd $GITHUB_WORKSPACE
@@ -87,27 +71,8 @@ jobs:
         with:
           submodules: recursive
 
-      # - name: Setup Python
-      #   uses: actions/setup-python@v5
-      #   with:
-      #     python-version: 3.8
-
-      # - name: Install pytest
-      #   run: |
-      #     python -m pip install --upgrade pip
-      #     pip install pytest
-
-      # - name: Install Souffle
-      #   run: |
-      #     sudo wget https://souffle-lang.github.io/ppa/souffle-key.public -O /usr/share/keyrings/souffle-archive-keyring.gpg
-      #     echo "deb [signed-by=/usr/share/keyrings/souffle-archive-keyring.gpg] https://souffle-lang.github.io/ppa/ubuntu/ stable main" | sudo tee /etc/apt/sources.list.d/souffle.list
-      #     sudo apt update && sudo apt install souffle=2.4
-
       - name: Test Souffle
         run: souffle --version
-
-      # - name: Install Boost
-      #   run: sudo apt install libboost-all-dev
 
       - name: Build Souffle addon
         run: cd $GITHUB_WORKSPACE/souffle-addon && make && cd $GITHUB_WORKSPACE

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -78,27 +78,30 @@ jobs:
       checks: write
       pull-requests: write
 
+    container:
+      image: ghcr.io/nevillegrech/gigahorse-toolchain-deps-souffle24:latest
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.8
+      # - name: Setup Python
+      #   uses: actions/setup-python@v5
+      #   with:
+      #     python-version: 3.8
 
-      - name: Install pytest
-        run: |
-          python -m pip install --upgrade pip
-          pip install pytest
+      # - name: Install pytest
+      #   run: |
+      #     python -m pip install --upgrade pip
+      #     pip install pytest
 
-      - name: Install Souffle
-        run: |
-          sudo wget https://souffle-lang.github.io/ppa/souffle-key.public -O /usr/share/keyrings/souffle-archive-keyring.gpg
-          echo "deb [signed-by=/usr/share/keyrings/souffle-archive-keyring.gpg] https://souffle-lang.github.io/ppa/ubuntu/ stable main" | sudo tee /etc/apt/sources.list.d/souffle.list
-          sudo apt update && sudo apt install souffle=2.4
+      # - name: Install Souffle
+      #   run: |
+      #     sudo wget https://souffle-lang.github.io/ppa/souffle-key.public -O /usr/share/keyrings/souffle-archive-keyring.gpg
+      #     echo "deb [signed-by=/usr/share/keyrings/souffle-archive-keyring.gpg] https://souffle-lang.github.io/ppa/ubuntu/ stable main" | sudo tee /etc/apt/sources.list.d/souffle.list
+      #     sudo apt update && sudo apt install souffle=2.4
 
       - name: Test Souffle
         run: souffle --version

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -106,8 +106,8 @@ jobs:
       - name: Test Souffle
         run: souffle --version
 
-      - name: Install Boost
-        run: sudo apt install libboost-all-dev
+      # - name: Install Boost
+      #   run: sudo apt install libboost-all-dev
 
       - name: Build Souffle addon
         run: cd $GITHUB_WORKSPACE/souffle-addon && make && cd $GITHUB_WORKSPACE


### PR DESCRIPTION
This also allows us to test using souffle2.4.1, closing #121.