### PR TITLE
Unpack 2 new metadata fields added in our datasets.

### DIFF
--- a/src/exporter.py
+++ b/src/exporter.py
@@ -147,7 +147,6 @@ class InstructionTsvExporter(TsvExporter):
         self.immutable_references = process_immutable_refs(metadata.get('immutable_references', {})) if metadata is not None else []
         self.abi = metadata.get('abi', {})
         self.storage_layout = metadata.get('storage_layout', {})
-        print(self.storage_layout)
 
     def export(self):
         """

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -145,8 +145,8 @@ class EVMBlockExporter(FactExporter):
 
         self.function_debug_data = process_function_debug_data(metadata.get('function_debug_info', {})) if metadata is not None else []
         self.immutable_references = process_immutable_refs(metadata.get('immutable_references', {})) if metadata is not None else []
-        self.abi = metadata.get('abi', {})
-        self.storage_layout = metadata.get('storage_layout', {})
+        self.abi = metadata.get('abi', {}) if metadata is not None else {}
+        self.storage_layout = metadata.get('storage_layout', {}) if metadata is not None else {}
 
     def export(self):
         """

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -2,6 +2,7 @@
 
 import abc
 import csv
+import json
 import os
 import src.opcodes as opcodes
 import src.basicblock as basicblock
@@ -97,6 +98,10 @@ class TsvExporter(Exporter):
             writer = csv.writer(f, delimiter='\t', lineterminator='\n')
             writer.writerows(entries)
 
+    def generate_json(self, filename: str, entries: Any):
+        with open(self.get_out_file_path(filename), 'w') as f:
+            json.dump(entries, f)
+
 
 class InstructionTsvExporter(TsvExporter):
     """
@@ -140,6 +145,9 @@ class InstructionTsvExporter(TsvExporter):
 
         self.function_debug_data = process_function_debug_data(metadata.get('function_debug_info', {})) if metadata is not None else []
         self.immutable_references = process_immutable_refs(metadata.get('immutable_references', {})) if metadata is not None else []
+        self.abi = metadata.get('abi', {})
+        self.storage_layout = metadata.get('storage_layout', {})
+        print(self.storage_layout)
 
     def export(self):
         """
@@ -221,3 +229,5 @@ class InstructionTsvExporter(TsvExporter):
 
         self.generate('HighLevelFunctionInfo.facts', self.function_debug_data)
         self.generate('ImmutableLoads.facts', self.immutable_references)
+        self.generate_json('source-abi.json', self.abi)
+        self.generate_json('source-storage-layout.json', self.storage_layout)

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -86,7 +86,7 @@ class Exporter(abc.ABC):
         Exports the source object to an implementation-specific format.
         """
 
-class TsvExporter(Exporter):
+class FactExporter(Exporter):
     def __init__(self, output_dir: str):
         super().__init__(output_dir)
 
@@ -103,9 +103,9 @@ class TsvExporter(Exporter):
             json.dump(entries, f)
 
 
-class InstructionTsvExporter(TsvExporter):
+class EVMBlockExporter(FactExporter):
     """
-    Prints a textual representation of the given CFG to stdout.
+    Populates the decompiler's fact files (tsv and json) given the low-level evm blocks
 
     Args:
       blocks: low-level evm block representation to be output

--- a/src/runners.py
+++ b/src/runners.py
@@ -324,7 +324,7 @@ class DecompilerFactGenerator(AbstractFactGenerator):
 
         disassemble_start = time.time()
         blocks = blockparse.EVMBytecodeParser(bytecode).parse()
-        exporter.InstructionTsvExporter(work_dir, blocks, True, bytecode, metadata).export()
+        exporter.EVMBlockExporter(work_dir, blocks, True, bytecode, metadata).export()
 
         os.symlink(join(work_dir, 'bytecode.hex'), join(out_dir, 'bytecode.hex'))
 


### PR DESCRIPTION
Added handling of 2 new fields added in the `_metadata.json` files of our [datasets](https://github.com/sifislag/evm-bytecode-datasets/): `abi` and `storage_layout`.
Just unparsing them to individual files for now (during fact gen) in order to use them for evaluation of our pipeline in the future.