### PR TITLE
Introduce last resort ultra scalable decompiler configuration.

### DIFF
--- a/gigahorse.py
+++ b/gigahorse.py
@@ -16,6 +16,7 @@ import os
 
 # Local project imports
 from src.common import GIGAHORSE_DIR, DEFAULT_SOUFFLE_BIN, log
+from src.runners import MAIN_DECOMPILER_MAX_CONTEXT_DEPTH
 from src.runners import test_souffle, get_souffle_executable_path, compile_datalog, AbstractFactGenerator, DecompilerFactGenerator, CustomFactGenerator, MixedFactGenerator, AnalysisExecutor, TimeoutException, DecompilationException
 
 ## Constants
@@ -61,83 +62,67 @@ parser.add_argument(
 
 parser.add_argument("-S",
                     "--souffle_bin",
-                    nargs="?",
                     default=DEFAULT_SOUFFLE_BIN,
-                    const=DEFAULT_SOUFFLE_BIN,
                     metavar="BINARY",
-                    help="the location of the souffle binary.")
+                    help=f"The location of the souffle binary (default: {DEFAULT_SOUFFLE_BIN}).")
 
 parser.add_argument("-C",
                     "--client",
                     nargs="?",
                     default="",
-                    help="additional clients to run after decompilation.")
+                    help="Additional clients to run after decompilation.")
 
 parser.add_argument("-P",
                     "--pre-client",
                     nargs="?",
                     default="",
-                    help="additional clients to run before decompilation.")
+                    help="Additional clients to run before decompilation.")
 
 parser.add_argument("-r",
                     "--results_file",
-                    nargs="?",
                     default=DEFAULT_RESULTS_FILE,
-                    const=DEFAULT_RESULTS_FILE,
                     metavar="FILE",
-                    help="the location to write the results.")
+                    help=f"The location to write the results (default: {DEFAULT_RESULTS_FILE}).")
 
 parser.add_argument("-w",
                     "--working_dir",
-                    nargs="?",
                     default=TEMP_WORKING_DIR,
-                    const=TEMP_WORKING_DIR,
                     metavar="DIR",
-                    help="the location to were temporary files are placed.")
+                    help=f"The location to were temporary files are placed (default: {TEMP_WORKING_DIR}).")
 
 parser.add_argument('--cache_dir',
-                    nargs="?",
                     default=DEFAULT_CACHE_DIR,
-                    const=DEFAULT_CACHE_DIR,
                     metavar="DIR",
-                    help="the location to were temporary files are placed.")
+                    help=f"The location to were temporary files are placed (default: {DEFAULT_CACHE_DIR}).")
 
 
 parser.add_argument("-j",
                     "--jobs",
                     type=int,
-                    nargs="?",
                     default=DEFAULT_NUM_JOBS,
-                    const=DEFAULT_NUM_JOBS,
                     metavar="NUM",
-                    help="The number of subprocesses to run at once.")
+                    help=f"The number of subprocesses to run at once (default: {DEFAULT_NUM_JOBS}).")
 
 parser.add_argument("-k",
                     "--skip",
                     type=int,
-                    nargs="?",
                     default=0,
-                    const=0,
                     metavar="NUM",
-                    help="Skip the the analysis of the first NUM contracts.")
+                    help="Skip the the analysis of the first NUM contracts (default: 0).")
 
 parser.add_argument("-T",
                     "--timeout_secs",
                     type=int,
-                    nargs="?",
                     default=DEFAULT_TIMEOUT,
-                    const=DEFAULT_TIMEOUT,
                     metavar="SECONDS",
                     help="Forcibly halt decompilation/analysis of a single contact after "
-                         "the specified number of seconds. Separate timers for decompilation and anaysis.")
+                         "the specified number of seconds. Separate timers for decompilation and analysis.")
 
 parser.add_argument("--minimum_client_time",
                     type=int,
-                    nargs="?",
                     default=DEFAULT_MINIMUM_CLIENT_TIME,
-                    const=DEFAULT_MINIMUM_CLIENT_TIME,
                     metavar="SECONDS",
-                    help="Minimum time to allow each client to run.")
+                    help=f"Minimum time to allow each client to run (default: {DEFAULT_MINIMUM_CLIENT_TIME}).")
 
 parser.add_argument("-M",
                     "--souffle_macros",
@@ -591,9 +576,9 @@ if __name__ == "__main__":
     parser.add_argument("-cd",
                         "--context_depth",
                         type=int,
-                        nargs="?",
+                        default=MAIN_DECOMPILER_MAX_CONTEXT_DEPTH,
                         metavar="NUM",
-                        help="Override the maximum context depth for decompilation (default is 20).")
+                        help=f"Override the maximum context depth for decompilation (default is {MAIN_DECOMPILER_MAX_CONTEXT_DEPTH}).")
 
     parser.add_argument("--early_cloning",
                         action="store_true",

--- a/logic/context-sensitivity/abstract_context.dl
+++ b/logic/context-sensitivity/abstract_context.dl
@@ -56,7 +56,10 @@
      sigHash = FUNCTION_SELECTOR_SIGHASH),
     InputMaxContextDepth(d).
 
-
+  /**
+    This rule will never fire if executed using `gigahorse.py` as it will always provide a context depth value.
+    Default max context depth values for different decompiler configurations are defined in `src/runners.py`.
+  */
   MaxContextDepth(sigHash, 20) :-
     (local.PublicFunction(_, sigHash, _);
      sigHash = FUNCTION_SELECTOR_SIGHASH),

--- a/logic/last_resort.dl
+++ b/logic/last_resort.dl
@@ -1,0 +1,8 @@
+
+#define CONTEXT_SENSITIVITY FinitePreciseContext
+
+#define MAX_STACK_HEIGHT 30
+
+#include "main.dl"
+
+DecompilerConfig("last_resort").

--- a/logic/last_resort.dl
+++ b/logic/last_resort.dl
@@ -1,4 +1,9 @@
 
+/**
+  Last resort decompilation configuration that should almost never time out.
+  Max context depth is defined in `src/runners.py`.
+*/
+
 #define CONTEXT_SENSITIVITY FinitePreciseContext
 
 #define MAX_STACK_HEIGHT 30

--- a/src/runners.py
+++ b/src/runners.py
@@ -387,7 +387,7 @@ class DecompilerFactGenerator(AbstractFactGenerator):
                 raise TimeoutException()
             else:
                 # Default using scalable fallback config
-                log(f"Using scalable fallback decompilation configuration for {os.path.split(contract_filename)[1]}")
+                log(f"Using the scalable fallback decompilation configuration for {os.path.split(contract_filename)[1]}")
                 write_context_depth_file(os.path.join(in_dir, 'MaxContextDepth.csv'), 10)
 
                 sca_timeouts, sca_errors = self.analysis_executor.run_clients([DecompilerFactGenerator.fallback_scalable_decompiler_dl], [], in_dir, out_dir, start_time, half=True)
@@ -395,7 +395,7 @@ class DecompilerFactGenerator(AbstractFactGenerator):
                     raise DecompilationException()
                 elif sca_timeouts:
                     log(f"Using the last resort ultra scalable decompilation configuration for {os.path.split(contract_filename)[1]}")
-                    write_context_depth_file(os.path.join(in_dir, 'MaxContextDepth.csv'), 15)
+                    write_context_depth_file(os.path.join(in_dir, 'MaxContextDepth.csv'), 10)
                     last_timeouts, last_errors = self.analysis_executor.run_clients([DecompilerFactGenerator.last_resort_decompiler_dl], [], in_dir, out_dir, start_time)
                     if last_errors:
                         raise DecompilationException()

--- a/tests/context-sensitivity/finite-precise.json
+++ b/tests/context-sensitivity/finite-precise.json
@@ -1,6 +1,6 @@
 {
     "client_path": null,
-    "gigahorse_args": ["-i", "--disable_scalable_fallback", "--disable_precise_fallback", "--disable_inline", "-M", "CONTEXT_SENSITIVITY=FinitePreciseContext"],
+    "gigahorse_args": ["-i", "--disable_scalable_fallback", "--disable_precise_fallback", "--disable_inline", "-M", "CONTEXT_SENSITIVITY=FinitePreciseContext", "-cd", "27"],
     "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 4, 0],
     ["Analytics_BlockHasNoTACBlock", 0, 0]]
 }


### PR DESCRIPTION
The last resort configuration currently employs `FinitePreciseContext` with a maximum context depth of 10, and a `MAX_STACK_HEIGHT` of 30.

It can be disabled using the same `--disable_scalable_fallback` flag as the pre-existing scalable fallback.
If not disabled, the decompilation timeout `-T` limit is divided as follows:
* T/2 to the default pipeline defined in `logic/main.dl`.
* T/4 to the fallback scalable pipeline defined in `logic/fallback_scalable.dl`.
* T/4 to the last resort ultra scalable pipeline defined in `logic/last_resort.dl`.

Difference for `viair-dec23` using a timeout of 600s:

no_resort: 7 timeouts, 63 analyzed with the fallback scalable
last_resort: 0 timeouts, 61 analyzed with the fallback scalable, 9 analyzed with the last resort.

```
3000 total contracts

2993 contracts decompiled/analyzed by no_resort (0 exclusively)
3000 contracts decompiled/analyzed by last_resort (7 exclusively)

ANALYTIC: decomp_time
no_resort (common): 47330.343547582626 (+3.948%)
last_resort (common): 45532.557473659515

ANALYTIC: Analytics_JumpToMany
no_resort (common): 5598 (+1.01%)
last_resort (common): 5542

ANALYTIC: inline_time
no_resort (common): 11571.693530797958 (+7.295%)
last_resort (common): 10784.972083330154

ANALYTIC: client_time
no_resort (common): 2862.5500116348267 (+6.207%)
last_resort (common): 2695.259724378586

ANALYTIC: Analytics_NonModeledMSTORE
no_resort (common): 148892 (+0.1938%)
last_resort (common): 148604

ANALYTIC: Analytics_NonModeledMLOAD
no_resort (common): 134926 (+0.1693%)
last_resort (common): 134698

ANALYTIC: Analytics_CallToSignature
no_resort (common): 14524
last_resort (common): 14500 (-0.1652%)

ANALYTIC: Analytics_EventSignature
no_resort (common): 14545
last_resort (common): 14541 (-0.0275%)

ANALYTIC: Analytics_PublicFunctionArg
no_resort (common): 92402
last_resort (common): 92386 (-0.01732%)

no_resort (common): 2862.5500116348267 (+6.207%)
last_resort (common): 2695.259724378586

ANALYTIC: inline_time
no_resort (common): 11571.693530797958 (+7.295%)
last_resort (common): 10784.972083330154

ANALYTIC: Analytics_NonModeledSSTORE
no_resort (common): 4732
last_resort (common): 4754 (+0.4649%)

ANALYTIC: Analytics_NonModeledSLOAD
no_resort (common): 8450
last_resort (common): 8474 (+0.284%)
```

Overall we are a tiny bit more incomplete (in contracts that would have not timed out using the fallback scalable, but now use the last resort). Looks fine since we want to almost never fail.

I also cleaned up the logic passing the maximum context depth parameter to our decompiler.
+ I simplified arg declarations for `gigahorse.py`.