### PR TITLE
Use new set functor

### DIFF
--- a/logic/functions.dl
+++ b/logic/functions.dl
@@ -891,9 +891,13 @@ FunctionalBlockPopAndStackDelta(from, popDelta, stackDelta) :-
   FunctionalBlockStackDelta(from, stackDelta).
 .plan 1:(2,1)
 
+// PossibleFunctionalBlockPopAndStackDelta(from, from, initPath, 0, 0) :-
+//    IRFunctionEntry(from),
+//    initPath = as(from, Path).
+
 PossibleFunctionalBlockPopAndStackDelta(from, from, initPath, 0, 0) :-
    IRFunctionEntry(from),
-   initPath = as(from, Path).
+   initPath = as(@add_set(@empty_set(), from), Path).
 
 .decl PotentialCycleEntry(block: IRBlock)
 

--- a/logic/functions.dl
+++ b/logic/functions.dl
@@ -891,10 +891,6 @@ FunctionalBlockPopAndStackDelta(from, popDelta, stackDelta) :-
   FunctionalBlockStackDelta(from, stackDelta).
 .plan 1:(2,1)
 
-// PossibleFunctionalBlockPopAndStackDelta(from, from, initPath, 0, 0) :-
-//    IRFunctionEntry(from),
-//    initPath = as(from, Path).
-
 PossibleFunctionalBlockPopAndStackDelta(from, from, initPath, 0, 0) :-
    IRFunctionEntry(from),
    initPath = as(@add_set(@empty_set(), from), Path).


### PR DESCRIPTION
Use the newly introduced optimized set functors, replacing the use of the naive (string-concatanation-based) ones.

The improvement is only highlighted when using tougher benchmarks (i.e., viair-dec23).
Easier datasets have a smaller improvement (under 1%).

For a timeout of 120s:
```
2926 contracts decompiled/analyzed by sep26-ir-oldfunc (0 exclusively)
2932 contracts decompiled/analyzed by sep26-ir-newfunc7 (6 exclusively)

ANALYTIC: decomp_time
sep26-ir-oldfunc (common): 4657.450522184372 (+4.483%)
sep26-ir-newfunc7 (common): 4457.603654384613
```

For a timeout of 300s:
```
2934 contracts decompiled/analyzed by sep26-ir-oldfunc300 (0 exclusively)
2937 contracts decompiled/analyzed by sep26-ir-newfunc300 (3 exclusively)

ANALYTIC: decomp_time
sep26-ir-oldfunc300 (common): 6278.049761295319 (+8.199%)
sep26-ir-newfunc300 (common): 5802.309686422348
```

Other decompilation metrics are unaffected.