### PR TITLE
fix(loops): better handle loops that include CFG imprecision

### DIFF
--- a/clientlib/dominators.dl
+++ b/clientlib/dominators.dl
@@ -390,3 +390,17 @@ BlockMustReturn(block):-
   BlockMayReturn(block),
   !BlockMayCallOther(block),
   !BlockMayThrow(block).
+
+
+.decl JumpToMany(block: Block)
+DEBUG_OUTPUT(JumpToMany)
+JumpToMany(block):-
+  (Statement_Opcode(jump, "JUMP");
+  Statement_Opcode(jump, "CALLPRIVATE")),
+  Statement_Block(jump, block),
+  nEdges = count : LocalBlockEdge(block, _), nEdges > 1.
+
+JumpToMany(block):-
+  Statement_Opcode(jump, "JUMPI"),
+  Statement_Block(jump, block),
+  nEdges = count : LocalBlockEdge(block, _), nEdges > 2.

--- a/clientlib/loops.dl
+++ b/clientlib/loops.dl
@@ -70,7 +70,7 @@ StatementInStructuredLoop(s, loop) :-
    BlockInStructuredLoop(b, loop),
    Statement_Block(s, b).
 
-.output LoopWithManyExitsHasAdditionalBlocks, LoopWithManyExitsHasSingleConvergenceBlock, StructuredLoopBase_ElementNumber
+// .output LoopWithManyExitsHasAdditionalBlocks, LoopWithManyExitsHasSingleConvergenceBlock, StructuredLoopBase_ElementNumber
 /**
   Block that will be executed after the loop completes.
   We first define `LoopNextBase` as an exit to a non immediately terminating block.  
@@ -92,8 +92,10 @@ DEBUG_OUTPUT(LoopNextBase)
 // A terminating or reverting exist can be reached from outside the loop. 
 .decl LoopToSecondaryExitReachableFromOutside(loop: Block, exit: Block)
 
+// A loop with at least one jump-to-many instance.
+// When this is detected some extra, precise logic is disabled to avoid spurious inferences
 .decl LoopWithCFGImprecision(loop: Block)
-.output LoopWithCFGImprecision
+DEBUG_OUTPUT(LoopWithCFGImprecision)
 
 LoopNext(loop, next):-
   LoopNextBase(loop, next),
@@ -125,11 +127,11 @@ LoopToRevertingBlock(loop, termBlock):-
   LocalBlockEdge(jmpiBlock, termBlock),
   !BlockInStructuredLoopBase(termBlock, loop), // need to specify this as blockMuchThrow captures the loop body of reverting loops
   !LoopToSecondaryExitReachableFromOutside(loop, termBlock),
-  !BlockMustThrow(loop),
+  !BlockMustThrow(loop), // ensure it is not an always-reverting loop (copy of error data, then revert)
   !ThrowBlock(loop),
   (ThrowBlock(termBlock); BlockMustThrow(termBlock)).
 
-.output LoopToExitingBlock, LoopToRevertingBlock, LoopToSecondaryExitReachableFromOutside, BlockMustThrow, BlockMustReturn, BlockMayReturn, BlockMayThrow, Dominates, PostDominates, BlockInStructuredLoopBase
+// .output LoopToExitingBlock, LoopToRevertingBlock, LoopToSecondaryExitReachableFromOutside, BlockMustThrow, BlockMustReturn, BlockMayReturn, BlockMayThrow, Dominates, PostDominates, BlockInStructuredLoopBase
 LoopToExitingBlock(loop, termBlock):-
   BlockInStructuredLoopBase(jmpiBlock, loop),
   Block_Tail(jmpiBlock, jmpi),
@@ -170,6 +172,7 @@ LoopNextBase(loop, termBlock):-
   StructuredLoopBase_ElementNumber(loop, 1),
   (ThrowBlock(termBlock); BlockMustThrow(termBlock); BlockTerminates(termBlock)).
 
+// if we find an always-reverting block, just add a `LoopNextBase` fact
 LoopNextBase(loop, termBlock):-
   BlockInStructuredLoopBase(jmpiBlock, loop),
   Block_Tail(jmpiBlock, jmpi),
@@ -177,7 +180,7 @@ LoopNextBase(loop, termBlock):-
   LocalBlockEdge(jmpiBlock, termBlock),
   !BlockInStructuredLoopBase(termBlock, loop), // need to specify this as blockMuchThrow captures the loop body of reverting loops
   !LoopToSecondaryExitReachableFromOutside(loop, termBlock),
-  (BlockMustThrow(loop); ThrowBlock(loop)),
+  (ThrowBlock(loop); BlockMustThrow(loop)),
   (ThrowBlock(termBlock); BlockMustThrow(termBlock)).
 
 LoopWithCFGImprecision(loop):-
@@ -200,7 +203,7 @@ LocalBlockPathExclBackEdges(block, block):-
 LocalBlockPathExclBackEdges(from, to):-
   LocalBlockPathExclBackEdges(from, mid),
   LocalBlockEdge(mid, to),
-  !JumpToMany(mid),
+  !JumpToMany(mid), // filter out imprecision
   !StructuredLoopBackEdge(mid, to).
 
 .decl LoopHasMultipleExitPoints(loop: Block, n_exit: number)
@@ -245,7 +248,7 @@ LoopWithManyExitsHasSingleConvergenceBlock(loop, conBlock):-
 
 /**
   When `LoopWithManyExitsHasSingleConvergenceBlock` holds, we find blocks from
-  `LoopNextBase` to the convergence bl0xdda0xbcock, to consider them part of the loop.
+  `LoopNextBase` to the convergence block, to consider them part of the loop.
 */
 .decl LoopWithManyExitsHasAdditionalBlocks(loop: Block, addBlock: Block)
 
@@ -259,7 +262,7 @@ LoopWithManyExitsHasAdditionalBlocks(loop, addBlock):-
   LoopWithManyExitsHasSingleConvergenceBlock(loop, conBlock),
   LocalBlockEdge(block, addBlock),
   addBlock != conBlock,
-  !JumpToMany(block),
+  !JumpToMany(block), // filter out imprecision
   !StructuredLoopBackEdge(block, addBlock).
 
 /**

--- a/clientlib/loops.dl
+++ b/clientlib/loops.dl
@@ -62,14 +62,15 @@ BlockInStructuredLoop(termBlock, loop):-
 
 BlockInStructuredLoop(addBlock, loop):-
   LoopWithManyExitsHasSingleConvergenceBlock(loop, _),
-  LoopWithManyExitsHasAdditionalBlocks(loop, addBlock).
+  LoopWithManyExitsHasAdditionalBlocks(loop, addBlock),
+  !LoopWithCFGImprecision(loop).
 
 .decl StatementInStructuredLoop(s: Statement, loop: Block)
 StatementInStructuredLoop(s, loop) :-
    BlockInStructuredLoop(b, loop),
    Statement_Block(s, b).
 
-// .output LoopWithManyExitsHasAdditionalBlocks, LoopWithManyExitsHasSingleConvergenceBlock, StructuredLoopBase_ElementNumber
+.output LoopWithManyExitsHasAdditionalBlocks, LoopWithManyExitsHasSingleConvergenceBlock, StructuredLoopBase_ElementNumber
 /**
   Block that will be executed after the loop completes.
   We first define `LoopNextBase` as an exit to a non immediately terminating block.  
@@ -90,6 +91,9 @@ DEBUG_OUTPUT(LoopNextBase)
 
 // A terminating or reverting exist can be reached from outside the loop. 
 .decl LoopToSecondaryExitReachableFromOutside(loop: Block, exit: Block)
+
+.decl LoopWithCFGImprecision(loop: Block)
+.output LoopWithCFGImprecision
 
 LoopNext(loop, next):-
   LoopNextBase(loop, next),
@@ -121,9 +125,11 @@ LoopToRevertingBlock(loop, termBlock):-
   LocalBlockEdge(jmpiBlock, termBlock),
   !BlockInStructuredLoopBase(termBlock, loop), // need to specify this as blockMuchThrow captures the loop body of reverting loops
   !LoopToSecondaryExitReachableFromOutside(loop, termBlock),
+  !BlockMustThrow(loop),
+  !ThrowBlock(loop),
   (ThrowBlock(termBlock); BlockMustThrow(termBlock)).
 
-// .output LoopToExitingBlock, LoopToRevertingBlock, LoopToSecondaryExitReachableFromOutside, BlockMustThrow, BlockMustReturn, BlockMayReturn, BlockMayThrow, Dominates, PostDominates
+.output LoopToExitingBlock, LoopToRevertingBlock, LoopToSecondaryExitReachableFromOutside, BlockMustThrow, BlockMustReturn, BlockMayReturn, BlockMayThrow, Dominates, PostDominates, BlockInStructuredLoopBase
 LoopToExitingBlock(loop, termBlock):-
   BlockInStructuredLoopBase(jmpiBlock, loop),
   Block_Tail(jmpiBlock, jmpi),
@@ -163,6 +169,21 @@ LoopNextBase(loop, termBlock):-
   LocalBlockEdge(jmpiBlock, termBlock),
   StructuredLoopBase_ElementNumber(loop, 1),
   (ThrowBlock(termBlock); BlockMustThrow(termBlock); BlockTerminates(termBlock)).
+
+LoopNextBase(loop, termBlock):-
+  BlockInStructuredLoopBase(jmpiBlock, loop),
+  Block_Tail(jmpiBlock, jmpi),
+  JUMPI(jmpi, _, _),
+  LocalBlockEdge(jmpiBlock, termBlock),
+  !BlockInStructuredLoopBase(termBlock, loop), // need to specify this as blockMuchThrow captures the loop body of reverting loops
+  !LoopToSecondaryExitReachableFromOutside(loop, termBlock),
+  (BlockMustThrow(loop); ThrowBlock(loop)),
+  (ThrowBlock(termBlock); BlockMustThrow(termBlock)).
+
+LoopWithCFGImprecision(loop):-
+  BlockInStructuredLoopBase(block, loop),
+  JumpToMany(block).
+
 /**
   The following relations are about 
 */
@@ -179,6 +200,7 @@ LocalBlockPathExclBackEdges(block, block):-
 LocalBlockPathExclBackEdges(from, to):-
   LocalBlockPathExclBackEdges(from, mid),
   LocalBlockEdge(mid, to),
+  !JumpToMany(mid),
   !StructuredLoopBackEdge(mid, to).
 
 .decl LoopHasMultipleExitPoints(loop: Block, n_exit: number)
@@ -223,7 +245,7 @@ LoopWithManyExitsHasSingleConvergenceBlock(loop, conBlock):-
 
 /**
   When `LoopWithManyExitsHasSingleConvergenceBlock` holds, we find blocks from
-  `LoopNextBase` to the convergence block, to consider them part of the loop.
+  `LoopNextBase` to the convergence bl0xdda0xbcock, to consider them part of the loop.
 */
 .decl LoopWithManyExitsHasAdditionalBlocks(loop: Block, addBlock: Block)
 
@@ -236,7 +258,9 @@ LoopWithManyExitsHasAdditionalBlocks(loop, addBlock):-
   LoopWithManyExitsHasAdditionalBlocks(loop, block),
   LoopWithManyExitsHasSingleConvergenceBlock(loop, conBlock),
   LocalBlockEdge(block, addBlock),
-  addBlock != conBlock.
+  addBlock != conBlock,
+  !JumpToMany(block),
+  !StructuredLoopBackEdge(block, addBlock).
 
 /**
   Basic relation for identifying post-iteration blocks.

--- a/clients/analytics_client.dl
+++ b/clients/analytics_client.dl
@@ -43,18 +43,6 @@ Analytics_NonHighLevelLoopFiltered(loop):-
   !HighLevelLoop(loop),
   0 = count: {BlockInStructuredLoop(block, loop), JumpToMany(block)}.
 
-.decl JumpToMany(block: Block)
-JumpToMany(block):-
-  (Statement_Opcode(jump, "JUMP");
-  Statement_Opcode(jump, "CALLPRIVATE")),
-  Statement_Block(jump, block),
-  nEdges = count : LocalBlockEdge(block, _), nEdges > 1.
-
-JumpToMany(block):-
-  Statement_Opcode(jump, "JUMPI"),
-  Statement_Block(jump, block),
-  nEdges = count : LocalBlockEdge(block, _), nEdges > 2.
-
 /**
  * Memory Modeling
  */


### PR DESCRIPTION
The logic was tuned for loops with little or no imprecision (i.e. jump-to-manys) and resulted in spurious inferences when imprecision appeared.
This PR puts a bunch of safeguards to avoid these spurious inferences.