### PR TITLE
fix(decomp): reduce possible var collisions.

### DIFF
--- a/logic/functions.dl
+++ b/logic/functions.dl
@@ -1,4 +1,4 @@
-#define FRESH_VARIABLE(var, stmt, stackIndex) (IRStatementNum((stmt), ?stmtNum), var=-0xFFFF+?stmtNum*MAX_STACK_HEIGHT+(stackIndex))
+#define FRESH_VARIABLE(var, stmt, stackIndex) (IRStatementNum((stmt), ?stmtNum), var=-0xFFFFFF+?stmtNum*MAX_STACK_HEIGHT+(stackIndex))
 
 
 #define MAX_NUM_PRIVATE_FUNCTION_ARGS 50


### PR DESCRIPTION
Turns out we've had an analytic for this all along: `Analytics_DoubleDef`, we had contracts that triggered it in all datasets.
Will not add a test as a single contract having no collision doesn't matter for this, none should have one.
Will be keeping an eye on that analytic.