### PR TITLE
Minor improvement in function inference

### DIFF
--- a/logic/functions.dl
+++ b/logic/functions.dl
@@ -282,31 +282,29 @@ PossibleReturnAddressWithRank(newCallCtx, caller, retCtx, retBlock, retTarget, n
 
 PossibleReturnAddressWithRank(newCallCtx, caller, retCtx, retBlock, actualReturnTarget, 0) :-
   PossibleReturnAddressWithRank(prevCallCtx, targetSetter, _, _, intermCaller, 0),
-  PossibleReturnAddressWithRank(prevCallCtx, targetSetter, _, _, caller, 1),
-  PossibleReturnAddressWithPositiveRank(prevCallCtx, targetSetter, retCtx, retBlock, actualReturnTarget, n),
+  PossibleReturnAddressWithPositiveRank(prevCallCtx, targetSetter, retCtx, retBlock, actualReturnTarget, _),
   MaybeFunctionCallReturnNewContext(prevCallCtx, targetSetter, intermCallCtx, intermCaller),
   postTrans.PrivateFunctionReturn(intermCaller),
-  global.BlockEdge(intermCallCtx, intermCaller, newCallCtx, caller), n > 1,
+  global.BlockEdge(intermCallCtx, intermCaller, newCallCtx, caller),
   postTrans.BasicBlock_Tail(caller, jump),
   postTrans.Statement_Opcode(jump, "JUMP"),
   PossibleCallReturn(newCallCtx, caller, _, actualReturnTarget),
   !PossibleReturnAddressWithPos(caller, _, _, _, _),
   !PossibleReturnAddressWithPos(intermCaller, _, _, _, _).
-  .plan 1:(2,1,5,4,3,6,7,8,9), 2:(3,2,1,4,5,6,7,8,9), 3:(4,3,2,1,5,6,7,8,9)
+  .plan 1:(2,1,3,4,5,6,7,8), 2:(3,2,1,4,5,6,7,8)
 
 PossibleReturnAddressWithRank(newCallCtx, caller, retCtx, retBlock, retTarget, n) :-
   PossibleReturnAddressWithRank(prevCallCtx, targetSetter, _, _, intermCaller, 0),
-  PossibleReturnAddressWithRank(prevCallCtx, targetSetter, _, _, caller, 1),
   PossibleReturnAddressWithPositiveRank(prevCallCtx, targetSetter, retCtx, retBlock, retTarget, n),
   MaybeFunctionCallReturnNewContext(prevCallCtx, targetSetter, intermCallCtx, intermCaller),
   postTrans.PrivateFunctionReturn(intermCaller),
-  global.BlockEdge(intermCallCtx, intermCaller, newCallCtx, caller), n > 1,
+  global.BlockEdge(intermCallCtx, intermCaller, newCallCtx, caller), caller != retTarget,
   postTrans.BasicBlock_Tail(caller, jump),
   postTrans.Statement_Opcode(jump, "JUMP"),
-  PossibleCallReturn(newCallCtx, caller, _, actualReturnTarget), actualReturnTarget != retTarget,
+  PossibleCallReturn(newCallCtx, caller, _, actualReturnTarget),  actualReturnTarget != retTarget,
   !PossibleReturnAddressWithPos(caller, _, _, _, _),
   !PossibleReturnAddressWithPos(intermCaller, _, _, _, _).
-  .plan 1:(2,1,5,4,3,6,7,8,9), 2:(3,2,1,4,5,6,7,8,9), 3:(4,3,2,1,5,6,7,8,9)
+  .plan 1:(2,1,3,4,5,6,7,8), 2:(3,2,1,4,5,6,7,8)
 
 // PossibleReturnAddressWithRank(newCallCtx, caller, retCtx, retBlock, retTarget, n - 1 + maxrank) :-
 //   PossibleReturnAddressWithRank(prevCallCtx, targetSetter, _, _, intermCaller, 0),


### PR DESCRIPTION
Improvement in the propagation of `PossibleReturnAddressWithRank` inferences when returning to a dynamic jump.

# Results

Main improvement is on ir contracts, slight one for legacy ones as well.

## viair-dec23

```
2932 contracts decompiled/analyzed by sep24-ir-master (1 exclusively)                                                                        
2933 contracts decompiled/analyzed by sep24-ir-decompfix (2 exclusively)

ANALYTIC: decomp_time
sep24-ir-master (common): 29043.741072654724 (+0.1355%)
sep24-ir-decompfix (common): 29004.45024394989

ANALYTIC: Analytics_JumpToMany
sep24-ir-master (common): 4518 (+5.536%)
sep24-ir-decompfix (common): 4281

ANALYTIC: Analytics_BlockHasNoTACBlock
sep24-ir-master (common): 206 (+0.9804%)
sep24-ir-decompfix (common): 204

ANALYTIC: Analytics_DeadBlocks
sep24-ir-master (common): 656 (+30.16%)
sep24-ir-decompfix (common): 504

ANALYTIC: Analytics_StmtMissingOperand
sep24-ir-master (common): 283 (+10.98%)
sep24-ir-decompfix (common): 255

ANALYTIC: Analytics_PrivateFunctionMatchesMetadata
sep24-ir-master (common): 89388 (-0.2288%)
sep24-ir-decompfix (common): 89593

ANALYTIC: Analytics_PrivateFunctionMatchesMetadataIncorrectArgs
sep24-ir-master (common): 1087 (+8.159%)
sep24-ir-decompfix (common): 1005

ANALYTIC: Analytics_PrivateFunctionMatchesMetadataIncorrectReturnArgs
sep24-ir-master (common): 510 (+7.143%)
sep24-ir-decompfix (common): 476
```

## metadata-dataset1

```
ANALYTIC: decomp_time
sep24-meta-master (common): 12505.91153550148 (+0.3848%)
sep24-meta-decompfix (common): 12457.97710776329

ANALYTIC: Analytics_JumpToMany
sep24-meta-master (common): 115 (+1.77%)
sep24-meta-decompfix (common): 113

ANALYTIC: Analytics_PrivateFunctionMatchesMetadata
sep24-meta-master (common): 105133 (-0.002853%)
sep24-meta-decompfix (common): 105136

ANALYTIC: Analytics_PrivateFunctionMatchesMetadataIncorrectArgs
sep24-meta-master (common): 159 (+1.274%)
sep24-meta-decompfix (common): 157

ANALYTIC: Analytics_PrivateFunctionMatchesMetadataIncorrectReturnArgs
sep24-meta-master (common): 507 (+0.396%)
sep24-meta-decompfix (common): 505
```