### PR TITLE
Fix TAC function parameter names

### DIFF
--- a/clients/visualizeout.py
+++ b/clients/visualizeout.py
@@ -16,13 +16,14 @@ def emit(s: str, out: TextIO, indent: int=0):
     print(f'{indent*INDENT_BASE}{s}', file=out)
 
 
-def emit_stmt(stmt: Statement, out: TextIO):
-    def render_var(var: str):
-        if var in tac_variable_value:
-            return f"v{var.replace('0x', '')}({tac_variable_value[var]})"
-        else:
-            return f"v{var.replace('0x', '')}"
+def render_var(var: str):
+    if var in tac_variable_value:
+        return f"v{var.replace('0x', '')}({tac_variable_value[var]})"
+    else:
+        return f"v{var.replace('0x', '')}"
 
+
+def emit_stmt(stmt: Statement, out: TextIO):
     defs = [render_var(v) for v in stmt.defs]
     uses = [render_var(v) for v in stmt.operands]
 
@@ -55,7 +56,8 @@ def pretty_print_block(block: Block, visited: Set[str], out: TextIO):
 def pretty_print_tac(functions: Mapping[str, Function], out: TextIO):
     for function in sorted(functions.values(), key=lambda x: x.ident):
         visibility = 'public' if function.is_public else 'private'
-        emit(f"function {function.name}({', '.join(function.formals)}) {visibility} {{", out)
+        formals = [render_var(v) for v in function.formals]
+        emit(f"function {function.name}({', '.join(formals)}) {visibility} {{", out)
         pretty_print_block(function.head_block, set(), out)
 
         emit("}", out)


### PR DESCRIPTION
This pull request fixes the issue that `clients/visualizeout.py` emits function parameter names different from variable names used in the function body.

For example, here is the decompiled `contract.tac` of `examples/long_running.hex`.
```
function 0x757(0x757arg0x0, 0x757arg0x1) private {
    ...
    0x76b: MSTORE v767(0x0), v757arg0
    ...
    0x7ea: RETURNPRIVATE v757arg1, v7e4_2
    ...
}
```
Function parameter names in the declaration are 0x757arg0x0, 0x757arg0x1, while they are v757arg0, v757arg1 in the function body.

This was because `clients/visualizeout.py` called the `render_var` function for variable definitions and variable uses in the function body, but not for function parameters. This PR fixes the issue by calling `render_var` for `function.formals`, too.
```
function 0x757(v757arg0, v757arg1) private {
    ...
    0x76b: MSTORE v767(0x0), v757arg0
    ...
    0x7ea: RETURNPRIVATE v757arg1, v7e4_2
    ...
}
```