### PR TITLE
PreTransStatement_OriginalStatement left some pretrans statements behind

### DIFF
--- a/logic/local.dl
+++ b/logic/local.dl
@@ -76,13 +76,13 @@ blockCloner.Prev_Block_OriginalBlock(block, originalBlock):- revertCloner.Block_
 .init preTrans = PreTransLocalAnalysis
 COPY_OUTPUT(preTrans, blockCloner)
 
-PreTransStatement_OriginalStatement(heurClStmt, ogStmt) :-
-  blockCloner.StatementToClonedStatement(_, rvtClStmt, heurClStmt),
-  revertCloner.StatementToClonedStatement(_, ogStmt, rvtClStmt).
+PreTransStatement_OriginalStatement(insStmt, ogStmt) :-
+  clonerHelperInsertor.InsertedOpNewStatement(ogOrMidStmt, _, insStmt),
+  PreTransStatement_OriginalStatement(ogOrMidStmt, ogStmt).
 
 PreTransStatement_OriginalStatement(heurClStmt, ogStmt) :-
-  blockCloner.StatementToClonedStatement(_, ogStmt, heurClStmt),
-  !revertCloner.StatementToClonedStatement(_, _, ogStmt).
+  blockCloner.StatementToClonedStatement(_, ogOrMidStmt, heurClStmt),
+  PreTransStatement_OriginalStatement(ogOrMidStmt, ogStmt).
 
 ValidSelector(optionalSelector):-
   blockCloner.analysis.ValidSelector(optionalSelector).

--- a/logic/local.dl
+++ b/logic/local.dl
@@ -24,8 +24,8 @@ PreTransStatement_OriginalStatement(ogStmt, ogStmt) :-
   factReader.Statement_Opcode(ogStmt, _).
 
 PreTransStatement_OriginalStatement(rvtClStmt, ogStmt) :-
-  revertCloner.StatementToClonedStatement(_, ogStmt, rvtClStmt).
-
+  PreTransStatement_OriginalStatement(stmt, ogStmt),
+  revertCloner.StatementToClonedStatement(_, stmt, rvtClStmt).
 
 .init revertCloner = RevertBlockCloner
 COPY_CODE(revertCloner, factReader)
@@ -77,12 +77,12 @@ blockCloner.Prev_Block_OriginalBlock(block, originalBlock):- revertCloner.Block_
 COPY_OUTPUT(preTrans, blockCloner)
 
 PreTransStatement_OriginalStatement(insStmt, ogStmt) :-
-  clonerHelperInsertor.InsertedOpNewStatement(ogOrMidStmt, _, insStmt),
-  PreTransStatement_OriginalStatement(ogOrMidStmt, ogStmt).
+  PreTransStatement_OriginalStatement(ogOrMidStmt, ogStmt),
+  clonerHelperInsertor.InsertedOpNewStatement(ogOrMidStmt, _, insStmt).
 
 PreTransStatement_OriginalStatement(heurClStmt, ogStmt) :-
-  blockCloner.StatementToClonedStatement(_, ogOrMidStmt, heurClStmt),
-  PreTransStatement_OriginalStatement(ogOrMidStmt, ogStmt).
+  PreTransStatement_OriginalStatement(ogOrMidStmt, ogStmt),
+  blockCloner.StatementToClonedStatement(_, ogOrMidStmt, heurClStmt).
 
 ValidSelector(optionalSelector):-
   blockCloner.analysis.ValidSelector(optionalSelector).


### PR DESCRIPTION
Description:
Existing rules of `PreTransStatement_OriginalStatement` doesn't consider these pretrans statements inserted by `clonerHelperInsertor`. Here comes the POC.

POC:
- source code
    ```solidity
    contract POC {
        uint svar1;

        function test() public  {
            if(subFunc(0x111)){
                svar1 = 0x999;
            }
            else if(subFunc(0x222)){
                svar1 = 0x998;
            }
        }

        function subFunc(uint a) private pure returns (bool){
            return false;
        }
    }
    ```
- bin-runtime hex
`6080604052348015600e575f80fd5b50600436106026575f3560e01c8063f8a8fd6d14602a575b5f80fd5b60306032565b005b603b6101116064565b15604b576109995f819055506062565b60546102226064565b156061576109985f819055505b5b565b5f91905056fea26469706673582212208409c6264e9bc6ed430c39a4717a011660ef0e23c2d0c1dae34b6b4fe38cffd964736f6c63430008140033`

Steps to Reproduce:
1. run the tool under the latest version (for now it's the commit 3e6f86dec30b0f071dc1dbc730e24692a58aa0a7)
`$ ./gigahorse.py --disable_inline --disable_scalable_fallback -M "CONTEXT_SENSITIVITY=TransactionalWithShrinkingContext" -M"BLOCK_CLONING=HeuristicBlockCloner" --debug -C clients/visualizeout.py POC.bin-runtime.hex`
2. Formally, we can get the left-behind cases with the following rule (here is a concrete case from the POC). 
    ```
    LeftBehindPretransStatements(0xa0) :-
        clonerHelperInsertor.InsertedOpNewStatement(0x62, _, 0xa0)
        !PreTransStatement_OriginalStatement(0xa0, 0x62).
    ```

Expected Behavior:
1. `PreTransStatement_OriginalStatement(0xa0, 0x62)`
2. `TAC_Statement_OriginalStatement(0xa0, 0x62)`

Actual Behavior:
1. `!PreTransStatement_OriginalStatement(0xa0, 0x62)`
2. `!TAC_Statement_OriginalStatement(0xa0, 0x62)`

Environment:
* gigahorse: commit 3e6f86dec30b0f071dc1dbc730e24692a58aa0a7
