### PR TITLE
Refactor, change function selector synthetic sighash

### DIFF
--- a/logic/context-sensitivity/abstract_context.dl
+++ b/logic/context-sensitivity/abstract_context.dl
@@ -53,13 +53,13 @@
 
   MaxContextDepth(sigHash, d) :-
     (local.PublicFunction(_, sigHash, _);
-     sigHash = FALLBACK_FUNCTION_SIGHASH),
+     sigHash = FUNCTION_SELECTOR_SIGHASH),
     InputMaxContextDepth(d).
 
 
   MaxContextDepth(sigHash, 20) :-
     (local.PublicFunction(_, sigHash, _);
-     sigHash = FALLBACK_FUNCTION_SIGHASH),
+     sigHash = FUNCTION_SELECTOR_SIGHASH),
     !InputMaxContextDepth(_).
 }
 
@@ -157,7 +157,7 @@
   // Define our universe of contexts (including partial)
   .decl IsPotentialContext(pubFun: symbol, ctx: PrivateContext)
 
-  IsPotentialContext(FALLBACK_FUNCTION_SIGHASH, ctx) :-
+  IsPotentialContext(FUNCTION_SELECTOR_SIGHASH, ctx) :-
     InitialPrivateContext(ctx).
 
   IsPotentialContext(publicFun, private) :-
@@ -193,7 +193,7 @@
 
   InitialPrivateContext(nil).
 
-  InitialContext([FALLBACK_FUNCTION_SIGHASH, initialPrivateContext]) :-
+  InitialContext([FUNCTION_SELECTOR_SIGHASH, initialPrivateContext]) :-
     InitialPrivateContext(initialPrivateContext).
 
 
@@ -287,14 +287,14 @@
   //   local.PublicFunctionJump(caller, sigHash, _),
   //   !MaxContextDepth(sigHash, -1),
   //   DecomposeContext(ctx, prevSigHash, _),
-  //   prevSigHash != FALLBACK_FUNCTION_SIGHASH.
+  //   prevSigHash != FUNCTION_SELECTOR_SIGHASH.
   // .plan 1:(3,1,2)
   // MergeContext(ctx, caller, newContext):-
   //   ReachableContext(ctx, caller),
   //   local.PublicFunctionJump(caller, sigHash, _),
   //   !MaxContextDepth(sigHash, -1),
   //   DecomposeContext(ctx, prevSigHash, pri),
-  //   prevSigHash = FALLBACK_FUNCTION_SIGHASH,
+  //   prevSigHash = FUNCTION_SELECTOR_SIGHASH,
   //   newContext = [sigHash, pri].
   // .plan 1:(3,1,2)
 
@@ -304,14 +304,14 @@
     local.PublicFunction(funcStart, sigHash, _),
     !MaxContextDepth(sigHash, -1),
     DecomposeContext(ctx, prevSigHash, _),
-    prevSigHash != FALLBACK_FUNCTION_SIGHASH.
+    prevSigHash != FUNCTION_SELECTOR_SIGHASH.
   .plan 1:(4,1,2,3)
   MergeContextResponse(ctx, caller, funcStart, newContext) :-
     MergeContextRequest(ctx, caller, funcStart),
     local.PublicFunctionJump(caller, sigHash, _),
     local.PublicFunction(funcStart, sigHash, _),
     !MaxContextDepth(sigHash, -1),
-    DecomposeContext(ctx, FALLBACK_FUNCTION_SIGHASH, pri),
+    DecomposeContext(ctx, FUNCTION_SELECTOR_SIGHASH, pri),
     newContext = [sigHash, pri].
   .plan 1:(4,1,2,3)
   MergeContextResponse(ctx, caller, funcStart, ctx) :-

--- a/logic/context-sensitivity/finite_precise_context.dl
+++ b/logic/context-sensitivity/finite_precise_context.dl
@@ -14,13 +14,13 @@
 
   MaxContextDepth(sigHash, d) :-
     (local.PublicFunction(_, sigHash, _);
-     sigHash = FALLBACK_FUNCTION_SIGHASH),
+     sigHash = FUNCTION_SELECTOR_SIGHASH),
     InputMaxContextDepth(d).
 
   // HERE: much deeper
   MaxContextDepth(sigHash, 27) :-
     (local.PublicFunction(_, sigHash, _);
-     sigHash = FALLBACK_FUNCTION_SIGHASH),
+     sigHash = FUNCTION_SELECTOR_SIGHASH),
     !InputMaxContextDepth(_).
 
 
@@ -41,7 +41,7 @@
 
   InitialPrivateContext(nil).
 
-  InitialContext([FALLBACK_FUNCTION_SIGHASH, initialPrivateContext]) :-
+  InitialContext([FUNCTION_SELECTOR_SIGHASH, initialPrivateContext]) :-
     InitialPrivateContext(initialPrivateContext).
 
   DecomposeContext(ctx, publicFun, private):-
@@ -138,14 +138,14 @@
     local.PublicFunction(caller, sigHash, _),
     !MaxContextDepth(sigHash, -1),
     DecomposeContext(ctx, prevSigHash, _),
-    prevSigHash != FALLBACK_FUNCTION_SIGHASH.
+    prevSigHash != FUNCTION_SELECTOR_SIGHASH.
   .plan 1:(3,1,2)
   MergeContext(ctx, caller, newContext):-
     ReachableContext(ctx, caller),
     local.PublicFunction(caller, sigHash, _),
     !MaxContextDepth(sigHash, -1),
     DecomposeContext(ctx, prevSigHash, pri),
-    prevSigHash = FALLBACK_FUNCTION_SIGHASH,
+    prevSigHash = FUNCTION_SELECTOR_SIGHASH,
     newContext = [sigHash, pri].
   .plan 1:(3,1,2)
   #endif

--- a/logic/context-sensitivity/finite_shrinking_context.dl
+++ b/logic/context-sensitivity/finite_shrinking_context.dl
@@ -14,13 +14,13 @@
 
   MaxContextDepth(sigHash, d) :-
     (local.PublicFunction(_, sigHash, _);
-     sigHash = FALLBACK_FUNCTION_SIGHASH),
+     sigHash = FUNCTION_SELECTOR_SIGHASH),
     InputMaxContextDepth(d).
 
   // HERE: much deeper
   MaxContextDepth(sigHash, 10) :-
     (local.PublicFunction(_, sigHash, _);
-     sigHash = FALLBACK_FUNCTION_SIGHASH),
+     sigHash = FUNCTION_SELECTOR_SIGHASH),
     !InputMaxContextDepth(_).
 
 
@@ -41,7 +41,7 @@
 
   InitialPrivateContext(nil).
 
-  InitialContext([FALLBACK_FUNCTION_SIGHASH, initialPrivateContext]) :-
+  InitialContext([FUNCTION_SELECTOR_SIGHASH, initialPrivateContext]) :-
     InitialPrivateContext(initialPrivateContext).
 
   DecomposeContext(ctx, publicFun, private):-
@@ -100,14 +100,14 @@
     local.PublicFunction(caller, sigHash, _),
     !MaxContextDepth(sigHash, -1),
     DecomposeContext(ctx, prevSigHash, _),
-    prevSigHash != FALLBACK_FUNCTION_SIGHASH.
+    prevSigHash != FUNCTION_SELECTOR_SIGHASH.
   .plan 1:(3,1,2)
   MergeContext(ctx, caller, newContext):-
     ReachableContext(ctx, caller),
     local.PublicFunction(caller, sigHash, _),
     !MaxContextDepth(sigHash, -1),
     DecomposeContext(ctx, prevSigHash, pri),
-    prevSigHash = FALLBACK_FUNCTION_SIGHASH,
+    prevSigHash = FUNCTION_SELECTOR_SIGHASH,
     newContext = [sigHash, pri].
   .plan 1:(3,1,2)
   #endif

--- a/logic/context-sensitivity/hybrid_precise_context.dl
+++ b/logic/context-sensitivity/hybrid_precise_context.dl
@@ -17,19 +17,19 @@
 
   MaxImpreciseContextDepth(sigHash, d) :-
     (local.PublicFunction(_, sigHash, _);
-     sigHash = FALLBACK_FUNCTION_SIGHASH),
+     sigHash = FUNCTION_SELECTOR_SIGHASH),
     InputMaxImpreciseContextDepth(d).
 
   MaxImpreciseContextDepth(sigHash, 7) :-
     (local.PublicFunction(_, sigHash, _);
-     sigHash = FALLBACK_FUNCTION_SIGHASH),
+     sigHash = FUNCTION_SELECTOR_SIGHASH),
     !InputMaxImpreciseContextDepth(_).
 
   // Not yet configurable via input file
   .decl MaxPreciseContextDepth(sigHash: symbol, d: number)
   MaxPreciseContextDepth(sigHash, 27) :-
     (local.PublicFunction(_, sigHash, _);
-     sigHash = FALLBACK_FUNCTION_SIGHASH).
+     sigHash = FUNCTION_SELECTOR_SIGHASH).
 
   //
   // Much like PublicComponentContextSensitivity but need to change truncation logic
@@ -54,7 +54,7 @@
   // Define our universe of contexts (including partial)
   .decl IsPotentialContext(pubFun: symbol, ctx: PrivateContext)
 
-  IsPotentialContext(FALLBACK_FUNCTION_SIGHASH, ctx) :-
+  IsPotentialContext(FUNCTION_SELECTOR_SIGHASH, ctx) :-
     InitialPrivateContext(ctx).
 
   IsPotentialContext(publicFun, private) :-
@@ -105,7 +105,7 @@
     InitialPrecisePrivateContext(initialPrivateContext);
     InitialImprecisePrivateContext(initialPrivateContext).
 
-  InitialContext([FALLBACK_FUNCTION_SIGHASH, initialPrivateContext]) :-
+  InitialContext([FUNCTION_SELECTOR_SIGHASH, initialPrivateContext]) :-
     InitialPrecisePrivateContext(initialPrivateContext).  // ONLY PRECISE!!!
 
   PrecisePrivateContext(ctx) :-
@@ -256,14 +256,14 @@
     local.PublicFunction(caller, sigHash, _),
     !MaxImpreciseContextDepth(sigHash, -1),
     DecomposeContext(ctx, prevSigHash, _),
-    prevSigHash != FALLBACK_FUNCTION_SIGHASH.
+    prevSigHash != FUNCTION_SELECTOR_SIGHASH.
   .plan 1:(3,1,2)
   MergeContext(ctx, caller, newContext) :-
     ReachableContext(ctx, caller),
     local.PublicFunction(caller, sigHash, _),
     !MaxImpreciseContextDepth(sigHash, -1),
     DecomposeContext(ctx, prevSigHash, pri),
-    prevSigHash = FALLBACK_FUNCTION_SIGHASH,
+    prevSigHash = FUNCTION_SELECTOR_SIGHASH,
     newContext = [sigHash, pri].
   .plan 1:(3,1,2)
   #endif

--- a/logic/context-sensitivity/transactional_with_residual_context.dl
+++ b/logic/context-sensitivity/transactional_with_residual_context.dl
@@ -18,7 +18,7 @@
 
   // Define our universe of contexts (including partial)
   .decl IsPotentialContext(pubFun: symbol, ctx: PrivateContext, residual: number)
-  IsPotentialContext(FALLBACK_FUNCTION_SIGHASH, ctx, 0) :-
+  IsPotentialContext(FUNCTION_SELECTOR_SIGHASH, ctx, 0) :-
     InitialPrivateContext(ctx).
 
   IsPotentialContext(publicFun, private, residual) :-
@@ -48,7 +48,7 @@
    .plan 1:(2,1)
 
 
-  InitialContext([FALLBACK_FUNCTION_SIGHASH, initialPrivateContext, 0]) :-
+  InitialContext([FUNCTION_SELECTOR_SIGHASH, initialPrivateContext, 0]) :-
     InitialPrivateContext(initialPrivateContext).
 
   PrivateContextDepth(init, 0):-
@@ -109,14 +109,14 @@
     local.PublicFunction(caller, sigHash),
     !MaxContextDepth(sigHash, -1),
     DecomposeContext(ctx, prevSigHash, _, _),
-    prevSigHash != FALLBACK_FUNCTION_SIGHASH.
+    prevSigHash != FUNCTION_SELECTOR_SIGHASH.
   .plan 1:(3,1,2)
   MergeContext(ctx, caller, newContext):-
     ReachableContext(ctx, caller),
     local.PublicFunction(caller, sigHash),
     !MaxContextDepth(sigHash, -1),
     DecomposeContext(ctx, prevSigHash, pri, _),
-    prevSigHash = FALLBACK_FUNCTION_SIGHASH,
+    prevSigHash = FUNCTION_SELECTOR_SIGHASH,
     newContext = [sigHash, pri, 0].
   .plan 1:(3,1,2)
   #endif

--- a/logic/functions.dl
+++ b/logic/functions.dl
@@ -622,7 +622,7 @@ IRFunctionCall(fromir, irfunc) :-
 */
 .decl PubFun(entry:symbol, hex:symbol)
 
-PubFun("0x0", FALLBACK_FUNCTION_SIGHASH):- global.sens.Context_PublicFunction(_, _).
+PubFun("0x0", FUNCTION_SELECTOR_SIGHASH):- global.sens.Context_PublicFunction(_, _).
 PubFun(entry, sigHash):- global.sens.Context_PublicFunction(_, sigHash), PublicFunctionFiltered(entry, sigHash).
 
 // Intra-function edges (i.e., real CFG edges)

--- a/logic/types_defs.dl
+++ b/logic/types_defs.dl
@@ -21,6 +21,7 @@
 
 #define FALLBACK_FUNCTION_SIGHASH "0x00000000"
 #define RECEIVE_FUNCTION_SIGHASH "0xeeeeeeee"
+#define FUNCTION_SELECTOR_SIGHASH "0xfa11bacc"
 
 
 .type Block <: symbol

--- a/logic/types_defs.dl
+++ b/logic/types_defs.dl
@@ -17,6 +17,7 @@
 #define CheckIsStackIndex(v) ((v) >= 0, (v) < MAX_STACK_HEIGHT)
 
 
+// The following 4 constants as also defined in src/common.py
 #define FUNCTION_SELECTOR "0x0"
 
 #define FALLBACK_FUNCTION_SIGHASH "0x00000000"

--- a/logic/types_defs.dl
+++ b/logic/types_defs.dl
@@ -21,7 +21,7 @@
 
 #define FALLBACK_FUNCTION_SIGHASH "0x00000000"
 #define RECEIVE_FUNCTION_SIGHASH "0xeeeeeeee"
-#define FUNCTION_SELECTOR_SIGHASH "0xfa11bacc"
+#define FUNCTION_SELECTOR_SIGHASH "0xff5e1ec7"
 
 
 .type Block <: symbol

--- a/src/common.py
+++ b/src/common.py
@@ -9,6 +9,12 @@ DEFAULT_SOUFFLE_BIN = 'souffle'
 
 SOUFFLE_COMPILED_SUFFIX = '_compiled'
 
+# The following 4 constants are also defined in `logic/types_defs.dl`
+FUNCTION_SELECTOR = "0x0"
+FALLBACK_FUNCTION_SIGHASH = "0x00000000"
+RECEIVE_FUNCTION_SIGHASH = "0xeeeeeeee"
+FUNCTION_SELECTOR_SIGHASH = "0xff5e1ec7"
+
 log = lambda msg: logging.log(logging.INFO + 1, msg)
 log_debug = lambda msg: logging.log(logging.DEBUG, msg)
 


### PR DESCRIPTION
Minor refactor in decompiler logic, introduce a new constant `FUNCTION_SELECTOR_SIGHASH` with value `0xff5e1ec7`.
Was needed as constant `FALLBACK_FUNCTION_SIGHASH` was used both for the fallback function and function selector.
Doesn't affect our results.