### PR TITLE
Improve early codecopy transformations.

### DIFF
--- a/logic/local.dl
+++ b/logic/local.dl
@@ -256,17 +256,18 @@ insertor.insertOps(mload,
 ) :-
   preTrans.CODECOPYSmallConstWLoad(codeCopy, const, mload).
 
-insertor.removeOp(codeCopy),
-insertor.insertOps(codeCopy,
-  LIST(
-    STMT(SWAP2, ""),
-    STMT(POP, ""),
-    STMT(POP, ""),
-    STMT(PUSH32, const),
-    STMT(SWAP1, "")
-  )
-) :-
-  preTrans.CODECOPYSmallConstNoLoad(codeCopy, const).
+// SL: Removing this for now, don't remember what I was thinking. Seems plain wrong.
+// insertor.removeOp(codeCopy),
+// insertor.insertOps(codeCopy,
+//   LIST(
+//     STMT(SWAP2, ""),
+//     STMT(POP, ""),
+//     STMT(POP, ""),
+//     STMT(PUSH32, const),
+//     STMT(SWAP1, "")
+//   )
+// ) :-
+//   preTrans.CODECOPYSmallConstNoLoad(codeCopy, const).
 
 .init postTrans = PostTransLocalAnalysis
 

--- a/logic/local.dl
+++ b/logic/local.dl
@@ -256,18 +256,19 @@ insertor.insertOps(mload,
 ) :-
   preTrans.CODECOPYSmallConstWLoad(codeCopy, const, mload).
 
-// SL: Removing this for now, don't remember what I was thinking. Seems plain wrong.
-// insertor.removeOp(codeCopy),
-// insertor.insertOps(codeCopy,
-//   LIST(
-//     STMT(SWAP2, ""),
-//     STMT(POP, ""),
-//     STMT(POP, ""),
-//     STMT(PUSH32, const),
-//     STMT(SWAP1, "")
-//   )
-// ) :-
-//   preTrans.CODECOPYSmallConstNoLoad(codeCopy, const).
+// Replace codecopy with MSTORE of constant value
+insertor.removeOp(codeCopy),
+insertor.insertOps(codeCopy,
+  LIST(
+    STMT(SWAP2, ""),
+    STMT(POP, ""),
+    STMT(POP, ""),
+    STMT(PUSH32, const),
+    STMT(SWAP1, ""),
+    STMT(MSTORE, "")
+  )
+) :-
+  preTrans.CODECOPYSmallConstNoLoad(codeCopy, const).
 
 .init postTrans = PostTransLocalAnalysis
 

--- a/logic/local_components.dl
+++ b/logic/local_components.dl
@@ -723,6 +723,19 @@ IsStackIndexLessThan(n, maximum) :- n = range(0, maximum, 1).
     Statement_Opcode(mload, "MLOAD"),
     BeforeLocalStackContents(mload, 0, memLocVar).
 
+  // handle constant writes, mostly in optimized code.
+  CODECOPYSmallConstWLoad(codeCopy, const, mload):-
+    CODECOPYSmallConst(codeCopy, const),
+    BeforeLocalStackContents(codeCopy, 0, memLocVar1),
+    CheckIsVariable(memLocVar1),
+    Variable_Value(memLocVar1, val),
+    Statement_Next(codeCopy, someStmt),
+    Statement_Next(someStmt, mload),
+    Statement_Opcode(mload, "MLOAD"),
+    BeforeLocalStackContents(mload, 0, memLocVar2),
+    CheckIsVariable(memLocVar2),
+    Variable_Value(memLocVar2, val).
+
   CODECOPYSmallConstNoLoad(codeCopy, const):-
     CODECOPYSmallConst(codeCopy, const),
     !CODECOPYSmallConstWLoad(codeCopy, const, _).


### PR DESCRIPTION
Introduces new rule to cover pattern in newer, optimized source code.
Also fixes the no-mload transformation, which was totally broken.

Results in the `mixed-dataset2`:
```
ANALYTIC: Analytics_LocalBlockEdge
jun25-mix-master (common): 1317624 (-0.1286%)
jun25-mix-codec2 (common): 1319321

ANALYTIC: Analytics_MissingEdgeInTAC
jun25-mix-master (common): 178
jun25-mix-codec2 (common): 139 (-21.91%)

ANALYTIC: Analytics_MissingJumpTargetAnyCtx
jun25-mix-master (common): 21 (+320%)
jun25-mix-codec2 (common): 5

ANALYTIC: Analytics_Contexts
jun25-mix-master (common): 1146146
jun25-mix-codec2 (common): 1147820 (+0.1461%)

ANALYTIC: Analytics_CallToSignature
jun25-mix-master (common): 10799 (-0.231%)
jun25-mix-codec2 (common): 10824

ANALYTIC: Analytics_EventSignature
jun25-mix-master (common): 10628 (-0.1972%)
jun25-mix-codec2 (common): 10649
```