### PR TITLE
Fix inliner bug: Add missing facts in InVar_OutVar

### DIFF
--- a/clientlib/tac-transformers/abstract_function_inliner.dl
+++ b/clientlib/tac-transformers/abstract_function_inliner.dl
@@ -400,6 +400,9 @@
     stmtId = cat(cat(cat(cat(callerBlock, "S"), phiBlock), "_"), to_string(i)),
     defVar = cat(cat(cat(cat(actualRet, "V"), phiBlock), "_"), to_string(i)).
 
+  InVar_OutVar(actualRet, "", defVar):-
+    NewPHIInfo(_, _, actualRet, _, _, defVar, _).
+
   Out_Statement_Defines(outStmt, outVar, i),
   InVar_OutVar(inVar, callerBlock, outVar),
   VariableToClone(inVar, fromFun, callerBlock, callerFun, outVar):-


### PR DESCRIPTION
This resulted in missing variables, in some rare edge cases.