### PR TITLE
Always handle errors during execution of compiled souffle binaries

### DIFF
--- a/src/runners.py
+++ b/src/runners.py
@@ -98,9 +98,10 @@ class AnalysisExecutor:
             souffle_err = open(err_filename).read()
             # Used to be "Error:" to avoid reporting the file not found errors of souffle
             # However with souffle 2.4 they cause the program to stop so we have to report them as well
-            if any(s in souffle_err for s in ["Error", "error", "core dumped", "Segmentation", "segmentation", "corrupted"]):
+            if any(s in souffle_err for s in ["Error", "error", "core dumped", "Segmentation", "segmentation", "corrupted", "std::"]):
                 errors.append(os.path.basename(souffle_client))
-                log(souffle_err)
+            elif len(souffle_err) > 0:
+                log(f"Unrecognized error during {souffle_client} dl execution: {souffle_err}.")
         return errors, timeouts
 
     def run_script_client(self, script_client: str, in_dir: str, out_dir: str, start_time: float):

--- a/src/runners.py
+++ b/src/runners.py
@@ -78,13 +78,13 @@ class AnalysisExecutor:
         timeouts = []
         err_filename = join(out_dir, os.path.basename(souffle_client) + '.err')
         if not self.interpreted:
-            err_file: Any = devnull
+            err_file: Any = open(err_filename, 'w')
             analysis_args = [
                 get_souffle_executable_path(self.cache_dir, souffle_client),
                 f"--facts={in_dir}", f"--output={out_dir}"
             ]
         else:
-            err_file = open(err_filename, 'w') # if self.debug else devnull
+            err_file = open(err_filename, 'w') if self.debug else devnull
             analysis_args = [
                 self.souffle_bin,
                 join(os.getcwd(), souffle_client),

--- a/src/runners.py
+++ b/src/runners.py
@@ -84,7 +84,7 @@ class AnalysisExecutor:
                 f"--facts={in_dir}", f"--output={out_dir}"
             ]
         else:
-            err_file = open(err_filename, 'w') if self.debug else devnull
+            err_file = open(err_filename, 'w') # if self.debug else devnull
             analysis_args = [
                 self.souffle_bin,
                 join(os.getcwd(), souffle_client),
@@ -94,11 +94,11 @@ class AnalysisExecutor:
 
         if run_process(analysis_args, self.calc_timeout(start_time, half), stderr=err_file) < 0:
             timeouts.append(souffle_client)
-        if self.debug and err_file != devnull:
+        if err_file != devnull:
             souffle_err = open(err_filename).read()
             # Used to be "Error:" to avoid reporting the file not found errors of souffle
             # However with souffle 2.4 they cause the program to stop so we have to report them as well
-            if any(s in souffle_err for s in ["Error", "core dumped", "Segmentation", "corrupted"]):
+            if any(s in souffle_err for s in ["Error", "error", "core dumped", "Segmentation", "segmentation", "corrupted"]):
                 errors.append(os.path.basename(souffle_client))
                 log(souffle_err)
         return errors, timeouts

--- a/src/runners.py
+++ b/src/runners.py
@@ -42,6 +42,14 @@ if not os.path.isfile(join(functor_path, 'libfunctors.so')):
 class TimeoutException(Exception):
     pass
 
+class DecompilationException(Exception):
+    """
+    Error during the execution of any fact-producing datalog executable.
+    This includes main decompiler, scalable fallback, inliner, and any pre clients.
+    Other errors are just output as `client_errors` on the produced json.
+    """
+    pass
+
 def set_memory_limit(memory_limit: int):
     resource.setrlimit(resource.RLIMIT_AS, (memory_limit, memory_limit))
 
@@ -345,10 +353,12 @@ class DecompilerFactGenerator(AbstractFactGenerator):
             # Create a symlink with a name starting with 'Verbatim_' to be added to results json
             os.symlink(join(work_dir, 'compiler_info.csv'), join(out_dir, 'Verbatim_compiler_info.csv'))
 
-        timeouts, _ = self.analysis_executor.run_clients(self.souffle_pre_clients, self.other_pre_clients, work_dir, work_dir, disassemble_start)
+        timeouts, errors = self.analysis_executor.run_clients(self.souffle_pre_clients, self.other_pre_clients, work_dir, work_dir, disassemble_start)
         if timeouts:
             # pre clients should be very light, should never happen
             raise TimeoutException()
+        if errors:
+            raise DecompilationException()
 
         write_context_depth_file(os.path.join(work_dir, 'MaxContextDepth.csv'), self.context_depth)
 
@@ -367,9 +377,11 @@ class DecompilerFactGenerator(AbstractFactGenerator):
 
     def run_decomp(self, contract_filename: str, in_dir: str, out_dir: str, start_time: float) -> str:
         config = "default"
-        def_timeouts, _ = self.analysis_executor.run_clients([DecompilerFactGenerator.decompiler_dl], [], in_dir, out_dir, start_time, not self.disable_scalable_fallback)
+        def_timeouts, def_errors = self.analysis_executor.run_clients([DecompilerFactGenerator.decompiler_dl], [], in_dir, out_dir, start_time, not self.disable_scalable_fallback)
 
-        if def_timeouts or not self.decomp_out_produced(out_dir):
+        if def_errors:
+            raise DecompilationException()
+        elif def_timeouts or not self.decomp_out_produced(out_dir):
             if self.disable_scalable_fallback:
                 raise TimeoutException()
             else:
@@ -377,8 +389,10 @@ class DecompilerFactGenerator(AbstractFactGenerator):
                 log(f"Using scalable fallback decompilation configuration for {os.path.split(contract_filename)[1]}")
                 write_context_depth_file(os.path.join(in_dir, 'MaxContextDepth.csv'), 10)
 
-                sca_timeouts, _ = self.analysis_executor.run_clients([DecompilerFactGenerator.fallback_scalable_decompiler_dl], [], in_dir, out_dir, start_time)
-                if not sca_timeouts and self.decomp_out_produced(out_dir):
+                sca_timeouts, sca_errors = self.analysis_executor.run_clients([DecompilerFactGenerator.fallback_scalable_decompiler_dl], [], in_dir, out_dir, start_time)
+                if sca_errors:
+                    raise DecompilationException()
+                elif not sca_timeouts and self.decomp_out_produced(out_dir):
                     config = "scalable"
                 else:
                     raise TimeoutException()


### PR DESCRIPTION
Changes the behavior of `gigahorse.py` w.r.t. errors encountered during the execution of dl binaries.
There used to be silent errors in a few cases (for user-defined clients) and we would eliminate them via testing but this is not ideal, so I changed it.
Will leave error reporting under `-i` as it is for now as it the souffle interpreter includes more error output.

Introduced new `DecompilationException` that is thrown when an error happens during decompilation, pre-clients, or inlining.