### PR TITLE
TAC_OriginalStatement_Block left some original statements behind

### DIFF
--- a/logic/decompiler_output.dl
+++ b/logic/decompiler_output.dl
@@ -358,21 +358,24 @@ TAC_Statement_InlineInfo(irStmt, nil):-
 .output TAC_OriginalStatement_Block
 
 // unmodified statements
-TAC_OriginalStatement_Block(stmt, irblock) :-
-  postTrans.Statement_Block(_, block),
+TAC_OriginalStatement_Block(ogStmt, irblock) :-
+  PreTransStatement_OriginalStatement(stmt, ogStmt),
   preTrans.Statement_Block(stmt, block),
+  postTrans.Statement_Block(_, block),
   Block_IRBlock(block, _, irblock).
 
 
 // tracks statements that have been placed into generated blocks
-TAC_OriginalStatement_Block(stmt, irblock) :-
+TAC_OriginalStatement_Block(ogStmt, irblock) :-
+  PreTransStatement_OriginalStatement(stmt, ogStmt),
   postTrans.Statement_Block(stmt, block),
   !preTrans.Statement_Block(_, block),
   preTrans.Statement_Block(stmt, _),
   Block_IRBlock(block, _, irblock).
 
 // tracks deleted statements where their old block was also changed
-TAC_OriginalStatement_Block(stmt, irblock) :-
+TAC_OriginalStatement_Block(ogStmt, irblock) :-
+  PreTransStatement_OriginalStatement(stmt, ogStmt),
   preTrans.Statement_Block(stmt, block),
   !postTrans.Statement_Block(stmt, _),
   !postTrans.Statement_Block(_, block),


### PR DESCRIPTION
Description:
We're talking about srcmap from the gigahorse-IR/TAC to the bytecode. Let's first define what're original statements in a gigahorse decompilation. Original statements are those statements in the original bytecode. Based on the definition, existing rules of `TAC_OriginalStatement_Block` are confused by pretrans statements and original statements, which is clear from not using `PreTransStatement_OriginalStatement`. When the original statements are cloned and then no longer reachable, they are left behind. And this leads to cases in `UnmappedStatements`. Here comes the POC.

POC:
- source code
    ```solidity
    contract POC {
        uint svar1;

        function test() public  {
            if(subFunc(0x111)){
                svar1 = 0x999;
            }
            else if(subFunc(0x222)){
                svar1 = 0x998;
            }
        }

        function subFunc(uint a) private pure returns (bool){
            return false;
        }
    }
    ```
- bin-runtime hex
`6080604052348015600e575f80fd5b50600436106026575f3560e01c8063f8a8fd6d14602a575b5f80fd5b60306032565b005b603b6101116064565b15604b576109995f819055506062565b60546102226064565b156061576109985f819055505b5b565b5f91905056fea26469706673582212208409c6264e9bc6ed430c39a4717a011660ef0e23c2d0c1dae34b6b4fe38cffd964736f6c63430008140033`

Steps to Reproduce:
1. run the tool under the latest version (for now it's the commit 3e6f86dec30b0f071dc1dbc730e24692a58aa0a7)
`$ ./gigahorse.py --disable_inline --disable_scalable_fallback -M "CONTEXT_SENSITIVITY=TransactionalWithShrinkingContext" -M"BLOCK_CLONING=HeuristicBlockCloner" --debug -C clients/visualizeout.py POC.bin-runtime.hex `
2. Formally, we can get the left-behind cases with the following rule (here is a concrete case from the POC).
    ``` 
    LeftBehindOriginalStatements(0x62) :-
        !TAC_OriginalStatement_Block(0x62, _),
        UnmappedStatements(0x62),
        TAC_Statement_OriginalStatement(0x162, 0x62),
        blockCloner.StatementToClonedStatement(_, 0x62, 0x162),
        PreTransStatement_OriginalStatement(0x162, 0x62).
    ```

Expected Behavior:
1. `TAC_OriginalStatement_Block(0x62, 0x162)`
2. `!TAC_OriginalStatement_Block(0x162, 0x162)`

Actual Behavior:
1. `!TAC_OriginalStatement_Block(0x62, _)`
2. `TAC_OriginalStatement_Block(0x162, 0x162)`

Environment:
* gigahorse: commit 3e6f86dec30b0f071dc1dbc730e24692a58aa0a7