### PR TITLE
feat(tests): speedup tests by compiling analysis binaries during setup

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,30 @@
+import subprocess
+import pytest
+from os.path import join, dirname, abspath
+
+GIGAHORSE_TOOLCHAIN_ROOT = dirname(abspath(__file__))
+
+
+@pytest.fixture(scope="session", autouse=True)
+def gigahorse_prereqs():
+    """Runs once, before any test_gigahorse case executes."""
+    common_clients = ["-C", join(GIGAHORSE_TOOLCHAIN_ROOT, 'clients/analytics_client.dl')]
+    gigahorse_args = ["--disable_scalable_fallback"]
+    result = subprocess.run(
+            [
+                'python3',
+                join(GIGAHORSE_TOOLCHAIN_ROOT, 'gigahorse.py'),
+                join(GIGAHORSE_TOOLCHAIN_ROOT, 'examples/long_running.hex'),
+                '--restart',
+                '--jobs', '1',
+                '--working_dir', ".tmp_pretest",
+                *common_clients,
+                *gigahorse_args
+            ],
+            capture_output=True
+        )
+    if result.returncode != 0:
+        print(result)
+        pytest.exit(f"Compilation failed {result.stderr}.", returncode=1)
+    yield
+    # anything after yield runs once at the very end, e.g. cleanup

--- a/conftest.py
+++ b/conftest.py
@@ -9,7 +9,7 @@ import sys
 GIGAHORSE_TOOLCHAIN_ROOT = dirname(abspath(__file__))
 
 def pytest_sessionstart(session):
-    print("\n[gigahorse] running prereq compilation before tests begin...\n", file=sys.stderr)
+    print("\n[gigahorse] Running analysis binary compilation before tests begin...\n", file=sys.stderr)
 
 @pytest.fixture(scope="session", autouse=True)
 def gigahorse_prereqs(tmp_path_factory, worker_id):
@@ -17,7 +17,6 @@ def gigahorse_prereqs(tmp_path_factory, worker_id):
 
     def _run_prereq(working_dir: Path):
         common_clients = ["-C", join(GIGAHORSE_TOOLCHAIN_ROOT, "clients/analytics_client.dl")]
-        gigahorse_args = ["--disable_scalable_fallback"]
         result = subprocess.run(
             [
                 "python3",
@@ -26,13 +25,13 @@ def gigahorse_prereqs(tmp_path_factory, worker_id):
                 "--restart",
                 "--jobs", "1",
                 "--working_dir", str(working_dir),
+                "--disable_scalable_fallback",
                 *common_clients,
-                *gigahorse_args,
             ],
             capture_output=True,
         )
         if result.returncode != 0:
-            pytest.exit(f"Prereq compilation failed:\n{result.stderr.decode()}", returncode=1)
+            pytest.exit(f"Analysis binary compilation failed:\n{result.stderr.decode()}", returncode=1)
 
     if worker_id == "master":
         _run_prereq(tmp_path_factory.mktemp("pretest"))

--- a/conftest.py
+++ b/conftest.py
@@ -1,30 +1,49 @@
 import subprocess
-import pytest
+from pathlib import Path
 from os.path import join, dirname, abspath
+
+import pytest
+from filelock import FileLock
+import sys
 
 GIGAHORSE_TOOLCHAIN_ROOT = dirname(abspath(__file__))
 
+def pytest_sessionstart(session):
+    print("\n[gigahorse] running prereq compilation before tests begin...\n", file=sys.stderr)
 
 @pytest.fixture(scope="session", autouse=True)
-def gigahorse_prereqs():
-    """Runs once, before any test_gigahorse case executes."""
-    common_clients = ["-C", join(GIGAHORSE_TOOLCHAIN_ROOT, 'clients/analytics_client.dl')]
-    gigahorse_args = ["--disable_scalable_fallback"]
-    result = subprocess.run(
+def gigahorse_prereqs(tmp_path_factory, worker_id):
+    """Compiles core .dl files exactly once, shared across all workers."""
+
+    def _run_prereq(working_dir: Path):
+        common_clients = ["-C", join(GIGAHORSE_TOOLCHAIN_ROOT, "clients/analytics_client.dl")]
+        gigahorse_args = ["--disable_scalable_fallback"]
+        result = subprocess.run(
             [
-                'python3',
-                join(GIGAHORSE_TOOLCHAIN_ROOT, 'gigahorse.py'),
-                join(GIGAHORSE_TOOLCHAIN_ROOT, 'examples/long_running.hex'),
-                '--restart',
-                '--jobs', '1',
-                '--working_dir', ".tmp_pretest",
+                "python3",
+                join(GIGAHORSE_TOOLCHAIN_ROOT, "gigahorse.py"),
+                join(GIGAHORSE_TOOLCHAIN_ROOT, "examples/long_running.hex"),
+                "--restart",
+                "--jobs", "1",
+                "--working_dir", str(working_dir),
                 *common_clients,
-                *gigahorse_args
+                *gigahorse_args,
             ],
-            capture_output=True
+            capture_output=True,
         )
-    if result.returncode != 0:
-        print(result)
-        pytest.exit(f"Compilation failed {result.stderr}.", returncode=1)
+        if result.returncode != 0:
+            pytest.exit(f"Prereq compilation failed:\n{result.stderr.decode()}", returncode=1)
+
+    if worker_id == "master":
+        _run_prereq(tmp_path_factory.mktemp("pretest"))
+    else:
+        root_tmp_dir = tmp_path_factory.getbasetemp().parent
+        lock_path = root_tmp_dir / "gigahorse_prereq.lock"
+        done_path = root_tmp_dir / "gigahorse_prereq.done"
+
+        with FileLock(str(lock_path)):
+            if not done_path.exists():
+                _run_prereq(root_tmp_dir / "pretest_shared")
+                done_path.write_text("done")
+
     yield
-    # anything after yield runs once at the very end, e.g. cleanup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,8 @@ Documentation = "https://github.com/nevillegrech/gigahorse-toolchain#readme"
 dev = [
     "mypy>=1.13",
     "pytest>=8.3",
+    "pytest-xdist>=3.8",
+    "filelock>=3.15",
 ]
 
 [tool.uv]

--- a/tests/core-decompiler/00a3c53138715e8c2b8c078c7821e763-incomplete-with-opt.json
+++ b/tests/core-decompiler/00a3c53138715e8c2b8c078c7821e763-incomplete-with-opt.json
@@ -1,6 +1,6 @@
 {
     "client_path": null,
-    "gigahorse_args": ["-i", "--disable_inline"],
+    "gigahorse_args": ["--disable_inline"],
     "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 0, 0], ["Analytics_BlockHasNoTACBlock", 0, 0],
                            ["Analytics_MissingJumpTargetSomeCtx", 0, 0], ["Analytics_MissingJumpTargetAnyCtx", 0, 0],
                            ["Analytics_DoubleDef", 0, 0]]

--- a/tests/core-decompiler/00a3c53138715e8c2b8c078c7821e763-incomplete-with-opt.json
+++ b/tests/core-decompiler/00a3c53138715e8c2b8c078c7821e763-incomplete-with-opt.json
@@ -1,6 +1,6 @@
 {
     "client_path": null,
-    "gigahorse_args": ["--disable_inline"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 0, 0], ["Analytics_BlockHasNoTACBlock", 0, 0],
                            ["Analytics_MissingJumpTargetSomeCtx", 0, 0], ["Analytics_MissingJumpTargetAnyCtx", 0, 0],
                            ["Analytics_DoubleDef", 0, 0]]

--- a/tests/core-decompiler/0x4679ea96f15a4742274dc72e1a58e01af333d302-incomplete-transferFrom.json
+++ b/tests/core-decompiler/0x4679ea96f15a4742274dc72e1a58e01af333d302-incomplete-transferFrom.json
@@ -1,6 +1,6 @@
 {
     "client_path": null,
-    "gigahorse_args": ["-i", "--disable_inline"],
+    "gigahorse_args": ["--disable_inline"],
     "expected_analytics": [["Analytics_JumpToMany", 1, 0], ["Analytics_UnreachableBlock", 0, 0], ["Analytics_BlockHasNoTACBlock", 0, 0],
                            ["Analytics_MissingJumpTargetSomeCtx", 0, 0], ["Analytics_MissingJumpTargetAnyCtx", 0, 0], ["Analytics_DoubleDef", 0, 0]]
 }

--- a/tests/core-decompiler/0x4679ea96f15a4742274dc72e1a58e01af333d302-incomplete-transferFrom.json
+++ b/tests/core-decompiler/0x4679ea96f15a4742274dc72e1a58e01af333d302-incomplete-transferFrom.json
@@ -1,6 +1,6 @@
 {
     "client_path": null,
-    "gigahorse_args": ["--disable_inline"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_JumpToMany", 1, 0], ["Analytics_UnreachableBlock", 0, 0], ["Analytics_BlockHasNoTACBlock", 0, 0],
                            ["Analytics_MissingJumpTargetSomeCtx", 0, 0], ["Analytics_MissingJumpTargetAnyCtx", 0, 0], ["Analytics_DoubleDef", 0, 0]]
 }

--- a/tests/core-decompiler/0xd129D8C12f0e7aA51157D9e6cc3F7Ece2dc84ecD-mevbot.json
+++ b/tests/core-decompiler/0xd129D8C12f0e7aA51157D9e6cc3F7Ece2dc84ecD-mevbot.json
@@ -1,6 +1,6 @@
 {
     "client_path": null,
-    "gigahorse_args": ["-i", "--disable_inline", "-T", "200"],
+    "gigahorse_args": ["--disable_inline", "-T", "200"],
     "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 0, 0], ["Analytics_BlockHasNoTACBlock", 0, 0],
     ["Analytics_MissingEdgeInTAC", 0, 0], ["Analytics_MissingJumpTargetSomeCtx", 0, 0], ["Analytics_MissingJumpTargetAnyCtx", 0, 0],
     ["Analytics_DoubleDef", 0, 0]]

--- a/tests/core-decompiler/0xd129D8C12f0e7aA51157D9e6cc3F7Ece2dc84ecD-mevbot.json
+++ b/tests/core-decompiler/0xd129D8C12f0e7aA51157D9e6cc3F7Ece2dc84ecD-mevbot.json
@@ -1,6 +1,6 @@
 {
     "client_path": null,
-    "gigahorse_args": ["--disable_inline", "-T", "200"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 0, 0], ["Analytics_BlockHasNoTACBlock", 0, 0],
     ["Analytics_MissingEdgeInTAC", 0, 0], ["Analytics_MissingJumpTargetSomeCtx", 0, 0], ["Analytics_MissingJumpTargetAnyCtx", 0, 0],
     ["Analytics_DoubleDef", 0, 0]]

--- a/tests/core-decompiler/11116421e77b80a26b273843d54829d8.json
+++ b/tests/core-decompiler/11116421e77b80a26b273843d54829d8.json
@@ -1,6 +1,6 @@
 {
     "client_path": null,
-    "gigahorse_args": ["-i", "--disable_inline"],
+    "gigahorse_args": ["--disable_inline"],
     "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 0, 0], ["Analytics_BlockHasNoTACBlock", 0, 0],
                            ["Analytics_DoubleDef", 0, 0],
                            ["Analytics_MissingJumpTargetSomeCtx", 0, 0], ["Analytics_MissingJumpTargetAnyCtx", 0, 0],

--- a/tests/core-decompiler/11116421e77b80a26b273843d54829d8.json
+++ b/tests/core-decompiler/11116421e77b80a26b273843d54829d8.json
@@ -1,6 +1,6 @@
 {
     "client_path": null,
-    "gigahorse_args": ["--disable_inline"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 0, 0], ["Analytics_BlockHasNoTACBlock", 0, 0],
                            ["Analytics_DoubleDef", 0, 0],
                            ["Analytics_MissingJumpTargetSomeCtx", 0, 0], ["Analytics_MissingJumpTargetAnyCtx", 0, 0],

--- a/tests/core-decompiler/134a17969a5a108b721d9ff270bc6dca_callprivatei.json
+++ b/tests/core-decompiler/134a17969a5a108b721d9ff270bc6dca_callprivatei.json
@@ -1,6 +1,6 @@
 {
     "client_path": null,
-    "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback", "--early_cloning"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_StmtMissingOperand", 0, 0],
     ["Analytics_UnreachableBlock", 0 ,0], ["Analytics_BlockHasNoTACBlock", 0, 0], ["Analytics_DoubleDef", 0, 0],
     ["Analytics_PrivateFunctionMatchesMetadata", 58, 0],

--- a/tests/core-decompiler/2eb080bb2a31076a82ed1433ed020184-missingop.json
+++ b/tests/core-decompiler/2eb080bb2a31076a82ed1433ed020184-missingop.json
@@ -1,6 +1,6 @@
 {
     "client_path": null,
-    "gigahorse_args": ["--disable_inline"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_BlockHasNoTACBlock", 0, 0], ["Analytics_StmtMissingOperand", 1, 0],
                            ["Analytics_MissingJumpTargetSomeCtx", 0, 0], ["Analytics_MissingJumpTargetAnyCtx", 0, 0], ["Analytics_DoubleDef", 0, 0]]
 }

--- a/tests/core-decompiler/2eb080bb2a31076a82ed1433ed020184-missingop.json
+++ b/tests/core-decompiler/2eb080bb2a31076a82ed1433ed020184-missingop.json
@@ -1,6 +1,6 @@
 {
     "client_path": null,
-    "gigahorse_args": ["-i", "--disable_inline"],
+    "gigahorse_args": ["--disable_inline"],
     "expected_analytics": [["Analytics_BlockHasNoTACBlock", 0, 0], ["Analytics_StmtMissingOperand", 1, 0],
                            ["Analytics_MissingJumpTargetSomeCtx", 0, 0], ["Analytics_MissingJumpTargetAnyCtx", 0, 0], ["Analytics_DoubleDef", 0, 0]]
 }

--- a/tests/core-decompiler/49ceac2769b83ac04f76bb527e62ed01.json
+++ b/tests/core-decompiler/49ceac2769b83ac04f76bb527e62ed01.json
@@ -1,6 +1,6 @@
 {
     "client_path": null,
-    "gigahorse_args": ["-i", "--disable_inline"],
+    "gigahorse_args": ["--disable_inline"],
     "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 0, 0], ["Analytics_BlockHasNoTACBlock", 0, 0],
                            ["Analytics_MissingJumpTargetSomeCtx", 0, 0], ["Analytics_MissingJumpTargetAnyCtx", 0, 0], ["Analytics_DoubleDef", 0, 0]]
 }

--- a/tests/core-decompiler/49ceac2769b83ac04f76bb527e62ed01.json
+++ b/tests/core-decompiler/49ceac2769b83ac04f76bb527e62ed01.json
@@ -1,6 +1,6 @@
 {
     "client_path": null,
-    "gigahorse_args": ["--disable_inline"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 0, 0], ["Analytics_BlockHasNoTACBlock", 0, 0],
                            ["Analytics_MissingJumpTargetSomeCtx", 0, 0], ["Analytics_MissingJumpTargetAnyCtx", 0, 0], ["Analytics_DoubleDef", 0, 0]]
 }

--- a/tests/core-decompiler/7A250D5630B4CF539739DF2C5DACB4C659F2488D-UniRouterV2.json
+++ b/tests/core-decompiler/7A250D5630B4CF539739DF2C5DACB4C659F2488D-UniRouterV2.json
@@ -1,6 +1,6 @@
 {
     "client_path": null,
-    "gigahorse_args": ["-i", "--disable_inline", "--improved_ssa"],
+    "gigahorse_args": ["-i", "--disable_inline", "--improved_ssa", "--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 0, 0], ["Analytics_BlockHasNoTACBlock", 0, 0], ["Analytics_DataFlowImprecision", 0, 0],
                            ["Analytics_MissingJumpTargetSomeCtx", 0, 0], ["Analytics_MissingJumpTargetAnyCtx", 0, 0], ["Analytics_DoubleDef", 0, 0]]
 }

--- a/tests/core-decompiler/F650C3D88D12DB855B8BF7D11BE6C55A4E07DCC9.json
+++ b/tests/core-decompiler/F650C3D88D12DB855B8BF7D11BE6C55A4E07DCC9.json
@@ -1,6 +1,6 @@
 {
     "client_path": null,
-    "gigahorse_args": ["--disable_inline"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 7, 0], ["Analytics_BlockHasNoTACBlock", 0, 0],
                             ["Analytics_PublicFunction", 51, 0],
                            ["Analytics_MissingJumpTargetSomeCtx", 0, 0], ["Analytics_MissingJumpTargetAnyCtx", 0, 0], ["Analytics_DoubleDef", 0, 0]]

--- a/tests/core-decompiler/F650C3D88D12DB855B8BF7D11BE6C55A4E07DCC9.json
+++ b/tests/core-decompiler/F650C3D88D12DB855B8BF7D11BE6C55A4E07DCC9.json
@@ -1,6 +1,6 @@
 {
     "client_path": null,
-    "gigahorse_args": ["-i", "--disable_inline"],
+    "gigahorse_args": ["--disable_inline"],
     "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 7, 0], ["Analytics_BlockHasNoTACBlock", 0, 0],
                             ["Analytics_PublicFunction", 51, 0],
                            ["Analytics_MissingJumpTargetSomeCtx", 0, 0], ["Analytics_MissingJumpTargetAnyCtx", 0, 0], ["Analytics_DoubleDef", 0, 0]]

--- a/tests/core-decompiler/WETH.json
+++ b/tests/core-decompiler/WETH.json
@@ -1,6 +1,6 @@
 {
     "client_path": null,
-    "gigahorse_args": ["--disable_inline"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 0, 0], ["Analytics_BlockHasNoTACBlock", 0, 0],
                            ["Analytics_MissingJumpTargetSomeCtx", 0, 0], ["Analytics_MissingJumpTargetAnyCtx", 0, 0],
                            ["Analytics_PublicFunction", 12, 0]]

--- a/tests/core-decompiler/WETH.json
+++ b/tests/core-decompiler/WETH.json
@@ -1,6 +1,6 @@
 {
     "client_path": null,
-    "gigahorse_args": ["-i", "--disable_inline"],
+    "gigahorse_args": ["--disable_inline"],
     "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 0, 0], ["Analytics_BlockHasNoTACBlock", 0, 0],
                            ["Analytics_MissingJumpTargetSomeCtx", 0, 0], ["Analytics_MissingJumpTargetAnyCtx", 0, 0],
                            ["Analytics_PublicFunction", 12, 0]]

--- a/tests/early-cloning/025e998a619d32b096abc559fb0e4b4b_preInsertor.json
+++ b/tests/early-cloning/025e998a619d32b096abc559fb0e4b4b_preInsertor.json
@@ -1,6 +1,6 @@
 {
     "client_path": null,
-    "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback", "--early_cloning"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_StmtMissingOperand", 0, 0],
     ["Analytics_UnreachableBlock", 0 ,0], ["Analytics_BlockHasNoTACBlock", 0, 0],
     ["Analytics_PrivateFunctionMatchesMetadata", 49, 0],

--- a/tests/early-cloning/94e2dee39b28629940bf79e23d0cf206_generalCloner.json
+++ b/tests/early-cloning/94e2dee39b28629940bf79e23d0cf206_generalCloner.json
@@ -1,6 +1,6 @@
 {
     "client_path": null,
-    "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback", "--early_cloning"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_StmtMissingOperand", 0, 0],
     ["Analytics_UnreachableBlock", 0 ,0], ["Analytics_BlockHasNoTACBlock", 0, 0],
     ["Analytics_PrivateFunctionMatchesMetadata", 41, 0],

--- a/tests/early-cloning/no-jump-to-many/config.json
+++ b/tests/early-cloning/no-jump-to-many/config.json
@@ -1,5 +1,5 @@
 {
     "client_path": null,
-    "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback", "--early_cloning"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_JumpToMany", 0, 0]]
 }

--- a/tests/guards/external-guards.json
+++ b/tests/guards/external-guards.json
@@ -1,5 +1,5 @@
 {
     "client_path": "clients/analytics_client.dl",
-    "gigahorse_args": ["-i", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_SenderGuard", 2, 0]]
 }

--- a/tests/guards/mapping-guard.json
+++ b/tests/guards/mapping-guard.json
@@ -1,5 +1,5 @@
 {
     "client_path": "clients/analytics_client.dl",
-    "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_SenderGuard", 1, 0]]
 }

--- a/tests/guards/owner-guard.json
+++ b/tests/guards/owner-guard.json
@@ -1,5 +1,5 @@
 {
     "client_path": "clients/analytics_client.dl",
-    "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_SenderGuard", 1, 0]]
 }

--- a/tests/memory-modeling/arrays/0117c9ec55e2ac580fa9c9b1c2d1fff9.json
+++ b/tests/memory-modeling/arrays/0117c9ec55e2ac580fa9c9b1c2d1fff9.json
@@ -1,6 +1,6 @@
 {
     "client_path": null,
-    "gigahorse_args": ["-i", "--disable_scalable_fallback", "-C", "clients/analytics_client.dl"],
+    "gigahorse_args": ["--disable_scalable_fallback", "-C", "clients/analytics_client.dl"],
     "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 0, 0],
     ["Analytics_BlockHasNoTACBlock", 0, 0], ["Analytics_StmtMissingOperand", 0, 0],
     ["Analytics_NonHighLevelLoopFiltered", 0, 0],

--- a/tests/memory-modeling/arrays/0x9c1C32B81E452E5D8b70F42F27585Be505023AEe_mcopy.json
+++ b/tests/memory-modeling/arrays/0x9c1C32B81E452E5D8b70F42F27585Be505023AEe_mcopy.json
@@ -1,6 +1,6 @@
 {
     "client_path": null,
-    "gigahorse_args": ["-i", "--disable_scalable_fallback", "-C", "clients/analytics_client.dl"],
+    "gigahorse_args": ["--disable_scalable_fallback", "-C", "clients/analytics_client.dl"],
     "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 14, 0],
     ["Analytics_BlockHasNoTACBlock", 0, 0], ["Analytics_StmtMissingOperand", 0, 0],
     ["Analytics_NonModeledMLOAD", 0, 0],["Analytics_NonModeledMSTORE", 0, 0],

--- a/tests/memory-modeling/arrays/callDataArrayGet.json
+++ b/tests/memory-modeling/arrays/callDataArrayGet.json
@@ -1,6 +1,6 @@
 {
     "client_path": null,
-    "gigahorse_args": ["-i", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_BlockHasNoTACBlock", 0, 0],
     ["Analytics_StmtMissingOperand", 0, 0], ["Analytics_NonModeledCALLDATALOAD", 0, 0],
     ["Analytics_NonModeledMLOAD", 0, 0],["Analytics_NonModeledMSTORE", 0, 0]]

--- a/tests/memory-modeling/arrays/callDataArrays.json
+++ b/tests/memory-modeling/arrays/callDataArrays.json
@@ -1,6 +1,6 @@
 {
     "client_path": "clients/analytics_client.dl",
-    "gigahorse_args": ["-i", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_BlockHasNoTACBlock", 0, 0],
     ["Analytics_StmtMissingOperand", 0, 0],
     ["Analytics_NonHighLevelLoopFiltered", 0, 0],

--- a/tests/memory-modeling/calls/0x602B40BF327C10370483AE5ECDE15A7BB480DCCA.json
+++ b/tests/memory-modeling/calls/0x602B40BF327C10370483AE5ECDE15A7BB480DCCA.json
@@ -1,5 +1,5 @@
 {
     "client_path": "clients/analytics_client.dl",
-    "gigahorse_args": ["-i", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_scalable_fallback"],
     "expected_results": [["Analytics_ERC20ApproveCall", 2, 0]]
 }

--- a/tests/memory-modeling/calls/0xD6049E1F5F3EFF1F921F5532AF1A1632BA23929C.json
+++ b/tests/memory-modeling/calls/0xD6049E1F5F3EFF1F921F5532AF1A1632BA23929C.json
@@ -1,5 +1,5 @@
 {
     "client_path": "clients/analytics_client.dl",
-    "gigahorse_args": ["-i", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_scalable_fallback"],
     "expected_results": [["Analytics_CallToSignature", 4, 0]]
 }

--- a/tests/memory-modeling/calls/abiencwithselector.json
+++ b/tests/memory-modeling/calls/abiencwithselector.json
@@ -1,5 +1,5 @@
 {
     "client_path": "clients/analytics_client.dl",
-    "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_ERC20ApproveCall", 1, 0], ["Analytics_ERC20TransferFromCall", 1, 0], ["Analytics_ERC20TransferCall", 1, 0]]
 }

--- a/tests/memory-modeling/errors/basic.json
+++ b/tests/memory-modeling/errors/basic.json
@@ -1,5 +1,5 @@
 {
     "client_path": "clients/analytics_client.dl",
-    "gigahorse_args": ["--disable_inline"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_RevertSigUsed", 2, 0]]
 }

--- a/tests/memory-modeling/errors/basic.json
+++ b/tests/memory-modeling/errors/basic.json
@@ -1,5 +1,5 @@
 {
     "client_path": "clients/analytics_client.dl",
-    "gigahorse_args": ["-i", "--disable_inline"],
+    "gigahorse_args": ["--disable_inline"],
     "expected_analytics": [["Analytics_RevertSigUsed", 2, 0]]
 }

--- a/tests/memory-modeling/events/events1.json
+++ b/tests/memory-modeling/events/events1.json
@@ -1,5 +1,5 @@
 {
     "client_path": "clients/analytics_client.dl",
-    "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_EventSignature", 3, 0]]
 }

--- a/tests/memory-modeling/events/events2.json
+++ b/tests/memory-modeling/events/events2.json
@@ -1,5 +1,5 @@
 {
     "client_path": "clients/analytics_client.dl",
-    "gigahorse_args": ["-i", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_EventSignature", 1, 0], ["Analytics_NonModeledMLOAD", 0, 0], ["Analytics_NonModeledMSTORE", 0, 0]]
 }

--- a/tests/memory-modeling/structs/array-struct.json
+++ b/tests/memory-modeling/structs/array-struct.json
@@ -1,6 +1,6 @@
 {
     "client_path": null,
-    "gigahorse_args": ["-i", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 2, 0],
     ["Analytics_BlockHasNoTACBlock", 0, 0], ["Analytics_StmtMissingOperand", 0, 0],
     ["Analytics_NonModeledMLOAD", 0, 0],["Analytics_NonModeledMSTORE", 0, 0]]

--- a/tests/memory-modeling/structs/calldata-struct.json
+++ b/tests/memory-modeling/structs/calldata-struct.json
@@ -1,6 +1,6 @@
 {
     "client_path": "clients/analytics_client.dl",
-    "gigahorse_args": ["-i", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_BlockHasNoTACBlock", 0, 0],
     ["Analytics_StmtMissingOperand", 0, 0], ["Analytics_PublicFunctionStructArg", 2, 0],
     ["Analytics_NonModeledCALLDATALOAD", 0, 0], ["Analytics_ArrayCopy", 3, 0],

--- a/tests/memory-modeling/structs/simple-struct.json
+++ b/tests/memory-modeling/structs/simple-struct.json
@@ -1,6 +1,6 @@
 {
     "client_path": null,
-    "gigahorse_args": ["-i", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 1, 0],
     ["Analytics_BlockHasNoTACBlock", 0, 0], ["Analytics_StmtMissingOperand", 0, 0],
     ["Analytics_NonModeledMLOAD", 0, 0],["Analytics_NonModeledMSTORE", 0, 0]]

--- a/tests/memory-modeling/structs/stored-struct.json
+++ b/tests/memory-modeling/structs/stored-struct.json
@@ -1,6 +1,6 @@
 {
     "client_path": null,
-    "gigahorse_args": ["-i", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 0, 0],
     ["Analytics_BlockHasNoTACBlock", 0, 0], ["Analytics_StmtMissingOperand", 0, 0],
     ["Analytics_NonModeledMLOAD", 0, 0],["Analytics_NonModeledMSTORE", 0, 0]]

--- a/tests/multi-contract/multi1.json
+++ b/tests/multi-contract/multi1.json
@@ -1,6 +1,6 @@
 {
     "client_path": "clients/analytics_client.dl",
-    "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "contract_specific": {"0x987115C38Fd9Fd2aA2c6F1718451d167c13A3186_multi.json":
         {"expected_analytics": [["errors", 0, 0], ["Analytics_ResolvedExternalCall", 7, 0]]}
     }

--- a/tests/precise-fallback/no-jump-to-many/config.json
+++ b/tests/precise-fallback/no-jump-to-many/config.json
@@ -1,5 +1,5 @@
 {
     "client_path": null,
-    "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_JumpToMany", 0, 0]]
 }

--- a/tests/storage/0xf40593A22398c277237266A81212f7D41023b630-merged.json
+++ b/tests/storage/0xf40593A22398c277237266A81212f7D41023b630-merged.json
@@ -1,5 +1,5 @@
 {
     "client_path": "clients/analytics_client.dl",
-    "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_GlobalVariable", 12, 0]]
 }

--- a/tests/storage/Audius.json
+++ b/tests/storage/Audius.json
@@ -1,5 +1,5 @@
 {
     "client_path": "clients/analytics_client.dl",
-    "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_GlobalVariable", 13, 0], ["Analytics_NonHighLevelLoopFiltered", 0, 0]]
 }

--- a/tests/storage/array-mapping.json
+++ b/tests/storage/array-mapping.json
@@ -1,5 +1,5 @@
 {
     "client_path": "clients/analytics_client.dl",
-    "gigahorse_args": ["-i", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_Map", 2, 0]]
 }

--- a/tests/storage/array-merged.json
+++ b/tests/storage/array-merged.json
@@ -1,6 +1,6 @@
 {
     "client_path": "clients/analytics_client.dl",
-    "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [ ["Analytics_NonModeledSSTORE", 0, 0], ["Analytics_NonModeledSLOAD", 0, 0]],
     "expected_verbatim": [["Verbatim_StorageOffset_Type", "0x0\tstruct_[0-9]*\\[\\]\n"],
                             ["Verbatim_StructToString", "struct_[0-9]*\tstruct struct_[0-9]* { address field0_0_19; bool field0_20_20; bool field0_21_21; }\n"]]

--- a/tests/storage/array-two-words.json
+++ b/tests/storage/array-two-words.json
@@ -1,6 +1,6 @@
 {
     "client_path": "clients/analytics_client.dl",
-    "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [ ["Analytics_NonModeledSSTORE", 0, 0], ["Analytics_NonModeledSLOAD", 0, 0]],
     "expected_verbatim": [["Verbatim_StorageOffset_Type", "0x0\tstruct_[0-9]*\\[\\]\n"],
                             ["Verbatim_StructToString", "struct_[0-9]*\tstruct struct_[0-9]* { uint256 field0; uint256 field1; }\n"]]

--- a/tests/storage/array1-iropt.json
+++ b/tests/storage/array1-iropt.json
@@ -1,6 +1,6 @@
 {
     "client_path": "clients/analytics_client.dl",
-    "gigahorse_args": ["-i", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_NonModeledSSTORE", 0, 0], ["Analytics_NonModeledSLOAD", 0, 0], ["Analytics_ArrayDeleteOp", 1, 0], ["Analytics_NonHighLevelLoopFiltered", 0, 0]],
     "expected_verbatim": [["Verbatim_StorageOffset_Type", "0x0\taddress[]\n"]]
 }

--- a/tests/storage/array1-opt.json
+++ b/tests/storage/array1-opt.json
@@ -1,6 +1,6 @@
 {
     "client_path": "clients/analytics_client.dl",
-    "gigahorse_args": ["-i", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_NonModeledSSTORE", 0, 0], ["Analytics_NonModeledSLOAD", 0, 0], ["Analytics_ArrayDeleteOp", 1, 0]],
     "expected_verbatim": [["Verbatim_StorageOffset_Type", "0x0\taddress[]\n"]]
 }

--- a/tests/storage/array1.json
+++ b/tests/storage/array1.json
@@ -1,6 +1,6 @@
 {
     "client_path": "clients/analytics_client.dl",
-    "gigahorse_args": ["-i", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_StorageArray", 1, 0], ["Analytics_NonModeledSSTORE", 0, 0],
                             ["Analytics_NonModeledSLOAD", 0, 0], ["Analytics_ArrayDeleteOp", 1, 0],
                             ["Analytics_NonHighLevelLoopFiltered", 0, 0]],

--- a/tests/storage/complex.json
+++ b/tests/storage/complex.json
@@ -1,5 +1,5 @@
 {
     "client_path": "clients/analytics_client.dl",
-    "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [ ["Analytics_NonModeledSSTORE", 0, 0], ["Analytics_NonModeledSLOAD", 0, 0]]
 }

--- a/tests/storage/map1.json
+++ b/tests/storage/map1.json
@@ -1,6 +1,6 @@
 {
     "client_path": "clients/analytics_client.dl",
-    "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_Map", 1, 0], ["Analytics_NonModeledSSTORE", 0, 0], ["Analytics_NonModeledSLOAD", 0, 0]],
     "expected_verbatim": [["Verbatim_StorageOffset_Type", "0x0\tmapping (uint256 => bool)\n"]]
 }

--- a/tests/storage/mapping-merged.json
+++ b/tests/storage/mapping-merged.json
@@ -1,6 +1,6 @@
 {
     "client_path": "clients/analytics_client.dl",
-    "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [ ["Analytics_NonModeledSSTORE", 0, 0], ["Analytics_NonModeledSLOAD", 0, 0]],
     "expected_verbatim": [["Verbatim_StorageOffset_Type", "0x0\tmapping \\(uint256 => struct_[0-9]*\\)\n"],
                             ["Verbatim_StructToString", "struct_[0-9]*\tstruct struct_[0-9]* { address field0_0_19; bool field0_20_20; bool field0_21_21; uint256 field1; }\n"]]

--- a/tests/storage/merged-iropt.json
+++ b/tests/storage/merged-iropt.json
@@ -1,5 +1,5 @@
 {
     "client_path": "clients/analytics_client.dl",
-    "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_GlobalVariable", 3, 0]]
 }

--- a/tests/storage/merged-opt.json
+++ b/tests/storage/merged-opt.json
@@ -1,5 +1,5 @@
 {
     "client_path": "clients/analytics_client.dl",
-    "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_GlobalVariable", 3, 0]]
 }

--- a/tests/storage/merged.json
+++ b/tests/storage/merged.json
@@ -1,5 +1,5 @@
 {
     "client_path": "clients/analytics_client.dl",
-    "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_GlobalVariable", 3, 0]]
 }

--- a/tests/storage/nested-mapping.json
+++ b/tests/storage/nested-mapping.json
@@ -1,6 +1,6 @@
 {
     "client_path": "clients/analytics_client.dl",
-    "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_Map", 1, 0], ["Analytics_NonModeledSSTORE", 0, 0], ["Analytics_NonModeledSLOAD", 0, 0]],
     "expected_verbatim": [["Verbatim_StorageOffset_Type", "0x0\tmapping (uint256 => mapping (uint256 => uint256))\n"]]
 }

--- a/tests/storage/transient-and-storage-conflict.json
+++ b/tests/storage/transient-and-storage-conflict.json
@@ -1,5 +1,5 @@
 {
     "client_path": "clients/analytics_client.dl",
-    "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_GlobalVariable", 1, 0], ["Analytics_Map", 2, 0]]
 }

--- a/tests/storage/transient-and-storage-opt.json
+++ b/tests/storage/transient-and-storage-opt.json
@@ -1,5 +1,5 @@
 {
     "client_path": "clients/analytics_client.dl",
-    "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_GlobalVariable", 4, 0]]
 }

--- a/tests/storage/transient-iropt.json
+++ b/tests/storage/transient-iropt.json
@@ -1,5 +1,5 @@
 {
     "client_path": "clients/analytics_client.dl",
-    "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_GlobalVariable", 4, 0]]
 }

--- a/tests/storage/transient-opt.json
+++ b/tests/storage/transient-opt.json
@@ -1,5 +1,5 @@
 {
     "client_path": "clients/analytics_client.dl",
-    "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_GlobalVariable", 4, 0]]
 }

--- a/tests/storage/transient.json
+++ b/tests/storage/transient.json
@@ -1,5 +1,5 @@
 {
     "client_path": "clients/analytics_client.dl",
-    "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_GlobalVariable", 4, 0]]
 }

--- a/tests/via-ir/simple-storage.json
+++ b/tests/via-ir/simple-storage.json
@@ -1,6 +1,6 @@
 {
     "client_path": "clients/analytics_client.dl",
-    "gigahorse_args": ["-i", "--disable_inline", "--disable_scalable_fallback"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_NonModeledSSTORE", 0, 0], ["Analytics_NonModeledSLOAD", 0, 0],
                             ["Analytics_NonModeledMSTORE", 0, 0], ["Analytics_NonModeledMLOAD", 0, 0]]
 }

--- a/tests/vyper/blind.json
+++ b/tests/vyper/blind.json
@@ -1,6 +1,6 @@
 {
     "client_path": null,
-    "gigahorse_args": ["-i", "--disable_inline"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 0, 0], ["Analytics_PublicFunction", 10, 0]],
     "expected_verbatim": [["Verbatim_compiler_info", "vyper\t0.3.7"]]
 }

--- a/tests/vyper/simple-open.json
+++ b/tests/vyper/simple-open.json
@@ -1,6 +1,6 @@
 {
     "client_path": null,
-    "gigahorse_args": ["-i", "--disable_inline"],
+    "gigahorse_args": ["--disable_inline", "--disable_scalable_fallback"],
     "expected_analytics": [["Analytics_JumpToMany", 0, 0], ["Analytics_UnreachableBlock", 0, 0], ["Analytics_PublicFunction", 10, 0]],
     "expected_verbatim": [["Verbatim_compiler_info", "vyper\t0.3.7"]]
 }

--- a/uv.lock
+++ b/uv.lock
@@ -75,12 +75,30 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.29.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/94/00f2059e4835eace3ae8fde680b932c496f8ec7bdc99168dfa53fb2e6b79/filelock-3.29.7.tar.gz", hash = "sha256:5b481979797ae69e72f0b389d89a80bdd585c260c5b3f1fb9c0a5ba9bb3f195d", size = 71521, upload-time = "2026-07-08T05:46:58.716Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/02/be4a57b60c7149b55b9e3b3c13f609cd8eb5307c751f22bd8fb8d262e75b/filelock-3.29.7-py3-none-any.whl", hash = "sha256:987db6f789a3a2a59f55081801b2b3697cb97e2a736b5f1a9e99b559285fbc51", size = 46036, upload-time = "2026-07-08T05:46:57.53Z" },
 ]
 
 [[package]]
@@ -99,8 +117,10 @@ viz = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "filelock" },
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pytest-xdist" },
 ]
 
 [package.metadata]
@@ -113,8 +133,10 @@ provides-extras = ["tooling", "viz"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "filelock", specifier = ">=3.15" },
     { name = "mypy", specifier = ">=1.13" },
     { name = "pytest", specifier = ">=8.3" },
+    { name = "pytest-xdist", specifier = ">=3.8" },
 ]
 
 [[package]]
@@ -520,6 +542,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add (via `conftest.py`) a prerequisite step that compiles souffle binaries for the common/reused decompilation config.
Previously all tests used `-i`, now only the ones for different context sensitivity flavors, the scalable fallback, and improved ssa do.

Drops testing time, when running 1 worker, to 25% of the original.

Also added `pytest-xdist` and `filelock` as dependencies.