### PR TITLE
A couple of improvements in `--improved_ssa`

### DIFF
--- a/logic/decompiler_output.dl
+++ b/logic/decompiler_output.dl
@@ -2,8 +2,6 @@
 // PLEASE ALSO CHANGE clientlib/decompiler_imports.dl
 // Also clientlib/function_inliner.dl
 
-.type TACVariable <: symbol
-
 .output ByteCodeHex(IO="file", filename="bytecode.hex")
 
 .decl DecompilerConfig(config: symbol) btree_delete
@@ -90,6 +88,10 @@ TAC_Variable_BlockValue(as(tacvar,TACVariable), irvalue) :-
    // value matches address of block
    STARTSWITH(value, "0x").
 
+TAC_Variable_BlockValue(lVar, value):-
+  TAC_Variable_BlockValue(rVar, value),
+  SimpleAssignment(_, lVar, rVar).
+
 .decl StatementAndBlockInSameFunction(stmt: IRStatement, block: Block, irblock: IRBlock)
 StatementAndBlockInSameFunction(stmt, block, irblock) :-
   Statement_IRStatement(_, func, stmt),
@@ -102,6 +104,10 @@ TAC_Variable_Value(as(tacvar, TACVariable), value) :-
    lastFunctional.Variable_Stmt_String(var, stmt, tacvar),
    lastLocal.Variable_Value(var, value),
    STARTSWITH(value, "0x").
+
+TAC_Variable_Value(lVar, value):-
+  TAC_Variable_Value(rVar, value),
+  SimpleAssignment(_, lVar, rVar).
 
 /**
   __HACK__ to get around the patterns produced by the new `--via-ir` compilation pipeline.
@@ -258,6 +264,16 @@ TAC_Block(phiStmt, block) :-
 //TAC_Block(callStmt, block) :-
 //   BasicBlock_CALL(block, callStmt).
 
+.decl SimpleAssignment(irStmt: IRStatement, lvar: TACVariable, rvar: TACVariable)
+SimpleAssignment(irStmt, lVar, rVar):-
+  (TAC_Op(irStmt, "MOV"); TAC_Op(irStmt, "MOV2")),
+  TAC_Use(irStmt, rVar, 0),
+  TAC_Def(irStmt, lVar, 0).
+
+SimpleAssignment(irStmt, lVar, rVar):-
+  TAC_Op(irStmt, "MOV2"),
+  TAC_Use(irStmt, rVar, 1),
+  TAC_Def(irStmt, lVar, 1).
 
 /***********
  *  Function-discovery outputs to visualization scripts

--- a/logic/functions.dl
+++ b/logic/functions.dl
@@ -526,11 +526,7 @@ StackBalancingBlockJumpImprecision(block, func):-
 #define BLOCK_TO_IRBLOCK(b) as(b, IRBlock)
 #define STATEMENT_TO_IRSTATEMENT(s) as(s, IRStatement)
 #define FUNCTION_TO_IRFUNCTION(f) as(f, IRBlock)
- 
-.type IRBlock <: symbol
-// exploit type checking in new IR
-#define IRFunction IRBlock
-.type IRStatement <: symbol
+
 
 .decl Block_IRBlock(block: Block, func: Block, irblock: IRBlock)
 .decl Function_IRFunction(func: Block, irFunc: IRFunction)

--- a/logic/functions.dl
+++ b/logic/functions.dl
@@ -1245,6 +1245,29 @@ INIT_FSTACK_FROM_LOCAL(firstFunctional, postTrans)
 
 #else
 
+.decl DUPOrSWAPStatementUsesVar(stmt: IRStatement, var: Variable)
+
+DUPOrSWAPStatementUsesVar(stmt, var):-
+  IRStatement_Opcode(stmt, opcode),
+  postTrans.DUPN(opcode, n),
+  IRStatement_Block(stmt, block),
+  firstFunctional.IRBeforeLocalStackContents(stmt, n - 1, index),
+  firstFunctional.FunctionalBlockInputContents(block, index, var).
+
+DUPOrSWAPStatementUsesVar(stmt, var):-
+  IRStatement_Opcode(stmt, opcode),
+  postTrans.SWAPN(opcode, _),
+  IRStatement_Block(stmt, block),
+  firstFunctional.IRBeforeLocalStackContents(stmt, 0, index),
+  firstFunctional.FunctionalBlockInputContents(block, index, var).
+
+DUPOrSWAPStatementUsesVar(stmt, var):-
+  IRStatement_Opcode(stmt, opcode),
+  postTrans.SWAPN(opcode, n),
+  IRStatement_Block(stmt, block),
+  firstFunctional.IRBeforeLocalStackContents(stmt, n, index),
+  firstFunctional.FunctionalBlockInputContents(block, index, var).
+
 .decl FunctionalBlockUsesPHIVar(block: IRBlock, var: Variable, index: StackIndex)
 DEBUG_OUTPUT(FunctionalBlockUsesPHIVar)
 
@@ -1345,6 +1368,7 @@ DoesNotPostDominate(candidate, s) :-
   s != candidate.
 
 .decl PostDominates(postdominator: IRBlock, s: IRBlock)
+// .output PostDominates(IO="file", filename="FLPostDominates.csv", delimiter="\t")
 PostDominates(postdominator,s) :-
   IRInFunction(postdominator, f),
   IRInFunction(s, f),
@@ -1460,6 +1484,16 @@ DUPTouchesPHIWithLoss(stmt, var):-
   firstFunctional.IRBeforeLocalStackContents(stmt, n, var),
   IRStatement_Opcode(stmt, opcode),
   postTrans.SWAPN(opcode, n).
+
+DUPTouchesPHIWithLoss(stmt, var):-
+  FunctionalBlockUsesPHIVar(_, var, _),
+  DUPOrSWAPStatementUsesVar(stmt, var),
+  IRStatement_Block(stmt, touchBlock),
+  firstFunctional.FunctionalStatement_Defines(defStmt, var, _),
+  IRStatement_Block(defStmt, defBlock),
+  DoesNotPostDominate(touchBlock, defBlock).
+
+//   IRInFunction(defBlock, func),
 
 // .output firstFunctional.IRBeforeLocalStackContents, firstFunctional.FunctionalBlockInputContents, firstFunctional.FunctionalBlockOutputContents, postTrans.StatementStackDelta, NumberOfFunctionReturnArguments, NumberOfFunctionArguments
 

--- a/logic/types_defs.dl
+++ b/logic/types_defs.dl
@@ -37,3 +37,12 @@
 .type OptionalSelector = NoSelector{}
                       | SelectorVariable{selector: Variable}
                       | SelectorStackIndex{block: Block, selector: StackIndex}
+
+
+
+.type IRBlock <: symbol
+// exploit type checking in new IR
+#define IRFunction IRBlock
+.type IRStatement <: symbol
+
+.type TACVariable <: symbol


### PR DESCRIPTION
Add `MOV` instructions when an instruction touches a PHI (r)variable defined in an earlier block that is not postdominated by the later one.
Also improve completeness of the initial `TAC_Variable_Value` facts.