### PR TITLE
Introduce `LoopNext` relation, change `BlockInStructuredLoop` semantics.

### DIFF
--- a/clientlib/loops.dl
+++ b/clientlib/loops.dl
@@ -2,44 +2,85 @@
 
 //// ** Recognize structured loops and related stuff **
 
-.decl StructuredLoopBackEdge(from:Block, to:Block)
-.decl StructuredLoopHead(s:Block)
+.decl StructuredLoopBackEdge(from: Block, to: Block)
+.decl StructuredLoopHead(s: Block)
 
-StructuredLoopBackEdge(from,to),
+StructuredLoopBackEdge(from, to),
 StructuredLoopHead(to) :-
-  LocalBlockEdge(from,to),
-  Dominates(to,from).
+  LocalBlockEdge(from, to),
+  Dominates(to, from).
 
 // Detect a loop body *without* also capturing surrounding loops (i.e., not just SCC)
-.decl BlockInStructuredLoop(s:Block, loophead:Block)
-BlockInStructuredLoop(backEdgeNode,loophead) :- StructuredLoopBackEdge(backEdgeNode,loophead).
-BlockInStructuredLoop(loophead,loophead) :- StructuredLoopHead(loophead).
+.decl BlockInStructuredLoop(s: Block, loophead: Block)
+/**
+  Base of above relation, excluding reverting statements inside the loop
+*/
+.decl BlockInStructuredLoopBase(s: Block, loophead: Block)
+
+BlockInStructuredLoopBase(backEdgeNode, loophead) :- StructuredLoopBackEdge(backEdgeNode, loophead).
+BlockInStructuredLoopBase(loophead, loophead) :- StructuredLoopHead(loophead).
 
 // Can reach back edge node without going through loop head!
-BlockInStructuredLoop(s,loophead) :-
-  BlockInStructuredLoop(other,loophead),
-  LocalBlockEdge(s,other),
+BlockInStructuredLoopBase(s, loophead) :-
+  BlockInStructuredLoopBase(other, loophead),
+  LocalBlockEdge(s, other),
   other != loophead.
 
-.decl ContainsInnerStructuredLoop(loophead: Block, innerLoopHead: Block)
-ContainsInnerStructuredLoop(loophead,innerLoopHead) :-
-  StructuredLoopHead(loophead),
-  StructuredLoopHead(innerLoopHead),
-  BlockInStructuredLoop(innerLoopHead,loophead),
-  innerLoopHead != loophead.
+BlockInStructuredLoop(block, loop):-
+  BlockInStructuredLoopBase(block, loop).
 
+// If non reverting loop exit exists, consider reverting ones part of the loop
+BlockInStructuredLoop(revertBlock, loop):-
+  LoopNextBase(loop, _),
+  LoopToRevert(loop, revertBlock).
+
+BlockInStructuredLoop(revertBlock, loop):-
+  LoopNextBase(loop, _),
+  LoopToRevert(loop, revertOne),
+  // reverts can span across multiple blocks (connected via direct jumps)
+  LocalBlockPath(revertOne, revertBlock).
 
 .decl StatementInStructuredLoop(s: Statement, loop: Block)
-
 StatementInStructuredLoop(s, loop) :-
    BlockInStructuredLoop(b, loop),
    Statement_Block(s, b).
-   
 
-.decl InnermostStructuredLoop(loophead:Block)
-InnermostStructuredLoop(loophead) :-
-  StructuredLoopHead(loophead),
-  !ContainsInnerStructuredLoop(loophead,_).
+
+/**
+  Block that will be executed after the loop completes.
+  We first define `LoopNextBase` as an exit to a non-terminating block.  
+  If such a fact exists, we consider it `LoopNext` and "exits" to reverting blocks as part of the loop.  
+  If no such fact is produced we consider exits to reverting blocks as `LoopNext` facts.
+  (This mostly covers cases where a revert message is copied using a loop, followed by a `REVERT`).
+*/
+.decl LoopNext(loop: Block, next: Block)
+DEBUG_OUTPUT(LoopNext)
+// Internal relation: Loop exits to a non-terminating block
+.decl LoopNextBase(loop: Block, next: Block)
+// Internal relation: Loop exits to a reverting block
+.decl LoopToRevert(loop: Block, revertBlock: Block)
+
+LoopNext(loop, next):-
+  LoopNextBase(loop, next).
+
+LoopNext(loop, revertBlock):-
+  LoopToRevert(loop, revertBlock),
+  !LoopNextBase(loop, _).
+
+LoopNextBase(loop, out):-
+  BlockInStructuredLoopBase(jmpiBlock, loop),
+  Block_Tail(jmpiBlock, jmpi),
+  JUMPI(jmpi, _, _),
+  LocalBlockEdge(jmpiBlock, out),
+  !BlockInStructuredLoopBase(out, loop),
+  !ThrowBlock(out).
+
+LoopToRevert(loop, revertBlock):-
+  BlockInStructuredLoopBase(jmpiBlock, loop),
+  Block_Tail(jmpiBlock, jmpi),
+  JUMPI(jmpi, _, _),
+  LocalBlockEdge(jmpiBlock, revertBlock),
+  ThrowBlock(revertBlock).
 
 // condVar determines whether a loop is exited
 .decl LoopExitCond(condVar: Variable, loop: Block)
@@ -49,35 +90,32 @@ InnermostStructuredLoop(loophead) :-
 // control flows to other block within the same function
 // TODO: need more info on consequent and alternative branches
 LoopExitCond(condVar, loop) :-
-   BlockInStructuredLoop(jmpiBlock, loop),
+   BlockInStructuredLoopBase(jmpiBlock, loop),
    Block_Tail(jmpiBlock, jmpi),
    JUMPI(jmpi, _, condVar),
    LocalBlockEdge(jmpiBlock, out),
-   !BlockInStructuredLoop(out, loop),
-   !ThrowBlock(out),
+   LoopNext(loop, out),
    LocalBlockEdge(jmpiBlock, in),
-   BlockInStructuredLoop(in, loop).
+   BlockInStructuredLoopBase(in, loop).
 
 
 LoopExitCondPredicateTrue(condVar, loop, jmpiBlock) :-
-   BlockInStructuredLoop(jmpiBlock, loop),
+   BlockInStructuredLoopBase(jmpiBlock, loop),
    Block_Tail(jmpiBlock, jmpi),
    JUMPI(jmpi, _, condVar),
    LocalBlockEdge(jmpiBlock, out),
-   !BlockInStructuredLoop(out, loop),
-   !ThrowBlock(out),
+   LoopNext(loop, out),
    FallthroughEdge(jmpiBlock, in),
-   BlockInStructuredLoop(in, loop).
+   BlockInStructuredLoopBase(in, loop).
 
 LoopExitCondPredicateFalse(condVar, loop, jmpiBlock) :-
-   BlockInStructuredLoop(jmpiBlock, loop),
+   BlockInStructuredLoopBase(jmpiBlock, loop),
    Block_Tail(jmpiBlock, jmpi),
    JUMPI(jmpi, _, condVar),
    FallthroughEdge(jmpiBlock, out),
-   !BlockInStructuredLoop(out, loop),
-   !ThrowBlock(out),
+   LoopNext(loop, out),
    LocalBlockEdge(jmpiBlock, in),
-   BlockInStructuredLoop(in, loop).
+   BlockInStructuredLoopBase(in, loop).
 
 
 .decl CanReachBlock(s:Block, t:Block)

--- a/clients/analytics_client.dl
+++ b/clients/analytics_client.dl
@@ -4,140 +4,25 @@
 // compare between distant versions of the decompiler
 #include "../clientlib/decompiler_imports.dl"
 
-.decl TransferOpcode(op: Opcode)
-.decl Flows(from:Variable, to:Variable)
-    
-// Maps formals args (or locals) to formal return args
-Flows(x, x) :- isVariable(x).
-Flows(x, y) :- Flows(_, x), PHI(_, x, y).
-  Flows(x, y) :-
-  Flows(_, x),
-  Statement_Uses(stmt, x, _),
-  Statement_Defines(stmt, y, _),
-  Statement_Opcode(stmt, op),
-  TransferOpcode(op).
-
-// Case: Flows from formal to formal return
-Flows(actual, actualReturn) :-
-   FunctionFlowSummary(fn, formal, m),
-   FunctionCallReturn(block, fn, _),
-   FormalArgs(fn, formal, n),
-   ActualArgs(block, actual, n),
-   ActualReturnArgs(block, actualReturn, m).
-
-// Case: Flows from local variable to formal return
-// Flows(variable, actualReturn) :-
-//    FunctionFlowSummary(fn, variable, m),
-//    FunctionCallReturn(block, fn, _),
-//    !FormalArgs(fn, variable, _),
-//    ActualReturnArgs(block, actualReturn, m).
-
-// Recursive Case
-Flows(x, z) :- Flows(x, y), Flows(y, z).
-
-// Flows from variable to return argument
-.decl FunctionFlowSummary(fn: Function, from:Variable, n:number)
-
-// Flow from local or formal to formal return
-FunctionFlowSummary(fn, from, n) :-
-   Flows(from, to),
-   FormalReturnArgs(fn, to, n).
-
-// Case: flow within the same function, or back to local
-
-.decl GlobalFlows(from:Variable, to:Variable)
-GlobalFlows(x, y) :- Flows(x, y).
-
-// Case: forward inter-procedural assignment only
-GlobalFlows(x, y) :-
-   GlobalFlows(x, actual),
-   ActualArgs(caller, actual, n),
-   CallGraphEdge(caller, fn),
-   FormalArgs(fn, formal, n),
-   Flows(formal, y).
-
-TransferOpcode("AND").
-TransferOpcode("OR").
-TransferOpcode("XOR").
-TransferOpcode("NOT").
-TransferOpcode("PHI").
-       
-.decl Analytics_DataFlows(a: Variable, b: Variable)
-.output Analytics_DataFlows
-
-Analytics_DataFlows(a, b) :-
-   GlobalFlows(a, b).
-
-.decl Analytics_PolymorphicVariable(a: Variable)
-.output Analytics_PolymorphicVariable
-
-Analytics_PolymorphicVariable(v) :-
-   GlobalFlows(a, v),
-   GlobalFlows(b, v),
-   a != b.
-
-
-.decl Analytics_DataFlowsToSamePublicFunction(a: Variable, b: Variable)
-
-Analytics_DataFlowsToSamePublicFunction(a, b) :-
-   GlobalFlows(a, b),
-   Variable_Function(a, f),
-   Variable_Function(b, f),
-   IsPublicFunction(f).
-
-.decl StmtMissingOperand(s: Statement)
-.input StmtMissingOperand(IO="file", filename="Analytics_StmtMissingOperand.csv", delimiter="\t")
-
-.decl Analytics_MissingDataFlowsToSamePublicFunction(a: Variable, b: Variable)
-.output Analytics_MissingDataFlowsToSamePublicFunction
-       
-Analytics_MissingDataFlowsToSamePublicFunction(a, b) :-
-   StmtMissingOperand(s),
-   Statement_Defines(s, a, _),
-   Analytics_DataFlowsToSamePublicFunction(a, b).
-       
-
-.decl Analytics_DataFlowsToDifferentPublicFunction(a: Variable, b: Variable)
-.output Analytics_DataFlowsToDifferentPublicFunction
-
-Analytics_DataFlowsToDifferentPublicFunction(a, b) :-
-   GlobalFlows(a, b),
-   Variable_Function(a, fa), fa != "0x0",
-   IsPublicFunction(fa),
-   Variable_Function(b, fb), fb != "0x0",
-   IsPublicFunction(fb),
-   fa != fb.
-
-
-
-.decl SizeOfFunction(f: Function, n: number)
-
-SizeOfFunction(f, n) :-
-  InFunction(_, f),
-  n = count : InFunction(_, f).
-
-.decl FunctionIsNotLargest(f: Function)
-
-FunctionIsNotLargest(f) :-
-  SizeOfFunction(f, n),
-  SizeOfFunction(g, m), f != g,
-  ((m > n) ; (m = n, ord(g) > ord(f))).
-
-.decl Analytics_LargestFunction(f: Function, b: Block)
-.output Analytics_LargestFunction
-
-Analytics_LargestFunction(f, b) :- InFunction(b, f), !FunctionIsNotLargest(f).
-
-.decl Analytics_Variables(a: Variable)
-.output Analytics_Variables
-
-Analytics_Variables(a) :-
-   isVariable(a).
-
-
-
 // Has many dependencies, incl memory modeling and data structures
 #include "../clientlib/guards.dl"
+
+/**
+  Loop-related analytics
+*/
+
+.decl Analytics_Loop(loop: Block)
+.output Analytics_Loop
+
+.decl Analytics_NonHighLevelLoop(loop: Block)
+.output Analytics_NonHighLevelLoop
+
+Analytics_Loop(loop):-
+  BlockInStructuredLoop(_, loop).
+
+Analytics_NonHighLevelLoop(loop):-
+  Analytics_Loop(loop),
+  1 != count : LoopNext(loop, _).
 
 /**
  * Memory Modeling


### PR DESCRIPTION
Changes in this PR:
* New `LoopNext` relation now contains the block that will be executed after the loop.
* `BlockInStructuredLoop` now contains reverting blocks that are inside a loop.
* `LoopExit*` relation outputs also became more precise